### PR TITLE
feat: require outputStyle in settings.local.json

### DIFF
--- a/.claude/skills/workspace-health/scripts/config-check.sh
+++ b/.claude/skills/workspace-health/scripts/config-check.sh
@@ -98,7 +98,7 @@ fi
 
 # --- Required fields in settings.local.json ---
 if [ -f "$SETTINGS_LOCAL" ] && command -v jq >/dev/null 2>&1; then
-  REQUIRED_LOCAL_KEYS=("autoMemoryEnabled" "autoMemoryDirectory")
+  REQUIRED_LOCAL_KEYS=("outputStyle" "autoMemoryEnabled" "autoMemoryDirectory")
   for key in "${REQUIRED_LOCAL_KEYS[@]}"; do
     if ! jq -e "has(\"$key\")" "$SETTINGS_LOCAL" >/dev/null 2>&1; then
       echo "  WARN: settings.local.json missing '$key'"

--- a/.claude/skills/workspace-health/tests/test-scripts.sh
+++ b/.claude/skills/workspace-health/tests/test-scripts.sh
@@ -170,7 +170,7 @@ echo '{}' > "$_TMP_CFG3/.claude/settings.json"
 echo '{}' > "$_TMP_CFG3/.claude/settings.local.json"
 touch "$_TMP_CFG3/CLAUDE.md" "$_TMP_CFG3/USER.md" "$_TMP_CFG3/IDENTITY.md" "$_TMP_CFG3/.gitignore" "$_TMP_CFG3/MEMORY.md"
 _CFG_OUT3=$(bash "$SCRIPT_DIR/config-check.sh" "$_TMP_CFG3" 2>&1 || true)
-if echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryEnabled" && echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryDirectory"; then
+if echo "$_CFG_OUT3" | grep -q "WARN.*outputStyle" && echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryEnabled" && echo "$_CFG_OUT3" | grep -q "WARN.*autoMemoryDirectory"; then
   echo "  PASS: warns about missing required keys in settings.local.json"
   PASS=$((PASS + 1))
 else


### PR DESCRIPTION
## Summary
- Add `outputStyle` to `REQUIRED_LOCAL_KEYS` in config-check.sh
- Update test assertion to verify outputStyle warning
- Closes #57

## Context
After upstream merge on 2026-03-21, `outputStyle` was lost from `settings.json` (correctly moved to `settings.local.json`), but no health check caught the missing field. Now workspace-health warns if `outputStyle` is absent from `settings.local.json`.

## Test plan
- [x] 80/80 workspace-health tests pass
- [ ] Opus review

🤖 Generated with [Claude Code](https://claude.com/claude-code)