### PR TITLE
fix: enable typing indicator for DM chats

### DIFF
--- a/bot/src/__tests__/telegram-adapter.test.ts
+++ b/bot/src/__tests__/telegram-adapter.test.ts
@@ -276,11 +276,12 @@ describe("createTelegramAdapter", () => {
       assert.strictEqual(ctx._chatActions[0].opts.message_thread_id, 42);
     });
 
-    it("is a no-op for DM chats (drafts show typing)", async () => {
+    it("sends typing action for DM chats", async () => {
       const ctx = mockContext();
       const adapter = createTelegramAdapter(ctx, defaultBinding);
       await adapter.sendTyping();
-      assert.strictEqual(ctx._chatActions.length, 0);
+      assert.strictEqual(ctx._chatActions.length, 1);
+      assert.strictEqual(ctx._chatActions[0].action, "typing");
     });
 
     it("is a no-op when chatId is undefined", async () => {

--- a/bot/src/telegram-adapter.ts
+++ b/bot/src/telegram-adapter.ts
@@ -76,7 +76,7 @@ export function createTelegramAdapter(
     },
 
     async sendTyping(): Promise<void> {
-      if (!chatId || isDm) return;
+      if (!chatId) return;
       await ctx.api.sendChatAction(
         chatId,
         "typing",


### PR DESCRIPTION
## Summary
- Remove `isDm` guard from `sendTyping()` in telegram-adapter — DMs now get `sendChatAction("typing")` like groups
- `sendMessageDraft` (draft preview) continues to work in parallel for DMs

Closes #94

## Test plan
- [x] 915/915 tests pass
- [x] Manual: `sendChatAction("typing")` returns ok for DM chat (verified via curl)
- [ ] Verify typing indicator appears in DM after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)