### PR TITLE
rule: show file content as code block when user asks

### DIFF
--- a/.claude/rules/platform/show-files.md
+++ b/.claude/rules/platform/show-files.md
@@ -1,0 +1,5 @@
+# Show Files
+
+When the user asks to "show", "покажи", or "display" a file — output its full content as a code block in the response. Do not just read it internally with the Read tool. The user cannot see tool results — they only see your text output.
+
+Use appropriate syntax highlighting (```yaml, ```json, ```bash, etc.) based on file extension.


### PR DESCRIPTION
## Summary
- Adds platform rule: when user asks to show/display a file, output its content as a code block in the response
- Users can't see Read tool results — they only see text output
- Applies to all workspaces via platform rules

## Test plan
- [ ] Ask agent to "show config.yaml" — should output as ```yaml code block
- [ ] Ask agent to "покажи файл" — should output content, not just read internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)