### PR TITLE
chore: gitignore Playwright MCP default output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ orphan-allowlist.local.txt
 # Ralphex
 completed/
 
+# Playwright MCP default output directory (screenshots, snapshots, traces)
+.playwright-mcp/
+
 # Instance config overrides (user creates from .example)
 config.local.yaml
 crons.local.yaml


### PR DESCRIPTION
## Summary

- Add `.playwright-mcp/` to the workspace template `.gitignore`
- Prevents the Playwright MCP server's runtime artifacts (screenshots, snapshots, traces) from showing up as orphans in `workspace-health` checks

## Context

The Playwright MCP server (used for browser automation) writes screenshots and accessibility snapshots to `.playwright-mcp/` at the workspace root by default. These accumulate over time (~25MB observed in one local workspace) and currently get flagged by the orphan scanner as "untracked and not gitignored".

The global `~/.gitignore` was updated locally to cover existing workspaces, but adding to the template ensures fresh workspace clones inherit the rule without depending on machine-wide git config.

## Test plan

- [x] Verified `.playwright-mcp/test.png` is ignored after `git check-ignore -v`
- [x] No existing tracked files in `.playwright-mcp/` (nothing breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)