### PR TITLE
docs: slim README, move config reference to example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Both platforms share one Session Manager and use the same stream-relay logic via
 
 **Cron jobs** run separately via launchd plists. Each plist calls `run-cron.sh <task-name>`, which invokes `cron-runner.ts` to spawn a one-shot `claude -p` session with the cron's prompt.
 
-**Config:** `config.yaml` (at workspace root, alongside `bot/`) defines agents (workspace + model) and bindings (chatId/channelId -> agentId). At least one platform (Telegram or Discord) must be configured. Tokens are read from macOS Keychain at runtime.
+**Config:** `config.yaml` defines agents (workspace + model) and bindings (chatId/channelId -> agentId). At least one platform (Telegram or Discord) must be configured. Tokens are read from macOS Keychain at runtime.
 
 ## Installation
 
@@ -72,133 +72,82 @@ Both platforms share one Session Manager and use the same stream-relay logic via
 - macOS (launchd required for bot service management)
 - Node.js 20+ and npm
 - `jq` — required by hook scripts (`brew install jq`)
-- [Claude Code CLI](https://claude.ai/code) — must be authenticated via `claude auth login` before starting the bot
-- A Telegram bot token from [@BotFather](https://t.me/BotFather) (or a Discord bot token if using Discord)
+- [Claude Code CLI](https://claude.ai/code) — must be authenticated via `claude auth login`
+- A Telegram bot token from [@BotFather](https://t.me/BotFather) (or Discord bot token)
 
 ### Steps
 
-**1. Clone and install dependencies**
+**1. Clone and install**
 
 ```bash
-git clone https://github.com/your-org/minime.git ~/.minime
+git clone https://github.com/fitz123/claude-code-bot.git ~/.minime
 cd ~/.minime/bot && npm install
 ```
 
-**2. Copy and fill in config.yaml**
+**2. Copy and edit config files**
 
 ```bash
 cp config.yaml.example config.yaml
-```
-
-Edit `config.yaml`:
-- Set `workspaceCwd` to the absolute path of your cloned repo (e.g. `/Users/yourname/.minime`)
-- Set `chatId` in the `bindings` section to your Telegram user ID (send `/start` to @userinfobot to find it)
-
-**3. Copy crons.yaml**
-
-```bash
 cp crons.yaml.example crons.yaml
-```
-
-Edit or leave as-is. To start with no crons: replace the contents with `crons: []`.
-
-**4. Copy settings.local.json and set autoMemoryDirectory**
-
-```bash
 cp .claude/settings.local.json.example .claude/settings.local.json
 ```
 
-Edit `.claude/settings.local.json` and set `autoMemoryDirectory` to `<absolute-path-to-repo>/memory/auto` (e.g. `/Users/yourname/.minime/memory/auto`). Without this, Claude Code's auto-memory writes to its default location instead of the workspace.
+Edit `config.yaml` — set `workspaceCwd` to the absolute path of your repo and `chatId` to your Telegram user ID (send `/start` to [@userinfobot](https://t.me/userinfobot) to find it). See [config.yaml.example](config.yaml.example) for all options.
 
-**5. Store Telegram bot token in macOS Keychain**
+Edit `.claude/settings.local.json` — set `autoMemoryDirectory` to `<repo-path>/memory/auto`.
+
+To start with no crons, replace contents of `crons.yaml` with `crons: []`.
+
+**3. Store Telegram bot token in macOS Keychain**
 
 ```bash
 security add-generic-password -s 'telegram-bot-token' -a 'minime' -w 'YOUR_TOKEN_HERE'
 ```
 
-The service name `telegram-bot-token` must match `telegramTokenService` in `config.yaml`.
-
-**6. Authenticate Claude Code**
+**4. Authenticate Claude Code**
 
 ```bash
 claude auth login
 ```
 
-This stores your Claude Code OAuth token in Keychain automatically. The bot's startup script reads it from there.
-
-**7. Create the log directory**
+**5. Create launchd service**
 
 ```bash
 mkdir -p ~/.minime/logs
-```
-
-**8. Create the launchd plist**
-
-```bash
 cp bot/telegram-bot.plist.example ~/Library/LaunchAgents/ai.minime.telegram-bot.plist
 ```
 
-Edit `~/Library/LaunchAgents/ai.minime.telegram-bot.plist` and replace:
-- `WORKSPACE` — absolute path to the repo (e.g. `/Users/yourname/.minime`)
-- `LOG_DIR` — log directory (e.g. `/Users/yourname/.minime/logs`)
-- `USER_HOME` — your home directory (e.g. `/Users/yourname`)
+Edit the plist — replace `WORKSPACE`, `LOG_DIR`, and `USER_HOME` with your paths.
 
-**9. Validate config**
+**6. Validate and start**
 
 ```bash
 cd ~/.minime && npx tsx bot/src/config.ts --validate
-```
-
-**10. Start the bot**
-
-```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.minime.telegram-bot.plist
 ```
 
-**11. Verify**
+**7. Verify**
 
 ```bash
-# Check service is running
 launchctl list | grep ai.minime.telegram-bot
-
-# Tail logs
 tail -f ~/.minime/logs/telegram-bot.stdout.log
 ```
 
 Send a message to your bot in Telegram to confirm it responds.
 
-### Discord (optional)
+### Optional setup
 
-Store Discord bot token in Keychain:
-```bash
-security add-generic-password -s 'discord-bot-token' -a 'minime' -w 'YOUR_TOKEN_HERE'
-```
+**Discord:** Store token in Keychain (`security add-generic-password -s 'discord-bot-token' -a 'minime' -w 'TOKEN'`), add a `discord` section to `config.yaml`. See [config.yaml.example](config.yaml.example).
 
-Add a `discord` section to `config.yaml` — see [Add a Discord Binding](#add-a-discord-binding) below.
-
-### Crons (optional)
-
-Edit `crons.yaml`, then generate and load plists:
+**Crons:** Edit `crons.yaml`, then generate and load plists:
 ```bash
 cd ~/.minime/bot && npx tsx scripts/generate-plists.ts
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.minime.cron.<name>.plist
 ```
 
-See [Add a Cron](#add-a-cron) below for details.
+**Optional rules:** `cp .claude/optional-rules/memory-protocol.md .claude/rules/custom/`
 
-### Optional: activate rules
-
-Copy optional rules into the custom rules directory to activate them:
-```bash
-cp .claude/optional-rules/memory-protocol.md .claude/rules/custom/
-```
-
-### Optional: initialize ADR governance
-
-```bash
-mkdir -p reference/governance
-cp reference/governance/decisions.md.example reference/governance/decisions.md
-```
+**ADR governance:** `mkdir -p reference/governance && cp reference/governance/decisions.md.example reference/governance/decisions.md`
 
 ## Start / Stop
 
@@ -218,141 +167,58 @@ launchctl bootout gui/$(id -u)/ai.minime.telegram-bot
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.minime.telegram-bot.plist
 ```
 
-**Graceful shutdown:** On SIGTERM, the bot injects a shutdown notification into all active sessions asking agents to wrap up, then waits up to 60s for active turns to complete. Sessions that finish within the timeout exit cleanly; sessions that exceed it are force-killed. Idle sessions close immediately. Use `launchctl kill SIGTERM` (not `kickstart -k` which sends SIGKILL and bypasses graceful shutdown).
+**Warning:** Restarting kills all active Claude Code sessions (both Telegram and Discord), drops in-flight messages, and interrupts running sub-agents. Always confirm before restarting.
 
 ## Add a Cron
 
 1. Edit `crons.yaml` — add a new entry:
    ```yaml
-   # LLM cron (default) — runs claude -p with the given prompt
    - name: my-task
-     schedule: "30 9 * * *"       # cron syntax, local timezone
+     schedule: "30 9 * * *"
      prompt: >
        Do the thing.
-     agentId: main                # must match an agent in config.yaml
-     deliveryChatId: YOUR_CHAT_ID  # where to send results (optional if defaultDeliveryChatId set)
-     timeout: 300000              # ms, optional
-
-   # Script cron — runs a shell command directly (no LLM)
-   - name: backup-db
-     schedule: "0 2 * * *"
-     type: script                 # "script" or "llm" (default)
-     command: "/usr/bin/backup.sh --full"  # shell command to execute
      agentId: main
      deliveryChatId: YOUR_CHAT_ID
-     timeout: 300000              # ms, optional
    ```
 
-   Script-mode crons execute the command via `/bin/bash`, capture stdout, and deliver it the same way as LLM crons. They skip all Claude-specific setup (model, workspace, env vars). Empty output skips delivery.
-
-   **Cron field reference:**
-
-   | Field | Type | Default | Description |
-   |-------|------|---------|-------------|
-   | `name` | string | (required) | Unique identifier for the cron job |
-   | `schedule` | string | (required) | Cron expression (5-field), local timezone |
-   | `type` | `"llm"` or `"script"` | `"llm"` | LLM crons run `claude -p` with `prompt`; script crons run a shell `command` |
-   | `prompt` | string | — | Prompt text sent to Claude (required for `type: llm`) |
-   | `command` | string | — | Shell command to execute (required for `type: script`) |
-   | `agentId` | string | (required) | Must match an agent in `config.yaml` (determines workspace) |
-   | `deliveryChatId` | number | from config default | Telegram chat ID for result delivery |
-   | `deliveryThreadId` | number | from config default | Telegram forum topic ID for delivery |
-   | `timeout` | number | `300000` | Per-cron timeout in milliseconds (5 min default) |
-   | `enabled` | boolean | `true` | Set `false` to skip plist generation for this cron |
+   See [crons.yaml.example](crons.yaml.example) for all available fields.
 
 2. Generate launchd plists:
    ```bash
    cd ~/.minime/bot && npx tsx scripts/generate-plists.ts
    ```
 
-3. Load the new plist:
+3. Load and test:
    ```bash
    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.minime.cron.my-task.plist
-   ```
-
-4. Test it:
-   ```bash
    launchctl start ai.minime.cron.my-task
    tail -f ~/.minime/logs/cron-my-task.log
    ```
 
-To remove a cron: `launchctl bootout gui/$(id -u)/ai.minime.cron.<name>`, delete the entry from `crons.yaml`, regenerate.
-
-**Default delivery target:** Set `defaultDeliveryChatId` and optionally `defaultDeliveryThreadId` (top-level in `config.yaml`) to provide a default delivery target for all crons. Individual crons can still override with their own `deliveryChatId` / `deliveryThreadId`. If a cron omits `deliveryChatId` and no config default is set, an error is thrown.
-
-```yaml
-defaultDeliveryChatId: -1001234567890  # optional; default delivery target for all crons
-defaultDeliveryThreadId: 42            # optional; default thread for cron delivery
-```
-
-**Admin notifications:** Set `adminChatId` (top-level in `config.yaml`) to receive a fallback Telegram notification when cron delivery to `deliveryChatId` fails (e.g. bot blocked, chat deleted). Must be a non-zero integer (use a negative ID for groups/supergroups). If not set, failures are logged locally only.
-
-```yaml
-adminChatId: 123456789  # optional; receive cron delivery failure alerts here
-```
+To remove: `launchctl bootout gui/$(id -u)/ai.minime.cron.<name>`, delete from `crons.yaml`, regenerate.
 
 ## Add a Binding
 
-1. If needed, add a new agent to `config.yaml`:
+1. Add an agent and binding to `config.yaml`:
    ```yaml
    agents:
      new-agent:
        id: new-agent
        workspaceCwd: /Users/YOU/.minime/workspace-new
        model: claude-opus-4-6
-       fallbackModel: claude-sonnet-4-6
-       maxTurns: 250  # max agentic loops per message (omit for unlimited)
-       effort: high   # Claude reasoning effort: low, medium, high (omit for default)
-   ```
 
-2. Add the binding:
-   ```yaml
    bindings:
      - chatId: 123456789
        agentId: new-agent
-       kind: dm          # or "group"
+       kind: dm
        label: New Agent DM
-
-     # For forum supergroups, bind specific topics to agents:
-     - chatId: -1001234567890
-       agentId: general
-       kind: group
-       label: Forum General     # fallback for unbound topics
-
-     - chatId: -1001234567890
-       topicId: 42               # message_thread_id from Telegram
-       agentId: dev-agent
-       kind: group
-       label: Forum Dev Topic   # this topic gets its own agent + session
-
-     # Inline per-topic overrides (alternative to separate bindings):
-     - chatId: -1001234567890
-       agentId: main
-       kind: group
-       label: HQ Forum
-       requireMention: true          # require @mention or reply-to-bot (default for groups)
-       voiceTranscriptEcho: false    # suppress voice transcript echo reply
-       topics:
-         - topicId: 42
-           agentId: dev-agent        # override agent for this topic
-           requireMention: false     # respond to all messages in this topic
-         - topicId: 99
-           requireMention: false     # inherits agentId from parent binding
    ```
 
-   For forum supergroups, add `topicId` to bind a specific topic thread to its own agent. Each topic with a binding gets an isolated Claude session. Messages in unbound topics fall back to the chatId-only binding if one exists. Alternatively, use inline `topics` on a single binding to override `agentId` and `requireMention` per topic.
+   See [config.yaml.example](config.yaml.example) for all binding options including `requireMention`, `voiceTranscriptEcho`, `streamingUpdates`, `typingIndicator`, and per-topic overrides for forum supergroups.
 
-   Additional binding options:
-   - `requireMention` (boolean): Whether the bot requires an @mention or reply-to-bot to respond in groups. Defaults to `true` for groups. Can be overridden per topic.
-   - `voiceTranscriptEcho` (boolean): Whether to echo the voice transcript back to the chat. Defaults to `true`. Set `false` to suppress.
-   - `streamingUpdates` (boolean): Whether to send progressive streaming edits during response generation. Defaults to `true`. Set `false` to send only the final complete message (reduces API rate limit usage).
-   - `typingIndicator` (boolean): Whether to send typing indicators while processing. Defaults to `true`. Set `false` to suppress.
-   - `topics` (array): Per-topic overrides within a forum supergroup. Each entry has a required `topicId` and optional `agentId` and `requireMention` that override the parent binding's values.
-
-3. Validate and restart:
+2. Validate and restart:
    ```bash
    cd ~/.minime/bot && npx tsx src/config.ts --validate
-   # Then confirm and restart (graceful — launchd auto-restarts via KeepAlive)
    launchctl kill SIGTERM gui/$(id -u)/ai.minime.telegram-bot
    ```
 
@@ -368,64 +234,18 @@ adminChatId: 123456789  # optional; receive cron delivery failure alerts here
    discord:
      tokenService: discord-bot-token
      bindings:
-       # Guild-wide default: covers all channels in the server
        - guildId: "9876543210"
          agentId: main
          kind: channel
          label: My Server
          requireMention: true
-         streamingUpdates: true
-         typingIndicator: true
-         channels:                         # per-channel overrides (optional)
-           - channelId: "1234567890"
-             label: Dev Channel
-             requireMention: false         # no @mention needed here
-           - channelId: "1111111111"
-             agentId: coder                # different agent for this channel
-
-       # Per-channel binding (still works — exact channelId match wins)
-       - channelId: "5555555555"
-         guildId: "9876543210"
-         agentId: main
-         kind: channel
-         label: Legacy Channel
    ```
 
-   A binding with `guildId` but no `channelId` acts as a guild-wide default — any channel in that guild uses it. Per-channel overrides via the `channels` array can override `agentId`, `label`, `requireMention`, `streamingUpdates`, and `typingIndicator`. Resolution priority: exact `channelId` binding > per-channel override from `channels` > guild-wide fallback.
+   See [config.yaml.example](config.yaml.example) for per-channel overrides and guild-wide defaults.
 
-3. Discord threads automatically inherit the parent channel's binding and get independent sessions (keyed as `discord:channelId:threadId`).
+3. Required bot permissions/intents: Guilds, GuildMessages, MessageContent (privileged), DirectMessages. Slash commands (`/start`, `/reset`, `/status`) are registered per-guild on startup.
 
-4. Required Discord bot permissions/intents: Guilds, GuildMessages, MessageContent (privileged — must enable in Discord Developer Portal), DirectMessages.
-
-5. Discord slash commands (`/start`, `/reset`, `/status`) are registered per-guild on startup (instant propagation).
-
-`telegramTokenService` is optional — the bot can run Discord-only without any Telegram configuration.
-
-## Supported Message Types
-
-| Type | Handling |
-|------|----------|
-| Text | Sent directly to Claude session |
-| Voice | Transcribed locally via whisper-cli, transcript echoed back and sent to Claude |
-| Photo | Downloaded to temp file, file path appended to caption and sent to Claude for vision analysis |
-| Image document | Same as photo (supports image/jpeg, image/png, image/gif, image/webp, image/bmp) |
-| Non-image document | Downloaded to temp file (max 20 MB). Metadata header (filename, MIME type, size) and file path sent to Claude. Supports PDF, TXT, CSV, JSON, XML, HTML, ZIP, GZ, and others. |
-| Reaction | Emoji reactions on bot messages are forwarded to Claude as context (e.g. `[Reaction: 👍 on message 123]`). Reaction removals are also forwarded. In forum supergroups, reactions are routed to the correct topic session via an in-memory message-thread cache (cache miss degrades gracefully to chat-level routing). All reaction events are logged to `~/.minime/logs/reactions.jsonl`. Bot must be admin in groups to receive reaction events. |
-| File output | Claude is told about a per-session outbox directory via system prompt. Files written or copied there are sent to the user after the response completes: images as photos, others as documents. The outbox is cleaned up after delivery. |
-
-The bot subscribes to `message` and `message_reaction` update types only.
-
-In group chats, the bot only responds to messages that @mention the bot or reply to the bot (configurable via `requireMention` in bindings). Every message sent to Claude is prefixed with source context (e.g. `[Chat: HQ Forum | Topic: 591 | From: John (@johndoe)]` for forum topics, or `[Chat: HQ Forum | From: John (@johndoe)]` without topic) using the binding's `label` and the sender's Telegram profile.
-
-## Bot Commands
-
-| Command | Description |
-|---------|-------------|
-| `/start` | Show bot info and bound agent |
-| `/reset` | Close current session and clear message queue; prior context may be partially retained |
-| `/status` | Show active sessions, memory, uptime, and subprocess health (PID, alive/dead, processing duration, last success, restart count) |
-
-On Telegram, commands are auto-registered via `setMyCommands` on startup. On Discord, the same commands are available as slash commands, registered per-guild on startup (instant propagation).
+`telegramTokenService` is optional — the bot can run Discord-only.
 
 ## Configuration
 
@@ -446,85 +266,7 @@ When `metricsPort` is set in `config.yaml`, the bot exposes a Prometheus-compati
 metricsPort: 9090
 ```
 
-Available metrics:
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `bot_claude_tokens_input_total` | counter | Input tokens consumed (by agent) |
-| `bot_claude_tokens_output_total` | counter | Output tokens consumed (by agent) |
-| `bot_claude_tokens_cache_read_total` | counter | Cache read tokens (by agent) |
-| `bot_claude_tokens_cache_creation_total` | counter | Cache creation tokens (by agent) |
-| `bot_claude_cost_usd_total` | counter | USD cost from Claude API (by agent) |
-| `bot_claude_turn_duration_seconds` | histogram | Turn duration (by agent) |
-| `bot_telegram_api_errors_total` | counter | Telegram API errors (by method, error_code) |
-| `bot_sessions_active` | gauge | Currently active sessions |
-| `bot_session_crashes_total` | counter | Session subprocess crashes |
-| `bot_telegram_messages_received_total` | counter | Messages received (by type) |
-| `bot_telegram_messages_sent_total` | counter | Messages sent by the bot |
-
-## Troubleshooting
-
-### Log locations
-
-| Log | Path |
-|-----|------|
-| Bot stdout | `~/.minime/logs/telegram-bot.stdout.log` |
-| Bot stderr | `~/.minime/logs/telegram-bot.stderr.log` |
-| Session stderr (per-chat/topic) | `~/.minime/logs/session-<chatId>[_<topicId>].log` |
-| Cron (per-task) | `~/.minime/logs/cron-<name>.log` |
-| Message delivery | `~/.minime/logs/cron-delivery.log` |
-| Reaction events (JSONL) | `~/.minime/logs/reactions.jsonl` |
-
-### Voice transcription requirements
-
-Voice transcription requires:
-- `ffmpeg` (converts Opus-in-OGG to WAV)
-- `whisper-cli` (whisper.cpp CLI)
-- Whisper model file (e.g. `ggml-medium.bin`)
-
-Default paths assume Homebrew on Apple Silicon. Override with env vars: `FFMPEG_BIN`, `WHISPER_BIN`, `WHISPER_MODEL`, `WHISPER_LANGUAGE` (default: `auto`).
-
-### Common issues
-
-**CLAUDECODE env var prevents nested sessions**
-Claude Code sets `CLAUDECODE` in its environment. If a subprocess inherits it, spawning another `claude` CLI fails silently. Both `start-bot.sh` and `run-cron.sh` explicitly `unset CLAUDECODE`. If you see sessions failing to spawn, check that this env var is not leaking through.
-
-**Keychain access denied**
-The bot reads platform tokens from macOS Keychain via `security find-generic-password -s '<service>' -w` (e.g., `telegram-bot-token` or `discord-bot-token`). If this fails, macOS may be prompting for Keychain access in a non-interactive context. Fix: unlock Keychain before starting, or grant "Always Allow" to `security` for this item.
-
-**Messages sent during downtime are discarded**
-After a restart, messages older than 10 minutes (configurable via `sessionDefaults.maxMessageAgeMs` in `config.yaml`) are silently dropped. This prevents stale message floods from triggering unnecessary session spawns. If you sent a message during downtime, resend it after the bot comes back.
-
-**Session blocked after repeated crashes**
-If a session crashes 5 times in a row, it is circuit-broken — the bot refuses to spawn new sessions for that chat. Send `/reset` to clear the crash counter and unblock. Crash backoff starts at 5s and doubles on each crash (capped at 60s) before the circuit fully opens.
-
-**Session stuck / not responding**
-Sessions have a 1-hour idle timeout and max 12 concurrent (LRU eviction). If a session is stuck:
-- Check per-session stderr logs for subprocess crash details: `~/.minime/logs/session-<chatId>.log`
-- Check bot stderr log for bot-level errors
-- The session store persists across restarts: `~/.minime/data/sessions.json`
-- Restarting the bot cleanly closes all sessions (graceful SIGTERM)
-
-**Cron not firing**
-- Verify plist is loaded: `launchctl list | grep ai.minime.cron.my-task`
-- Check schedule: plists use `StartCalendarInterval`, not cron syntax directly. Regenerate if in doubt.
-- Check cron log for errors: `tail ~/.minime/logs/cron-my-task.log`
-
-**maxTurns limit**
-Limits how many agentic loops (tool call chains) Claude can do per single user message. Safety net against runaway agents burning rate limit quota. Set to 250 by default. Remove from config for unlimited. If hit mid-work, Claude stops and the subprocess exits — next message spawns a fresh session via --resume.
-**Max concurrent sessions reached**
-Only 12 warm sessions at a time (`sessionDefaults.maxConcurrentSessions`). LRU session gets evicted. If an important session keeps getting killed, consider increasing the limit in `config.yaml` or reducing idle timeout.
-
-## Scripts
-
-All in `bot/scripts/`.
-
-| Script | Purpose |
-|--------|---------|
-| `start-bot.sh` | Entry point for launchd. Sets up env (PATH, HOME, unset CLAUDECODE, Claude Code flags), runs `main.ts`. |
-| `run-cron.sh` | Entry point for cron plists. Same env setup, runs `cron-runner.ts --task <name>`. |
-| `deliver.sh` | Send a Telegram message. Reads token from Keychain, handles >4096 char splitting at paragraph boundaries, retries without Markdown on parse failure. Usage: `deliver.sh <chat_id> "text"` or pipe. |
-| `generate-plists.ts` | Reads `crons.yaml`, generates launchd plist XML files in `~/Library/LaunchAgents/`. Supports `--dry-run`. Converts cron schedule syntax to `StartCalendarInterval`. |
+See [bot/src/metrics.ts](bot/src/metrics.ts) for the full list of exported metrics.
 
 ## Similar Projects
 
@@ -595,4 +337,3 @@ No cron system, no multi-agent, no workspace management, no Discord. Single-user
 | Multi-CLI support | Claude Code | Claude Code, Codex, Gemini |
 
 Neither project is strictly better than the other — feature sets are comparable. Ductor covers more CLIs and has deeper crash recovery (in-flight turn tracking, process registry, stream coalescing). We're significantly simpler: a thin TypeScript wrapper around `claude -p` that delegates complexity to the OS (launchd for process isolation, filesystem hooks for workspace protection) rather than reimplementing it in application code.
-

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,8 +14,8 @@ agents:
     workspaceCwd: /Users/YOU/.minime/workspace   # absolute path required (~ not expanded)
     model: claude-opus-4-6
     fallbackModel: claude-sonnet-4-6
-    maxTurns: 250     # safety limit for agentic loops per message
-    effort: high
+    maxTurns: 250     # safety limit for agentic loops per message (omit for unlimited)
+    effort: high      # Claude reasoning effort: low, medium, high (omit for default)
 
   # Add more agents as needed:
   # coder:
@@ -27,19 +27,31 @@ agents:
 bindings:
   - chatId: YOUR_CHAT_ID             # your Telegram user ID (numeric)
     agentId: main
-    kind: dm
+    kind: dm                          # "dm" or "group"
     label: My DM
 
-  # Group binding example:
+  # Group binding example (forum supergroup with per-topic routing):
   # - chatId: -100YOUR_GROUP_ID
   #   agentId: main
   #   kind: group
   #   label: My Group
-  #   requireMention: true
-  #   topics:
-  #     - topicId: 42
-  #       agentId: coder
-  #       label: Dev Topic
+  #
+  #   ## Binding options (all optional):
+  #   # requireMention: true          # require @mention or reply-to-bot (default: true for groups, false for DMs)
+  #   # voiceTranscriptEcho: true     # echo voice transcript back to chat (default: true)
+  #   # streamingUpdates: true        # progressive streaming edits during response (default: true)
+  #   #                               # set false to send only the final message (reduces API rate limit usage)
+  #   # typingIndicator: true         # send typing indicators while processing (default: true)
+  #
+  #   ## Per-topic overrides (forum supergroups only):
+  #   # Each topic gets its own isolated Claude session.
+  #   # Messages in unbound topics fall back to the chat-level binding.
+  #   # topics:
+  #   #   - topicId: 42               # message_thread_id from Telegram
+  #   #     agentId: coder            # override agent for this topic (optional, inherits from parent)
+  #   #     requireMention: false     # override per topic (optional, inherits from parent)
+  #   #   - topicId: 99
+  #   #     requireMention: false     # inherits agentId from parent binding
 
 sessionDefaults:
   idleTimeoutMs: 3600000              # 1 hour (default)
@@ -48,12 +60,41 @@ sessionDefaults:
 
 metricsPort: 9091
 
+# Default delivery target for cron results (optional).
+# Individual crons can override with their own deliveryChatId/deliveryThreadId.
+# defaultDeliveryChatId: -1001234567890
+# defaultDeliveryThreadId: 42
+
+# Admin chat for fallback notifications when cron delivery fails (optional).
+# Must be a non-zero integer. Use negative ID for groups/supergroups.
+# adminChatId: 123456789
+
 # Discord support (optional — bot works Telegram-only without this section)
+# Store token: security add-generic-password -s 'discord-bot-token' -a 'minime' -w 'YOUR_TOKEN'
+# Required bot permissions/intents: Guilds, GuildMessages, MessageContent (privileged), DirectMessages
+# Slash commands (/start, /reset, /status) are registered per-guild on startup.
 # discord:
 #   tokenService: discord-bot-token
 #   bindings:
+#     # Guild-wide default: covers all channels in the server
 #     - guildId: 'YOUR_GUILD_ID'
 #       agentId: main
 #       kind: channel
 #       label: My Server
 #       requireMention: true
+#       streamingUpdates: true
+#       typingIndicator: true
+#       # Per-channel overrides (optional):
+#       # channels:
+#       #   - channelId: '1234567890'
+#       #     label: Dev Channel
+#       #     requireMention: false
+#       #   - channelId: '1111111111'
+#       #     agentId: coder            # different agent for this channel
+#
+#     # Per-channel binding (exact channelId match wins over guild-wide fallback):
+#     # - channelId: '5555555555'
+#     #   guildId: 'YOUR_GUILD_ID'
+#     #   agentId: main
+#     #   kind: channel
+#     #   label: Legacy Channel

--- a/crons.yaml.example
+++ b/crons.yaml.example
@@ -2,6 +2,21 @@
 # All times use the machine's local timezone
 # Copy this file to crons.yaml and customize:
 #   cp crons.yaml.example crons.yaml
+#
+# Field reference:
+#   name              (string, required)  Unique identifier for the cron job
+#   schedule          (string, required)  Cron expression (5-field), local timezone
+#   type              ("llm"|"script")    "llm" (default) runs claude -p with prompt; "script" runs a shell command
+#   prompt            (string)            Prompt text sent to Claude (required for type: llm)
+#   command           (string)            Shell command to execute (required for type: script)
+#   agentId           (string, required)  Must match an agent in config.yaml (determines workspace)
+#   deliveryChatId    (number)            Telegram chat ID for result delivery (falls back to config default)
+#   deliveryThreadId  (number)            Telegram forum topic ID for delivery (falls back to config default)
+#   timeout           (number)            Per-cron timeout in milliseconds (default: 300000 = 5 min)
+#   enabled           (boolean)           Set false to skip plist generation for this cron (default: true)
+#
+# Script-mode crons execute via /bin/bash, capture stdout, and deliver like LLM crons.
+# They skip all Claude-specific setup (model, workspace, env vars). Empty output skips delivery.
 
 crons:
   # Example: daily workspace backup
@@ -34,3 +49,12 @@ crons:
     agentId: main
     deliveryChatId: YOUR_CHAT_ID
     timeout: 600000                    # 10 minutes — AI processing may be slow
+
+  # Script-mode cron example — runs a shell command directly (no LLM)
+  # - name: backup-db
+  #   schedule: "0 2 * * *"
+  #   type: script
+  #   command: "/usr/bin/backup.sh --full"
+  #   agentId: main
+  #   deliveryChatId: YOUR_CHAT_ID
+  #   timeout: 300000


### PR DESCRIPTION
## Summary

- Remove Troubleshooting, Supported Message Types, Scripts, and Bot Commands sections from README
- Replace inline cron field reference table and binding option descriptions with links to example files
- Enrich `config.yaml.example` with comprehensive YAML comments: all binding options (`requireMention`, `voiceTranscriptEcho`, `streamingUpdates`, `typingIndicator`), per-topic overrides, Discord guild/channel config, delivery defaults, admin notifications
- Enrich `crons.yaml.example` with full field reference as header comments plus script-mode cron example

README: 585 -> 339 lines (270 editable + 69 untouched Similar Projects).

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all internal links (`config.yaml.example`, `crons.yaml.example`, `bot/src/metrics.ts`) resolve
- [ ] Confirm a new user can follow Installation steps end-to-end from README + example files

🤖 Generated with [Claude Code](https://claude.com/claude-code)