### PR TITLE
feat: add bot-operations platform rule

### DIFF
--- a/.claude/rules/platform/bot-operations.md
+++ b/.claude/rules/platform/bot-operations.md
@@ -1,0 +1,7 @@
+# Bot Operations
+
+- **Bot restart requires explicit user confirmation.** No exceptions.
+- **Graceful restart:** `launchctl kill SIGTERM gui/$(id -u)/ai.minime.telegram-bot` — sends SIGTERM, graceful shutdown waits up to 60s for active turns, then launchd auto-restarts (KeepAlive=true).
+- **Never use `launchctl kickstart -k`** — it sends SIGKILL, bypasses graceful shutdown, kills active sessions mid-turn.
+- **Config changes:** validate before restart (`npx tsx bot/src/config.ts --validate`)
+- **Cron changes:** edit crons.yaml → regenerate plists → load → test → verify logs


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/platform/bot-operations.md` with restart procedure
- Key rule: `launchctl kill SIGTERM` (graceful) instead of `kickstart -k` (SIGKILL)
- Documents graceful shutdown flow: SIGTERM → wait for active turns (60s) → exit → launchd auto-restart

## Context
`kickstart -k` sends SIGKILL which bypasses the graceful shutdown handler entirely, killing active Claude CLI sessions mid-turn and causing "subprocess exited before sending a result" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)