### PR TITLE
fix: move whisper model default path outside brew Cellar

### DIFF
--- a/bot/src/__tests__/voice.test.ts
+++ b/bot/src/__tests__/voice.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { tempFilePath, downloadFile, cleanupTempFile, transcribeAudio, convertToWav, FFMPEG_BIN, WHISPER_BIN, WHISPER_MODEL } from "../voice.js";
 
 describe("tempFilePath", () => {
@@ -140,7 +142,7 @@ describe("convertToWav", () => {
 describe("transcribeAudio", () => {
   it("exports correct whisper-cli paths", () => {
     assert.strictEqual(WHISPER_BIN, "/opt/homebrew/bin/whisper-cli");
-    assert.strictEqual(WHISPER_MODEL, "/opt/homebrew/share/whisper-cpp/ggml-medium.bin");
+    assert.strictEqual(WHISPER_MODEL, join(homedir(), ".minime/models/ggml-medium.bin"));
   });
 
   it("rejects when given a nonexistent audio file", async () => {

--- a/bot/src/voice.ts
+++ b/bot/src/voice.ts
@@ -1,4 +1,5 @@
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
 import { writeFile, unlink, chmod } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
@@ -8,7 +9,7 @@ const execFileAsync = promisify(execFileCb);
 
 export const FFMPEG_BIN = process.env.FFMPEG_BIN ?? "/opt/homebrew/bin/ffmpeg";
 export const WHISPER_BIN = process.env.WHISPER_BIN ?? "/opt/homebrew/bin/whisper-cli";
-export const WHISPER_MODEL = process.env.WHISPER_MODEL ?? "/opt/homebrew/share/whisper-cpp/ggml-medium.bin";
+export const WHISPER_MODEL = process.env.WHISPER_MODEL ?? join(homedir(), ".minime/models/ggml-medium.bin");
 
 /**
  * Generate a unique temp file path with given prefix and extension.


### PR DESCRIPTION
## Summary

- Change default `WHISPER_MODEL` path from `/opt/homebrew/share/whisper-cpp/ggml-medium.bin` to `~/.minime/models/ggml-medium.bin`
- The brew Cellar path gets deleted on `brew upgrade whisper-cpp`, breaking voice transcription
- New path under `~/.minime/models/` persists across brew upgrades

Closes #90

## Test plan

- [x] `node --import tsx --test src/__tests__/voice.test.ts` — 13/13 pass
- [x] `tsc --noEmit` — clean
- [x] Copy model file to `~/.minime/models/ggml-medium.bin` on production host
- [x] Test voice transcription end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)