### PR TITLE
feat: settings separation validation in workspace-health

### DIFF
--- a/.claude/skills/workspace-health/scripts/config-check.sh
+++ b/.claude/skills/workspace-health/scripts/config-check.sh
@@ -84,6 +84,34 @@ if [ -f "$SETTINGS_LOCAL" ]; then
 else
   echo "  INFO: settings.local.json not created (optional override file)"
 fi
+
+# --- Settings separation: user prefs must be in settings.local.json, not settings.json ---
+if [ -f "$SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+  USER_PREF_KEYS=("outputStyle" "autoMemoryEnabled" "autoMemoryDirectory")
+  for key in "${USER_PREF_KEYS[@]}"; do
+    if jq -e "has(\"$key\")" "$SETTINGS" >/dev/null 2>&1; then
+      echo "  FAIL: settings.json contains user preference '$key' (move to settings.local.json)"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+fi
+
+# --- Required fields in settings.local.json ---
+if [ -f "$SETTINGS_LOCAL" ] && command -v jq >/dev/null 2>&1; then
+  REQUIRED_LOCAL_KEYS=("autoMemoryEnabled" "autoMemoryDirectory")
+  for key in "${REQUIRED_LOCAL_KEYS[@]}"; do
+    if ! jq -e "has(\"$key\")" "$SETTINGS_LOCAL" >/dev/null 2>&1; then
+      echo "  WARN: settings.local.json missing '$key'"
+      WARNINGS=$((WARNINGS + 1))
+    fi
+  done
+  # autoMemoryDirectory must end with /memory/auto
+  MEM_DIR=$(jq -r '.autoMemoryDirectory // empty' "$SETTINGS_LOCAL" 2>/dev/null)
+  if [ -n "$MEM_DIR" ] && [[ "$MEM_DIR" != */memory/auto ]]; then
+    echo "  FAIL: autoMemoryDirectory must end with /memory/auto (got: $MEM_DIR)"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
 echo ""
 
 # --- Hooks configuration ---

--- a/.claude/skills/workspace-health/tests/test-scripts.sh
+++ b/.claude/skills/workspace-health/tests/test-scripts.sh
@@ -123,6 +123,63 @@ fi
 # settings.local.json missing should not be a FAIL
 assert_not_contains "missing settings.local.json is not a FAIL" "FAIL.*settings.local.json" bash "$SCRIPT_DIR/config-check.sh" "$WORKSPACE"
 
+# --- Settings separation tests ---
+# Test with synthetic workspace: user prefs in settings.json should FAIL
+TESTS=$((TESTS + 1))
+_TMP_CFG=$(mktemp -d)
+git -C "$_TMP_CFG" init -q >/dev/null 2>&1
+mkdir -p "$_TMP_CFG/.claude"
+echo '{"outputStyle":"X","autoMemoryEnabled":true}' > "$_TMP_CFG/.claude/settings.json"
+touch "$_TMP_CFG/CLAUDE.md" "$_TMP_CFG/USER.md" "$_TMP_CFG/IDENTITY.md" "$_TMP_CFG/.gitignore" "$_TMP_CFG/MEMORY.md"
+_CFG_OUT=$(bash "$SCRIPT_DIR/config-check.sh" "$_TMP_CFG" 2>&1 || true)
+if echo "$_CFG_OUT" | grep -q "FAIL.*outputStyle.*settings.local" && echo "$_CFG_OUT" | grep -q "FAIL.*autoMemoryEnabled.*settings.local"; then
+  echo "  PASS: detects user prefs in settings.json"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: did not detect user prefs in settings.json"
+  echo "    Output: $(echo "$_CFG_OUT" | grep -i 'fail\|warn' | head -5)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$_TMP_CFG"
+
+# Test: autoMemoryDirectory not ending in /memory/auto should FAIL
+TESTS=$((TESTS + 1))
+_TMP_CFG2=$(mktemp -d)
+git -C "$_TMP_CFG2" init -q >/dev/null 2>&1
+mkdir -p "$_TMP_CFG2/.claude"
+echo '{}' > "$_TMP_CFG2/.claude/settings.json"
+echo '{"autoMemoryEnabled":true,"autoMemoryDirectory":"/bad/path/memory"}' > "$_TMP_CFG2/.claude/settings.local.json"
+touch "$_TMP_CFG2/CLAUDE.md" "$_TMP_CFG2/USER.md" "$_TMP_CFG2/IDENTITY.md" "$_TMP_CFG2/.gitignore" "$_TMP_CFG2/MEMORY.md"
+_CFG_OUT2=$(bash "$SCRIPT_DIR/config-check.sh" "$_TMP_CFG2" 2>&1 || true)
+if echo "$_CFG_OUT2" | grep -q "FAIL.*autoMemoryDirectory.*memory/auto"; then
+  echo "  PASS: detects wrong autoMemoryDirectory path"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: did not detect wrong autoMemoryDirectory path"
+  echo "    Output: $(echo "$_CFG_OUT2" | grep -i 'fail\|warn' | head -5)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$_TMP_CFG2"
+
+# Test: missing required keys in settings.local.json should WARN
+TESTS=$((TESTS + 1))
+_TMP_CFG3=$(mktemp -d)
+git -C "$_TMP_CFG3" init -q >/dev/null 2>&1
+mkdir -p "$_TMP_CFG3/.claude"
+echo '{}' > "$_TMP_CFG3/.claude/settings.json"
+echo '{}' > "$_TMP_CFG3/.claude/settings.local.json"
+touch "$_TMP_CFG3/CLAUDE.md" "$_TMP_CFG3/USER.md" "$_TMP_CFG3/IDENTITY.md" "$_TMP_CFG3/.gitignore" "$_TMP_CFG3/MEMORY.md"
+_CFG_OUT3=$(bash "$SCRIPT_DIR/config-check.sh" "$_TMP_CFG3" 2>&1 || true)
+if echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryEnabled" && echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryDirectory"; then
+  echo "  PASS: warns about missing required keys in settings.local.json"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: did not warn about missing required keys"
+  echo "    Output: $(echo "$_CFG_OUT3" | grep -i 'fail\|warn' | head -5)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$_TMP_CFG3"
+
 # No ADR references
 TESTS=$((TESTS + 1))
 if grep -q 'ADR-[0-9]' "$SCRIPT_DIR/config-check.sh"; then


### PR DESCRIPTION
## Summary
- config-check.sh now detects user preferences (`outputStyle`, `autoMemoryEnabled`, `autoMemoryDirectory`) leaked into `settings.json` — these belong in `settings.local.json`
- Warns when `settings.local.json` is missing required keys (`autoMemoryEnabled`, `autoMemoryDirectory`)
- Validates `autoMemoryDirectory` ends with `/memory/auto` (prevents wrong-path bug from 2026-03-20)
- 3 new tests with synthetic workspaces covering all failure modes

## Test plan
- [x] All 3 new tests pass (synthetic bad configs)
- [x] Clean pass on valid workspace (0 errors, 0 warnings)
- [x] Pre-existing tests still pass (79/80, 1 pre-existing ADR failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)