### PR TITLE
docs(rules): strengthen NO_REPLY communication rule

### DIFF
--- a/.claude/rules/platform/communication.md
+++ b/.claude/rules/platform/communication.md
@@ -14,7 +14,21 @@ You're a participant, not Ninja's voice or proxy. Don't share his private info.
 
 ## Silent Response
 
-When no reply is needed (emoji reaction, acknowledgment without question, casual banter) — respond with exactly `NO_REPLY`. The bot swallows this token and sends nothing to the user. Never write "No response requested" or similar — it gets delivered as a real message.
+When no reply is needed (emoji reaction, acknowledgment without question, casual banter), your **ENTIRE response must be exactly the literal token `NO_REPLY`** — nothing else, no preamble, no summary, no explanation before or after.
+
+The bot's delivery suppression regex is `/^NO_REPLY\b/` applied to the trimmed output. It matches **only** when `NO_REPLY` is the FIRST text in your response. A reason after a colon is fine (`NO_REPLY: nothing actionable`), but **any leading content — even one word of summary — causes the WHOLE message to be delivered to the user.**
+
+Wrong (delivered as a real message):
+- `All checks clean. NO_REPLY` ← summary first → bot delivers everything
+- `Done. NO_REPLY` ← same
+- `Acknowledged.\n\nNO_REPLY` ← same
+
+Right (suppressed):
+- `NO_REPLY`
+- `NO_REPLY: nothing actionable`
+- `  NO_REPLY  ` (whitespace ignored after trim)
+
+Never write "No response requested" or similar — those get delivered as real messages.
 
 ## Telegram Formatting
 

--- a/.claude/rules/platform/communication.md
+++ b/.claude/rules/platform/communication.md
@@ -14,9 +14,9 @@ You're a participant, not Ninja's voice or proxy. Don't share his private info.
 
 ## Silent Response
 
-When no reply is needed (emoji reaction, acknowledgment without question, casual banter), your **ENTIRE response must be exactly the literal token `NO_REPLY`** — nothing else, no preamble, no summary, no explanation before or after.
+When no reply is needed (emoji reaction, acknowledgment without question, casual banter), your response must **start with the literal token `NO_REPLY`** — optionally followed by punctuation and a brief reason. Nothing may precede `NO_REPLY` — no preamble, no summary, no explanation.
 
-The bot's delivery suppression regex is `/^NO_REPLY\b/` applied to the trimmed output. It matches **only** when `NO_REPLY` is the FIRST text in your response. A reason after a colon is fine (`NO_REPLY: nothing actionable`), but **any leading content — even one word of summary — causes the WHOLE message to be delivered to the user.**
+The bot's delivery suppression regex is `/^NO_REPLY\b/` applied to the trimmed output. It matches **only** when `NO_REPLY` is the FIRST text in your response. Any leading content — even one word of summary — causes the WHOLE message to be delivered to the user.
 
 Wrong (delivered as a real message):
 - `All checks clean. NO_REPLY` ← summary first → bot delivers everything
@@ -25,8 +25,8 @@ Wrong (delivered as a real message):
 
 Right (suppressed):
 - `NO_REPLY`
-- `NO_REPLY: nothing actionable`
-- `  NO_REPLY  ` (whitespace ignored after trim)
+- `NO_REPLY: nothing actionable` ← reason after colon is fine
+- `  NO_REPLY  ` ← whitespace ignored after trim
 
 Never write "No response requested" or similar — those get delivered as real messages.
 


### PR DESCRIPTION
## Summary

- Makes explicit that `NO_REPLY` must be the **first** text in the response, not appended after a summary
- Documents the actual bot regex (`/^NO_REPLY\b/` from `bot/src/stream-relay.ts:274`)
- Adds wrong/right examples so agents self-check before sending

## Why

Repeated workspace-health cron deliveries ended with `NO_REPLY` but led with a one-line clean-status summary. The regex requires `NO_REPLY` at the start of the trimmed output, so the summary was delivered as a real message. The previous wording — "respond with exactly NO_REPLY" — was being interpreted liberally (agents added context first).

## Test plan

- [ ] Agents in new sessions read the strengthened rule and emit bare `NO_REPLY` when nothing is actionable (no leading summary)
- [ ] Cron prompts that already have the strict per-cron wording continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)