### PR TITLE
feat: increase default cron timeout to 15min

### DIFF
--- a/bot/src/cron-runner.ts
+++ b/bot/src/cron-runner.ts
@@ -18,7 +18,7 @@ const CRONS_PATH = resolve(REPO_ROOT, "crons.yaml");
 const LOG_DIR = process.env.LOG_DIR ?? join(homedir(), ".minime", "logs");
 const DELIVER_SCRIPT = resolve(BOT_DIR, "scripts", "deliver.sh");
 
-const DEFAULT_TIMEOUT_MS = 300000; // 5 minutes
+const DEFAULT_TIMEOUT_MS = 900000; // 15 minutes
 
 function log(taskName: string, msg: string): void {
   mkdirSync(LOG_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- Increase `DEFAULT_TIMEOUT_MS` from 300000 (5min) to 900000 (15min)
- Crons invoking Claude regularly hit ETIMEDOUT on complex prompts
- Per-cron `timeout` override in crons.yaml is unaffected

## Test plan
- [ ] Verify crons without explicit timeout use 15min default
- [ ] Verify crons with explicit timeout still use their value

🤖 Generated with [Claude Code](https://claude.com/claude-code)