### PR TITLE
fix: destroySession race with concurrent getOrCreateSession (#106)

### DIFF
--- a/bot/src/__tests__/session-manager.test.ts
+++ b/bot/src/__tests__/session-manager.test.ts
@@ -269,6 +269,83 @@ describe("SessionManager", () => {
     assert.strictEqual(result.resume, false, "destroyed session should not resume");
   });
 
+  it("destroySession removes stored state before awaiting child exit (race-safe)", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const { SessionStore } = await import("../session-store.js");
+
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("chat-race", {
+      sessionId: "race-sid",
+      chatId: "chat-race",
+      agentId: "main",
+      lastActivity: Date.now(),
+    });
+
+    const manager = new SessionManager(() => testConfig, TEST_STORE_PATH);
+
+    // Build a child that delays its exit to widen the race window
+    const slowChild = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(slowChild, {
+      stdout: new Readable({ read() {} }),
+      stderr: new Readable({ read() {} }),
+      stdin: new Writable({ write(_c, _e, cb) { cb(); } }),
+      pid: 99999,
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      kill(signal?: string) {
+        (slowChild as unknown as Record<string, unknown>).killed = true;
+        setTimeout(() => {
+          (slowChild as unknown as Record<string, unknown>).exitCode = 0;
+          slowChild.emit("exit", 0, signal ?? "SIGTERM");
+        }, 200);
+        return true;
+      },
+    });
+
+    const outboxPath = `${TEST_DIR}/outbox-race`;
+    const injectDir = `${TEST_DIR}/inject-race`;
+    mkdirSync(outboxPath, { recursive: true });
+    mkdirSync(injectDir, { recursive: true });
+
+    const fakeSession: ActiveSession = {
+      child: slowChild,
+      sessionId: "race-sid",
+      agentId: "main",
+      queue: new PQueue({ concurrency: 1 }),
+      idleTimer: null,
+      idleTimeoutMs: 100000,
+      lastActivity: Date.now(),
+      processingStartedAt: null,
+      lastSuccessAt: null,
+      restartCount: 0,
+      outboxPath,
+      injectDir,
+    };
+
+    (manager as unknown as { active: Map<string, ActiveSession> }).active.set("chat-race", fakeSession);
+
+    const destroyPromise = manager.destroySession("chat-race");
+
+    // Mid-flight: store entry must already be gone (delete precedes child-exit await)
+    const storeMid = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(
+      storeMid.getSession("chat-race"),
+      undefined,
+      "destroySession must delete store entry BEFORE awaiting child exit",
+    );
+
+    await destroyPromise;
+
+    // And destroySession's {persist: false} must keep it gone
+    const storeAfter = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(
+      storeAfter.getSession("chat-race"),
+      undefined,
+      "store must remain empty after destroy completes (persist: false)",
+    );
+  });
+
   it("destroySession deletes state that closeSession would preserve", async () => {
     const { SessionManager } = await import("../session-manager.js");
     const { SessionStore } = await import("../session-store.js");

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -454,7 +454,7 @@ export class SessionManager {
   }
 
   /** Close a session: persist state, SIGTERM child, clean up. */
-  async closeSession(chatId: string): Promise<void> {
+  async closeSession(chatId: string, { persist = true }: { persist?: boolean } = {}): Promise<void> {
     // Always clear crash count so /reconnect unblocks circuit-broken chats
     this.restartCounts.delete(chatId);
 
@@ -467,8 +467,10 @@ export class SessionManager {
       session.idleTimer = null;
     }
 
-    // Persist final state
-    this.store.setSession(chatId, this.toSessionState(chatId, session));
+    // Persist final state (skipped by destroySession to prevent race)
+    if (persist) {
+      this.store.setSession(chatId, this.toSessionState(chatId, session));
+    }
 
     // Remove from active map first to prevent re-entry
     this.active.delete(chatId);
@@ -567,10 +569,14 @@ export class SessionManager {
   /**
    * Destroy a session: close it AND delete stored state.
    * Next message will start a completely fresh session (no --resume).
+   *
+   * Deletes from store BEFORE closing and skips closeSession's persist
+   * to prevent a concurrent getOrCreateSession from resuming with
+   * --resume during the child-exit await window.
    */
   async destroySession(chatId: string): Promise<void> {
-    await this.closeSession(chatId);
     this.store.deleteSession(chatId);
+    await this.closeSession(chatId, { persist: false });
     // closeSession only touches the media dir when an in-memory session exists;
     // /clean after a bot restart/crash (or before any spawn) must still wipe it.
     try { cleanupSessionMediaDir(chatId); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- Closes #106.
- destroySession now deletes the store entry before awaiting the child-process exit, and calls closeSession(chatId, { persist: false }) so the closing snapshot does not re-add the row.
- Added a race-safe test that injects a slow-exiting child and verifies the store is already empty mid-destroy.

## Why
destroySession awaited closeSession, which persisted a fresh snapshot on its way out. During the 0-5s SIGTERM to exit window, a concurrent getOrCreateSession for the same chatId could read that snapshot and spawn with --resume, reviving the session the user just /cleaned. Root cause and reproduction in #106.

## Test plan
- [x] npx tsx --test bot/src/__tests__/session-manager.test.ts -> 60/60 pass
- [x] New test destroySession removes stored state before awaiting child exit (race-safe) fails without the ordering fix
- [ ] Full bot test suite in CI