### PR TITLE
feat: workspace-level orphan allowlists

### DIFF
--- a/.claude/hooks/guardian.sh
+++ b/.claude/hooks/guardian.sh
@@ -76,36 +76,48 @@ fi
 
 ROOT_COMPONENT="${REL_PATH%%/*}"
 
-# Load allowlist (same file orphan-scan.sh uses)
-ALLOWLIST="$WORKSPACE/.claude/skills/workspace-health/scripts/orphan-allowlist.txt"
+# Load allowlists (workspace-level first, fallback to skill-level)
+# Same logic as orphan-scan.sh for consistency
+ALLOWLIST_FILES=()
+if [[ -f "$WORKSPACE/.orphan-allowlist.txt" ]] || [[ -f "$WORKSPACE/.orphan-allowlist.local.txt" ]]; then
+  [[ -f "$WORKSPACE/.orphan-allowlist.txt" ]] && ALLOWLIST_FILES+=("$WORKSPACE/.orphan-allowlist.txt")
+  [[ -f "$WORKSPACE/.orphan-allowlist.local.txt" ]] && ALLOWLIST_FILES+=("$WORKSPACE/.orphan-allowlist.local.txt")
+else
+  SKILL_ALLOWLIST="$WORKSPACE/.claude/skills/workspace-health/scripts/orphan-allowlist.txt"
+  SKILL_ALLOWLIST_LOCAL="$WORKSPACE/.claude/skills/workspace-health/scripts/orphan-allowlist.local.txt"
+  [[ -f "$SKILL_ALLOWLIST" ]] && ALLOWLIST_FILES+=("$SKILL_ALLOWLIST")
+  [[ -f "$SKILL_ALLOWLIST_LOCAL" ]] && ALLOWLIST_FILES+=("$SKILL_ALLOWLIST_LOCAL")
+fi
 
-if [[ ! -f "$ALLOWLIST" ]]; then
-  echo "BLOCKED by directory guardian: allowlist not found at $ALLOWLIST" >&2
+if [[ ${#ALLOWLIST_FILES[@]} -eq 0 ]]; then
+  echo "BLOCKED by directory guardian: no allowlist found" >&2
   echo "Cannot verify whether '${REL_PATH}' is allowed. Blocking to be safe." >&2
   exit 2
 fi
 
 # Check root component against allowlist patterns
-while IFS= read -r line; do
-  # Strip comments and whitespace
-  line="${line%%#*}"
-  line="${line#"${line%%[![:space:]]*}"}"
-  line="${line%"${line##*[![:space:]]}"}"
-  [[ -z "$line" ]] && continue
+for ALLOWLIST in "${ALLOWLIST_FILES[@]}"; do
+  while IFS= read -r line; do
+    # Strip comments and whitespace
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
 
-  # Exact match
-  [[ "$ROOT_COMPONENT" == "$line" ]] && exit 0
+    # Exact match
+    [[ "$ROOT_COMPONENT" == "$line" ]] && exit 0
 
-  # Glob match
-  # shellcheck disable=SC2254
-  case "$ROOT_COMPONENT" in $line) exit 0 ;; esac
-done < "$ALLOWLIST"
+    # Glob match
+    # shellcheck disable=SC2254
+    case "$ROOT_COMPONENT" in $line) exit 0 ;; esac
+  done < "$ALLOWLIST"
+done
 
 # Not in allowlist — block with helpful error
 cat >&2 <<ERRMSG
 BLOCKED by directory guardian: cannot create '${REL_PATH}' in workspace root.
 
 The root-level name '${ROOT_COMPONENT}' is not in the allowed workspace structure.
-To allow it, add a pattern to: .claude/skills/workspace-health/scripts/orphan-allowlist.txt
+To allow it, add entry to: .orphan-allowlist.local.txt in workspace root
 ERRMSG
 exit 2

--- a/.claude/skills/workspace-health/scripts/orphan-scan.sh
+++ b/.claude/skills/workspace-health/scripts/orphan-scan.sh
@@ -17,8 +17,15 @@ echo "=== Orphan Scan: $WORKSPACE ==="
 echo ""
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALLOWLIST="$SCRIPT_DIR/orphan-allowlist.txt"
-ALLOWLIST_LOCAL="$SCRIPT_DIR/orphan-allowlist.local.txt"
+# Workspace-level allowlists (preferred — customizable per-repo)
+# Falls back to skill-level allowlists if workspace ones don't exist
+if [ -f "$WORKSPACE/.orphan-allowlist.txt" ] || [ -f "$WORKSPACE/.orphan-allowlist.local.txt" ]; then
+  ALLOWLIST="$WORKSPACE/.orphan-allowlist.txt"
+  ALLOWLIST_LOCAL="$WORKSPACE/.orphan-allowlist.local.txt"
+else
+  ALLOWLIST="$SCRIPT_DIR/orphan-allowlist.txt"
+  ALLOWLIST_LOCAL="$SCRIPT_DIR/orphan-allowlist.local.txt"
+fi
 
 # Load allowlist entries (skip comments and blank lines)
 ALLOWED=()
@@ -124,7 +131,7 @@ else
     fi
   done
   echo ""
-  echo "To suppress: add entries to .claude/skills/workspace-health/scripts/orphan-allowlist.local.txt"
+  echo "To suppress: add entries to .orphan-allowlist.local.txt in workspace root"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Guardian hook and orphan-scan now check workspace root first for allowlists
- `$WORKSPACE/.orphan-allowlist.txt` + `.orphan-allowlist.local.txt` take priority
- Falls back to skill-level allowlists if workspace-level don't exist
- Enables per-workspace customization without modifying shared skill files

## Test plan
- [ ] Verify guardian blocks writes to unlisted root paths
- [ ] Verify workspace-level allowlist is picked up when present
- [ ] Verify fallback to skill-level allowlist when workspace-level absent
- [ ] Run orphan-scan on workspace with custom allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)