### PR TITLE
chore: default to opus/sonnet aliases in config templates

### DIFF
--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -7,13 +7,20 @@
 # Optional: override the fleet-wide model in one place.
 # Any agent without its own `model` inherits this value; bump it to upgrade
 # every inheriting agent at once. Per-agent `model` still wins when declared.
-# defaultModel: claude-opus-4-7
-# defaultFallbackModel: claude-sonnet-4-6
+#
+# Use aliases (`opus`, `sonnet`, `haiku`) for auto-upgrade to the latest
+# version on your account tier, or full names (`claude-opus-4-7`) to pin.
+# Append `[1m]` for the 1M-token context window (e.g. `opus[1m]`) — check
+# Claude Code's Model configuration docs for plan eligibility.
+# defaultModel: opus
+# defaultFallbackModel: sonnet
 
 agents:
   main:
     workspaceCwd: /Users/you/.minime/workspace   # absolute path to your Claude workspace (~ not expanded)
-    # model omitted — inherits defaultModel. Uncomment to pin this agent to a specific model:
+    # model omitted — inherits defaultModel. Uncomment to pin this agent to a specific model
+    # or opt into the 1M context window on a single agent:
+    # model: opus[1m]
     # model: claude-haiku-4-5-20251001
 
 bindings:

--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,15 @@ logLevel: info
 # Fleet-wide defaults: any agent without its own `model` / `fallbackModel`
 # inherits these. Bump here to upgrade every inheriting agent at once.
 # Per-agent `model` / `fallbackModel` still wins when declared.
-defaultModel: claude-opus-4-6
-defaultFallbackModel: claude-sonnet-4-6
+#
+# Aliases (`opus`, `sonnet`, `haiku`) resolve to the latest version for your
+# account tier and auto-upgrade when Anthropic ships a new model. Pin to a
+# full name (e.g. `claude-opus-4-7`) if you want a fixed version. Append
+# `[1m]` (e.g. `opus[1m]`) to opt into the 1M-token context window on
+# supported models — see Claude Code's Model configuration docs for plan
+# eligibility.
+defaultModel: opus
+defaultFallbackModel: sonnet
 
 agents:
   main:


### PR DESCRIPTION
## Summary
- Swap pinned `claude-opus-4-6` / `claude-sonnet-4-6` defaults for the `opus` / `sonnet` aliases in `config.yaml` and `config.local.yaml.example`.
- Document the `[1m]` suffix for opting into the 1M-token context window.

## Why
- Fresh installs auto-track the latest recommended model for the account tier without config edits each Anthropic release.
- Operators who need version pinning still can (full names still work — config.ts passes the model string through unchanged).
- The 1M-context opt-in story was undocumented in the templates; users had to find Claude Code docs on their own.

## Test plan
- [x] `npx tsx bot/src/config.ts --validate` passes on new config.
- [x] Live check: `model: opus[1m]` on main agent resolves to `claude-opus-4-7[1m]` and the subprocess confirms 1M context window.
- [x] CI (gitleaks) passes.