### PR TITLE
fix: redact remaining PII

### DIFF
--- a/.claude/skills/workspace-health/tests/test-scripts.sh
+++ b/.claude/skills/workspace-health/tests/test-scripts.sh
@@ -344,7 +344,7 @@ fi
 
 # Part E references only public-repo files (no private workspace paths)
 TESTS=$((TESTS + 1))
-if grep -q '\.minime\|workspace-coder\|/ninja/' "$SKILL_MD" 2>/dev/null; then
+if grep -q '\.minime\|workspace-coder\|/username/' "$SKILL_MD" 2>/dev/null; then
   echo "  FAIL: SKILL.md Part E references private workspace paths"
   FAIL=$((FAIL + 1))
 else

--- a/.ralphex/plans/completed/memory-consolidation-platform.md
+++ b/.ralphex/plans/completed/memory-consolidation-platform.md
@@ -47,7 +47,7 @@ cd bot && npm test
 
 ## Reference: Claude Code session JSONL format
 
-Session transcripts are stored at `~/.claude/projects/<workspace-path-dashed>/*.jsonl`. The workspace path is converted by replacing `/` with `-` and prefixing with `-` (e.g., `/Users/user/.minime/workspace` → `-Users-ninja--minime-workspace`).
+Session transcripts are stored at `~/.claude/projects/<workspace-path-dashed>/*.jsonl`. The workspace path is converted by replacing `/` with `-` and prefixing with `-` (e.g., `/Users/user/.minime/workspace` → `-Users-user--minime-workspace`).
 
 Each JSONL file = one session. First line is always `type: "queue-operation"` with the initial prompt in `content`:
 
@@ -124,11 +124,11 @@ Individual memory files use YAML frontmatter with `name`, `description`, `type` 
 ```markdown
 ---
 name: coffee-shop-investment
-description: Инвестиция в кофейню — 3М₽, 50% доля, 1-я Советская ул. 7, СПб
+description: Инвестиция в кофейню — <redacted-amount>, <redacted-share>, <redacted-address>, СПб
 type: project
 ---
 
-Ninja инвестировал 3 000 000 ₽ в кофейню (50% доля). Договор подписан 13.03.2026.
+User инвестировал <redacted-amount> в кофейню (<redacted-share>). Договор подписан <redacted-date>.
 ...
 ```
 


### PR DESCRIPTION
## Summary
- Redact coffee shop investment data (amounts, address, ownership share) from ralphex plan example
- Replace `-Users-ninja-` path reference with `-Users-user-` in session path example
- Replace `/ninja/` grep pattern with `/username/` in workspace-health test script

## Files changed
- `.ralphex/plans/completed/memory-consolidation-platform.md`
- `.claude/skills/workspace-health/tests/test-scripts.sh`