### PR TITLE
fix: show real error messages instead of generic Something went wrong

### DIFF
--- a/bot/src/__tests__/message-queue.test.ts
+++ b/bot/src/__tests__/message-queue.test.ts
@@ -443,7 +443,7 @@ describe("MessageQueue error handling", () => {
     await wait(100);
 
     assert.strictEqual(callCount, 2);
-    assert.ok(repliedText.includes("Something went wrong processing queued messages"));
+    assert.ok(repliedText.includes("Something went wrong:"));
     assert.strictEqual(queue.isBusy("chat1"), false);
 
     queue.clearAll();

--- a/bot/src/message-queue.ts
+++ b/bot/src/message-queue.ts
@@ -203,7 +203,7 @@ export class MessageQueue {
       log.error("message-queue", `Send error for ${chatId}:`, err);
       if (state.latestPlatform) {
         await state.latestPlatform
-          .replyError("Something went wrong. Try again or /reset the session.")
+          .replyError(`Something went wrong: ${err instanceof Error ? err.message : String(err)}\n\nTry again or /reset the session.`)
           .catch(() => {});
       }
     } finally {
@@ -279,7 +279,7 @@ export class MessageQueue {
         log.error("message-queue", `Collect drain error for ${chatId}:`, err);
         if (state.latestPlatform) {
           await state.latestPlatform
-            .replyError("Something went wrong processing queued messages. Try again or /reset the session.")
+            .replyError(`Something went wrong: ${err instanceof Error ? err.message : String(err)}\n\nTry again or /reset the session.`)
             .catch(() => {});
         }
       } finally {


### PR DESCRIPTION
## Summary
- Both catch blocks in `message-queue.ts` now include `err.message` in the user-facing error
- Instead of one generic "Something went wrong" for all 11 error paths, users see the actual reason (subprocess crash, timeout, circuit breaker, etc.)

Closes #5

## Test plan
- [x] message-queue tests pass (29/29)
- [ ] Trigger a "Something went wrong" error and verify the real error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)