### PR TITLE
feat: atomic JSON writes for thread-cache and message-content-index

### DIFF
--- a/bot/src/__tests__/message-content-index.test.ts
+++ b/bot/src/__tests__/message-content-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -205,6 +205,29 @@ describe("message-content-index persistence", () => {
     assert.strictEqual(rec.preview, "Hello world");
     assert.strictEqual(rec.direction, "in");
     assert.strictEqual(typeof rec.timestamp, "number");
+  });
+
+  it("atomic write: .tmp file does not persist after successful save", () => {
+    recordMessage(-100, 1, "alice", "Hello", "in");
+    saveMessageIndex(indexPath);
+    assert.ok(existsSync(indexPath), "final file should exist");
+    assert.ok(!existsSync(indexPath + ".tmp"), ".tmp file should not persist after save");
+  });
+
+  it("atomic write: final file contains correct data", () => {
+    recordMessage(-100, 1, "alice", "Hello", "in");
+    recordMessage(-200, 2, "bob", "World", "out");
+    saveMessageIndex(indexPath);
+    const data = JSON.parse(readFileSync(indexPath, "utf8"));
+    assert.ok(Array.isArray(data));
+    assert.strictEqual(data.length, 2);
+  });
+
+  it("file permissions are 0o600 after save", () => {
+    recordMessage(-100, 1, "alice", "Hello", "in");
+    saveMessageIndex(indexPath);
+    const mode = statSync(indexPath).mode & 0o777;
+    assert.strictEqual(mode, 0o600);
   });
 });
 

--- a/bot/src/__tests__/message-thread-cache.test.ts
+++ b/bot/src/__tests__/message-thread-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setThread, getThread, clearThreadCache, threadCacheSize, saveThreadCache, restoreThreadCache } from "../message-thread-cache.js";
@@ -157,7 +157,7 @@ describe("message-thread-cache persistence", () => {
     writeFileSync(cachePath, JSON.stringify(entries), "utf8");
 
     restoreThreadCache(cachePath);
-    assert.strictEqual(threadCacheSize(), 9_999);
+    assert.strictEqual(threadCacheSize(), 10_000);
   });
 
   it("save creates parent directories if missing", () => {
@@ -175,5 +175,28 @@ describe("message-thread-cache persistence", () => {
     clearThreadCache();
     restoreThreadCache(cachePath);
     assert.strictEqual(getThread(-100, 1), 0);
+  });
+
+  it("atomic write: .tmp file does not persist after successful save", () => {
+    setThread(-100, 1, 10);
+    saveThreadCache(cachePath);
+    assert.ok(existsSync(cachePath), "final file should exist");
+    assert.ok(!existsSync(cachePath + ".tmp"), ".tmp file should not persist after save");
+  });
+
+  it("file permissions are 0o600 after save", () => {
+    setThread(-100, 1, 10);
+    saveThreadCache(cachePath);
+    const mode = statSync(cachePath).mode & 0o777;
+    assert.strictEqual(mode, 0o600);
+  });
+
+  it("atomic write: final file contains correct data", () => {
+    setThread(-100, 1, 10);
+    setThread(-200, 2, 20);
+    saveThreadCache(cachePath);
+    const data = JSON.parse(readFileSync(cachePath, "utf8"));
+    assert.ok(Array.isArray(data));
+    assert.strictEqual(data.length, 2);
   });
 });

--- a/bot/src/message-content-index.ts
+++ b/bot/src/message-content-index.ts
@@ -13,7 +13,7 @@
  * and a full wipe would destroy needed context.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { log } from "./logger.js";
@@ -88,15 +88,16 @@ export function messageIndexSize(): number {
  * Format: array of [key, value] pairs (Map serialization).
  */
 export function saveMessageIndex(path: string = DEFAULT_INDEX_PATH): void {
+  const tmpPath = path + ".tmp";
   try {
     const dir = dirname(path);
     mkdirSync(dir, { recursive: true, mode: 0o700 });
-    chmodSync(dir, 0o700);
     const entries = Array.from(index.entries());
-    writeFileSync(path, JSON.stringify(entries), { encoding: "utf8", mode: 0o600 });
-    chmodSync(path, 0o600);
+    writeFileSync(tmpPath, JSON.stringify(entries), { encoding: "utf8", mode: 0o600 });
+    renameSync(tmpPath, path);
     log.info("message-index", `Saved ${entries.length} entries to ${path}`);
   } catch (err) {
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
     log.error("message-index", `Failed to save index to ${path}:`, err);
   }
 }

--- a/bot/src/message-thread-cache.ts
+++ b/bot/src/message-thread-cache.ts
@@ -12,7 +12,7 @@
  * to the correct topic.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { log } from "./logger.js";
@@ -62,12 +62,16 @@ export function threadCacheSize(): number {
  * Format: array of [key, value] pairs (Map serialization).
  */
 export function saveThreadCache(path: string = DEFAULT_CACHE_PATH): void {
+  const tmpPath = path + ".tmp";
   try {
-    mkdirSync(dirname(path), { recursive: true });
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
     const entries = Array.from(cache.entries());
-    writeFileSync(path, JSON.stringify(entries), "utf8");
+    writeFileSync(tmpPath, JSON.stringify(entries), { encoding: "utf8", mode: 0o600 });
+    renameSync(tmpPath, path);
     log.info("thread-cache", `Saved ${entries.length} entries to ${path}`);
   } catch (err) {
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
     log.error("thread-cache", `Failed to save cache to ${path}:`, err);
   }
 }
@@ -88,7 +92,7 @@ export function restoreThreadCache(path: string = DEFAULT_CACHE_PATH): void {
     }
     let loaded = 0;
     for (const entry of parsed) {
-      if (loaded >= MAX_CACHE_SIZE - 1) break;
+      if (loaded >= MAX_CACHE_SIZE) break;
       if (!Array.isArray(entry) || entry.length !== 2) continue;
       const [key, value] = entry;
       if (typeof key !== "string" || typeof value !== "number") continue;


### PR DESCRIPTION
## Summary
- Make saveThreadCache and saveMessageIndex atomic (write .tmp → rename)
- Fix off-by-one in thread-cache restore (9999 → 10000)
- Add explicit file permissions (0o600 for files, 0o700 for dirs)
- Add 6 tests covering atomicity, data integrity, and permissions

## Details
Follows existing atomic write pattern from session-store.ts. Prevents data corruption if process crashes mid-write (POSIX rename is atomic).

Closes #46

Generated with Claude Code