### PR TITLE
feat: chat_id in API error logs + bot_telegram_api_calls_total counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,38 @@ metricsPort: 9090
 
 See [bot/src/metrics.ts](bot/src/metrics.ts) for the full list of exported metrics.
 
+#### Telegram API metrics
+
+Two complementary counters track outbound Telegram API traffic. Both increment per-attempt (the inner transformer runs once per autoRetry attempt), so `rate(errors) / rate(calls)` over the same window yields the attempt-level error ratio.
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `bot_telegram_api_calls_total` | `method`, `binding` | Total Telegram API call attempts (success or failure). The `binding` label is the originating binding's `label` (or its `agentId` when no label is set). Calls without a `chat_id` payload (e.g. `getUpdates`, `getMe`) use the sentinel `none`; calls whose `chat_id` does not match any configured binding use `unbound`. Raw `chat_id` is never emitted as a label value. |
+| `bot_telegram_api_errors_total` | `method`, `error_code` | Total Telegram API errors. `error_code` is the numeric Telegram error code (e.g. `429`) or `http_error` for transport-level failures. |
+
+Operationally, `none` is dominated by the `getUpdates` poll loop and is expected to be the highest-volume series. A non-zero `unbound` rate indicates traffic to a chat that no longer matches any configured binding — typically a stale cron target or a removed binding, and worth investigating.
+
+Example PromQL queries:
+
+```promql
+# 5-minute attempt-level error ratio, per method
+sum by (method) (rate(bot_telegram_api_errors_total[5m]))
+  /
+sum by (method) (rate(bot_telegram_api_calls_total[5m]))
+
+# Per-binding call rate — identifies the noisiest binding during a 429 burst
+sum by (binding) (rate(bot_telegram_api_calls_total[5m]))
+```
+
+#### Telegram API logging
+
+The `telegram-api` warn logs for `Rate limited` and `HTTP error` include `chat_id=` and (when present) `message_thread_id=` extracted from the API payload, so a single `grep` over the bot's stderr log identifies which binding triggered a burst. Methods without a `chat_id` (`getUpdates`, `getMe`, `setWebhook`, etc.) log without those fields — not with `chat_id=undefined`. Example:
+
+```
+2026-05-15T16:15:17.160Z WARN [telegram-api] Rate limited: method=sendMessageDraft chat_id=<numeric-chat-id> message_thread_id=7 retry_after=3
+2026-05-15T16:15:17.622Z WARN [telegram-api] Rate limited: method=getUpdates retry_after=1
+```
+
 ## Upgrading from config.yaml.example
 
 Older versions shipped `config.yaml.example` which you copied to `config.yaml` (gitignored). The current version tracks `config.yaml` directly and uses `config.local.yaml` for user overrides.

--- a/bot/src/__tests__/metrics.test.ts
+++ b/bot/src/__tests__/metrics.test.ts
@@ -4,6 +4,7 @@ import client from "prom-client";
 import {
   recordResultMetrics,
   recordTelegramApiError,
+  recordTelegramApiCall,
   tokensInput,
   tokensOutput,
   tokensCacheRead,
@@ -11,6 +12,7 @@ import {
   costUsd,
   turnDuration,
   telegramApiErrors,
+  telegramApiCalls,
   sessionsActive,
   sessionCrashes,
   messagesReceived,
@@ -125,6 +127,47 @@ describe("recordTelegramApiError", () => {
     );
     assert.strictEqual(edit429?.value, 2);
     assert.strictEqual(send400?.value, 1);
+  });
+});
+
+describe("recordTelegramApiCall", () => {
+  it("records call with method and binding labels", async () => {
+    recordTelegramApiCall("sendMessage", "User1 DM");
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(val.values.length, 1);
+    assert.strictEqual(val.values[0].labels.method, "sendMessage");
+    assert.strictEqual(val.values[0].labels.binding, "User1 DM");
+    assert.strictEqual(val.values[0].value, 1);
+  });
+
+  it("accumulates per (method, binding) label set", async () => {
+    recordTelegramApiCall("sendMessage", "User1 DM");
+    recordTelegramApiCall("sendMessage", "User1 DM");
+    recordTelegramApiCall("sendMessage", "Group A");
+    recordTelegramApiCall("getUpdates", "none");
+
+    const val = await telegramApiCalls.get();
+    const userSend = val.values.find(
+      (v) => v.labels.method === "sendMessage" && v.labels.binding === "User1 DM",
+    );
+    const groupSend = val.values.find(
+      (v) => v.labels.method === "sendMessage" && v.labels.binding === "Group A",
+    );
+    const poll = val.values.find(
+      (v) => v.labels.method === "getUpdates" && v.labels.binding === "none",
+    );
+    assert.strictEqual(userSend?.value, 2);
+    assert.strictEqual(groupSend?.value, 1);
+    assert.strictEqual(poll?.value, 1);
+  });
+
+  it("records 'unbound' sentinel as a regular label value", async () => {
+    recordTelegramApiCall("sendMessage", "unbound");
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(val.values[0].labels.binding, "unbound");
+    assert.strictEqual(val.values[0].value, 1);
   });
 });
 

--- a/bot/src/__tests__/telegram-bot.test.ts
+++ b/bot/src/__tests__/telegram-bot.test.ts
@@ -1,7 +1,9 @@
 process.env.TZ = "UTC";
-import { describe, it } from "node:test";
+import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { resolveBinding, isAuthorized, sessionKey, isImageMimeType, imageExtensionForMime, buildSourcePrefix, shouldRespondInGroup, BOT_COMMANDS, isStaleMessage, buildReplyContext, buildForwardContext, extensionForDocument, formatFileSize, formatDocumentMeta, buildReactionContext, AUTO_RETRY_OPTIONS, extractMediaInfo, extensionForMedia, formatMediaMeta, createTelegramBot } from "../telegram-bot.js";
+import { resolveBinding, isAuthorized, sessionKey, isImageMimeType, imageExtensionForMime, buildSourcePrefix, shouldRespondInGroup, BOT_COMMANDS, isStaleMessage, buildReplyContext, buildForwardContext, extensionForDocument, formatFileSize, formatDocumentMeta, buildReactionContext, AUTO_RETRY_OPTIONS, extractMediaInfo, extensionForMedia, formatMediaMeta, createTelegramBot, extractChatContext, formatChatContextForLog, createApiErrorLoggingTransformer, resolveBindingLabel, BINDING_LABEL_NONE, BINDING_LABEL_UNBOUND } from "../telegram-bot.js";
+import client from "prom-client";
+import { telegramApiCalls, telegramApiErrors } from "../metrics.js";
 import type { TelegramBinding, BotConfig } from "../types.js";
 import type { SessionManager } from "../session-manager.js";
 
@@ -1347,5 +1349,410 @@ describe("command handler wiring", () => {
     await bot.handleUpdate(makeCommandUpdate("clean", 2));
     assert.ok(mockSM.calls.includes("destroySession"), "/clean should call destroySession");
     assert.ok(!mockSM.calls.includes("closeSession"), "/clean handler calls destroySession, not closeSession directly");
+  });
+});
+
+describe("extractChatContext", () => {
+  it("returns chatId and messageThreadId when both present", () => {
+    const ctx = extractChatContext({ chat_id: 555000111, message_thread_id: 42, text: "hi" });
+    assert.deepStrictEqual(ctx, { chatId: 555000111, messageThreadId: 42 });
+  });
+
+  it("returns only chatId when message_thread_id is absent", () => {
+    const ctx = extractChatContext({ chat_id: -100999, text: "hi" });
+    assert.deepStrictEqual(ctx, { chatId: -100999 });
+  });
+
+  it("accepts string chat_id (channel @username)", () => {
+    const ctx = extractChatContext({ chat_id: "@somechannel" });
+    assert.deepStrictEqual(ctx, { chatId: "@somechannel" });
+  });
+
+  it("returns empty object for non-chat payload (getUpdates)", () => {
+    const ctx = extractChatContext({ offset: 0, timeout: 30 });
+    assert.deepStrictEqual(ctx, {});
+  });
+
+  it("returns empty object for undefined payload", () => {
+    assert.deepStrictEqual(extractChatContext(undefined), {});
+  });
+
+  it("returns empty object for non-object payload", () => {
+    assert.deepStrictEqual(extractChatContext("nope"), {});
+  });
+
+  it("ignores null chat_id", () => {
+    assert.deepStrictEqual(extractChatContext({ chat_id: null }), {});
+  });
+
+  it("ignores non-numeric message_thread_id", () => {
+    const ctx = extractChatContext({ chat_id: 1, message_thread_id: null });
+    assert.deepStrictEqual(ctx, { chatId: 1 });
+  });
+});
+
+describe("formatChatContextForLog", () => {
+  it("returns empty string for empty context (so log lines have no chat_id=undefined)", () => {
+    assert.strictEqual(formatChatContextForLog({}), "");
+  });
+
+  it("formats chatId only", () => {
+    assert.strictEqual(formatChatContextForLog({ chatId: 555000111 }), " chat_id=555000111");
+  });
+
+  it("formats chatId and messageThreadId", () => {
+    assert.strictEqual(
+      formatChatContextForLog({ chatId: -100999, messageThreadId: 42 }),
+      " chat_id=-100999 message_thread_id=42",
+    );
+  });
+
+  it("formats string chatId (channel @username)", () => {
+    assert.strictEqual(formatChatContextForLog({ chatId: "@somechannel" }), " chat_id=@somechannel");
+  });
+});
+
+describe("createApiErrorLoggingTransformer", () => {
+  type WarnArgs = { tag: string; message: string };
+
+  // Reset metric registry so the transformer's per-call counter increments
+  // don't leak across tests in this block (and into adjacent blocks).
+  beforeEach(() => {
+    client.register.resetMetrics();
+  });
+
+  function captureWarn(): { logs: WarnArgs[]; restore: () => void } {
+    const logs: WarnArgs[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => {
+      const line = args[0];
+      // Logger formats: "<ISO> WARN [<tag>] <message>"
+      const match = typeof line === "string" ? line.match(/^\S+\s+WARN\s+\[([^\]]+)\]\s+(.*)$/) : null;
+      if (match) logs.push({ tag: match[1], message: match[2] });
+      else logs.push({ tag: "", message: String(line) });
+    };
+    return { logs, restore: () => { console.warn = orig; } };
+  }
+
+  it("includes chat_id and message_thread_id in 429 rate-limit log", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 3 } } as const);
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, message_thread_id: 7, text: "x" });
+      const warn = logs.find((l) => l.tag === "telegram-api");
+      assert.ok(warn, "expected a telegram-api warn log");
+      // Pin full format so reorderings / extra noise / duplicates are caught.
+      assert.strictEqual(
+        warn.message,
+        "Rate limited: method=sendMessageDraft chat_id=555000111 message_thread_id=7 retry_after=3",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("records non-429 error responses without rate-limit log line", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => ({ ok: false, error_code: 400 } as const);
+      const res = await transformer(prev as never, "sendMessage", { chat_id: 555000111, text: "x" });
+      assert.strictEqual(res.ok, false);
+      // No "Rate limited" log for non-429 codes
+      const rateLog = logs.find((l) => l.tag === "telegram-api" && /Rate limited/.test(l.message));
+      assert.strictEqual(rateLog, undefined, "non-429 must not produce a Rate limited log");
+
+      // Error counter must record the 400 code
+      const errs = await telegramApiErrors.get();
+      const send400 = errs.values.find(
+        (v) => v.labels.method === "sendMessage" && v.labels.error_code === "400",
+      );
+      assert.strictEqual(send400?.value, 1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("omits chat context when payload has no chat_id (getUpdates-style)", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 1 } } as const);
+      await transformer(prev as never, "getUpdates", { offset: 0, timeout: 30 });
+      const warn = logs.find((l) => l.tag === "telegram-api");
+      assert.ok(warn, "expected a telegram-api warn log");
+      assert.match(warn.message, /^Rate limited: method=getUpdates retry_after=1$/);
+      assert.ok(!/chat_id/.test(warn.message), "log line must not mention chat_id");
+      assert.ok(!/undefined/.test(warn.message), "log line must not contain 'undefined'");
+    } finally {
+      restore();
+    }
+  });
+
+  it("includes chat_id in HTTP-error log when payload has chat_id and prev throws", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => { throw new Error("ECONNRESET"); };
+      await assert.rejects(
+        () => transformer(prev as never, "sendMessage", { chat_id: -100999, text: "x" }),
+        /ECONNRESET/,
+      );
+      const warn = logs.find((l) => l.tag === "telegram-api");
+      assert.ok(warn, "expected a telegram-api warn log");
+      // Pin full format so reorderings / extra noise / duplicates are caught.
+      assert.strictEqual(warn.message, "HTTP error: method=sendMessage chat_id=-100999 ECONNRESET");
+    } finally {
+      restore();
+    }
+  });
+
+  it("HTTP-error log omits chat context for non-chat payloads", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => { throw new Error("ETIMEDOUT"); };
+      await assert.rejects(
+        () => transformer(prev as never, "getUpdates", { offset: 0, timeout: 30 }),
+        /ETIMEDOUT/,
+      );
+      const warn = logs.find((l) => l.tag === "telegram-api");
+      assert.ok(warn, "expected a telegram-api warn log");
+      assert.match(warn.message, /^HTTP error: method=getUpdates ETIMEDOUT$/);
+      assert.ok(!/chat_id/.test(warn.message));
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not log on successful responses", async () => {
+    const { logs, restore } = captureWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer();
+      const prev = async () => ({ ok: true, result: true } as const);
+      await transformer(prev as never, "sendMessage", { chat_id: 1, text: "x" });
+      assert.strictEqual(logs.filter((l) => l.tag === "telegram-api").length, 0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("resolveBindingLabel", () => {
+  const bindings: TelegramBinding[] = [
+    { chatId: 111111111, agentId: "main", kind: "dm", label: "User1 DM" },
+    { chatId: -100999, agentId: "general", kind: "group", label: "General Group" },
+    { chatId: -100999, agentId: "dev-topic", kind: "group", topicId: 10, label: "Dev Topic" },
+    // Binding without a label — should fall back to agentId.
+    { chatId: 222222222, agentId: "agent-b", kind: "dm" },
+  ];
+
+  it("returns binding.label for a chat-targeted call with matching binding", () => {
+    assert.strictEqual(resolveBindingLabel({ chatId: 111111111 }, bindings), "User1 DM");
+  });
+
+  it("returns 'none' sentinel when payload has no chat_id (getUpdates-style)", () => {
+    assert.strictEqual(resolveBindingLabel({}, bindings), BINDING_LABEL_NONE);
+  });
+
+  it("returns 'unbound' sentinel when chat_id has no matching binding", () => {
+    assert.strictEqual(resolveBindingLabel({ chatId: 999999 }, bindings), BINDING_LABEL_UNBOUND);
+  });
+
+  it("sentinel constants are stable wire values for dashboards", () => {
+    // Pin the literal string values once: dashboard queries depend on these.
+    assert.strictEqual(BINDING_LABEL_NONE, "none");
+    assert.strictEqual(BINDING_LABEL_UNBOUND, "unbound");
+  });
+
+  it("returns 'unbound' for non-numeric string chat_id (e.g. @channelname)", () => {
+    assert.strictEqual(resolveBindingLabel({ chatId: "@somechannel" }, bindings), "unbound");
+  });
+
+  it("resolves topic-specific binding label when message_thread_id matches a topic binding", () => {
+    assert.strictEqual(
+      resolveBindingLabel({ chatId: -100999, messageThreadId: 10 }, bindings),
+      "Dev Topic",
+    );
+  });
+
+  it("falls back to chatId-only binding label for unlisted topic", () => {
+    assert.strictEqual(
+      resolveBindingLabel({ chatId: -100999, messageThreadId: 999 }, bindings),
+      "General Group",
+    );
+  });
+
+  it("falls back to agentId when binding has no label", () => {
+    assert.strictEqual(resolveBindingLabel({ chatId: 222222222 }, bindings), "agent-b");
+  });
+
+  it("accepts numeric-string chat_id and resolves it normally", () => {
+    assert.strictEqual(resolveBindingLabel({ chatId: "111111111" }, bindings), "User1 DM");
+  });
+
+  it("topics-array override inherits parent group label (TopicOverride has no label field)", () => {
+    // `TopicOverride` carries `topicId`/`agentId`/`requireMention` but no
+    // `label` — by design, topics-array entries inherit the parent group's
+    // label. This pins that behavior so the call counter's `binding` label
+    // collapses all topics under one group to that group's label. Per-topic
+    // distinction is intentionally not part of the metric: Telegram rate
+    // limits are per-chat, and parent-label cardinality is bounded by config.
+    // Operators who want a topic-distinct series can configure a top-level
+    // `topicId` binding with its own `label` (covered above by "Dev Topic").
+    const groupWithTopics: TelegramBinding[] = [
+      {
+        chatId: -100777,
+        agentId: "hq-main",
+        kind: "group",
+        label: "HQ",
+        topics: [
+          { topicId: 10, agentId: "hq-dev" },
+          { topicId: 30, agentId: "hq-ops" },
+        ],
+      },
+    ];
+    assert.strictEqual(
+      resolveBindingLabel({ chatId: -100777, messageThreadId: 10 }, groupWithTopics),
+      "HQ",
+    );
+    assert.strictEqual(
+      resolveBindingLabel({ chatId: -100777, messageThreadId: 30 }, groupWithTopics),
+      "HQ",
+    );
+  });
+});
+
+describe("createApiErrorLoggingTransformer — call counter", () => {
+  // The transformer increments `bot_telegram_api_calls_total` once per
+  // invocation regardless of outcome, using a binding-derived label. Each test
+  // resets the registry-level metrics so call counts are isolated.
+
+  const bindings: TelegramBinding[] = [
+    { chatId: 555000111, agentId: "main", kind: "dm", label: "User1 DM" },
+    { chatId: -100999, agentId: "ops", kind: "group", label: "Ops Group" },
+  ];
+
+  function silenceWarn(): { restore: () => void } {
+    const orig = console.warn;
+    console.warn = () => {};
+    return { restore: () => { console.warn = orig; } };
+  }
+
+  function findCall(values: Array<{ labels: Record<string, string | number>; value: number }>, method: string, binding: string): number {
+    return values.find((v) => v.labels.method === method && v.labels.binding === binding)?.value ?? 0;
+  }
+
+  it("increments on successful response with binding label from chat_id", async () => {
+    client.register.resetMetrics();
+    const transformer = createApiErrorLoggingTransformer({ bindings });
+    const prev = async () => ({ ok: true, result: true } as const);
+    await transformer(prev as never, "sendMessage", { chat_id: 555000111, text: "hi" });
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(findCall(val.values, "sendMessage", "User1 DM"), 1);
+  });
+
+  it("increments on 429 response with binding label from chat_id", async () => {
+    client.register.resetMetrics();
+    const { restore } = silenceWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer({ bindings });
+      const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 3 } } as const);
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+
+      const val = await telegramApiCalls.get();
+      assert.strictEqual(findCall(val.values, "sendMessageDraft", "User1 DM"), 1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("increments on thrown HTTP error with binding label from chat_id", async () => {
+    client.register.resetMetrics();
+    const { restore } = silenceWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer({ bindings });
+      const prev = async () => { throw new Error("ECONNRESET"); };
+      await assert.rejects(
+        () => transformer(prev as never, "sendMessage", { chat_id: 555000111, text: "x" }),
+        /ECONNRESET/,
+      );
+
+      const val = await telegramApiCalls.get();
+      assert.strictEqual(findCall(val.values, "sendMessage", "User1 DM"), 1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("uses 'none' sentinel for non-chat-targeted calls (getUpdates)", async () => {
+    client.register.resetMetrics();
+    const transformer = createApiErrorLoggingTransformer({ bindings });
+    const prev = async () => ({ ok: true, result: [] } as const);
+    await transformer(prev as never, "getUpdates", { offset: 0, timeout: 30 });
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(findCall(val.values, "getUpdates", "none"), 1);
+  });
+
+  it("uses 'unbound' sentinel for chat_id that does not match any binding", async () => {
+    client.register.resetMetrics();
+    const transformer = createApiErrorLoggingTransformer({ bindings });
+    const prev = async () => ({ ok: true, result: true } as const);
+    await transformer(prev as never, "sendMessage", { chat_id: 555555, text: "x" });
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(findCall(val.values, "sendMessage", "unbound"), 1);
+  });
+
+  it("counts each retried attempt separately (matches per-attempt error counter semantics)", async () => {
+    client.register.resetMetrics();
+    const { restore } = silenceWarn();
+    try {
+      const transformer = createApiErrorLoggingTransformer({ bindings });
+      const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 1 } } as const);
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+
+      const val = await telegramApiCalls.get();
+      assert.strictEqual(findCall(val.values, "sendMessageDraft", "User1 DM"), 3);
+    } finally {
+      restore();
+    }
+  });
+
+  it("collapses unmatched chat_ids into a single 'unbound' label (cardinality guard)", async () => {
+    // Regression guard: emitting raw chat_id as a label value would blow up
+    // Prometheus cardinality. 50 distinct unmatched chat_ids must collapse to
+    // exactly one binding label value ("unbound").
+    client.register.resetMetrics();
+    const transformer = createApiErrorLoggingTransformer({ bindings });
+    const prev = async () => ({ ok: true, result: true } as const);
+    for (let i = 0; i < 50; i++) {
+      await transformer(prev as never, "sendMessage", { chat_id: 9_000_000 + i, text: "x" });
+    }
+
+    const val = await telegramApiCalls.get();
+    const labelValues = new Set(val.values.map((v) => v.labels.binding));
+    assert.deepStrictEqual([...labelValues], ["unbound"], `expected only "unbound", got: ${[...labelValues].join(",")}`);
+    assert.strictEqual(findCall(val.values, "sendMessage", "unbound"), 50);
+  });
+
+  it("uses default empty bindings when factory called without opts", async () => {
+    // Documented default: every call falls into "unbound"/"none" sentinels.
+    // Guards against a regression where the default becomes `undefined` and
+    // resolveBindingLabel throws on `bindings.find(...)`.
+    client.register.resetMetrics();
+    const transformer = createApiErrorLoggingTransformer();
+    const prev = async () => ({ ok: true, result: true } as const);
+    await transformer(prev as never, "sendMessage", { chat_id: 555000111, text: "x" });
+    await transformer(prev as never, "getUpdates", { offset: 0, timeout: 30 });
+
+    const val = await telegramApiCalls.get();
+    assert.strictEqual(findCall(val.values, "sendMessage", "unbound"), 1);
+    assert.strictEqual(findCall(val.values, "getUpdates", "none"), 1);
   });
 });

--- a/bot/src/__tests__/telegram-bot.test.ts
+++ b/bot/src/__tests__/telegram-bot.test.ts
@@ -1439,7 +1439,7 @@ describe("createApiErrorLoggingTransformer", () => {
     try {
       const transformer = createApiErrorLoggingTransformer();
       const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 3 } } as const);
-      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, message_thread_id: 7, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, message_thread_id: 7, draft_id: 1, text: "x" });
       const warn = logs.find((l) => l.tag === "telegram-api");
       assert.ok(warn, "expected a telegram-api warn log");
       // Pin full format so reorderings / extra noise / duplicates are caught.
@@ -1660,7 +1660,7 @@ describe("createApiErrorLoggingTransformer — call counter", () => {
     try {
       const transformer = createApiErrorLoggingTransformer({ bindings });
       const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 3 } } as const);
-      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, draft_id: 1, text: "x" });
 
       const val = await telegramApiCalls.get();
       assert.strictEqual(findCall(val.values, "sendMessageDraft", "User1 DM"), 1);
@@ -1713,9 +1713,9 @@ describe("createApiErrorLoggingTransformer — call counter", () => {
     try {
       const transformer = createApiErrorLoggingTransformer({ bindings });
       const prev = async () => ({ ok: false, error_code: 429, parameters: { retry_after: 1 } } as const);
-      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
-      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
-      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, draft_id: 1, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, draft_id: 2, text: "x" });
+      await transformer(prev as never, "sendMessageDraft", { chat_id: 555000111, draft_id: 3, text: "x" });
 
       const val = await telegramApiCalls.get();
       assert.strictEqual(findCall(val.values, "sendMessageDraft", "User1 DM"), 3);

--- a/bot/src/metrics.ts
+++ b/bot/src/metrics.ts
@@ -59,6 +59,14 @@ export const telegramApiErrors = new client.Counter({
   labelNames: ["method", "error_code"] as const,
 });
 
+// --- Telegram API calls (success + failure) ---
+
+export const telegramApiCalls = new client.Counter({
+  name: "bot_telegram_api_calls_total",
+  help: "Total Telegram API calls attempted by the bot (success or failure)",
+  labelNames: ["method", "binding"] as const,
+});
+
 // --- Session lifecycle ---
 
 export const sessionsActive = new client.Gauge({
@@ -125,6 +133,18 @@ export function recordResultMetrics(
  */
 export function recordTelegramApiError(method: string, errorCode: number | string): void {
   telegramApiErrors.inc({ method, error_code: String(errorCode) });
+}
+
+/**
+ * Record a Telegram API call attempt for metrics. Incremented once per
+ * transformer invocation (each autoRetry attempt is a separate call), so
+ * `errors / calls` over the same window yields an attempt-level error ratio.
+ *
+ * The `binding` label MUST come from the resolved binding (or a fixed
+ * sentinel) — never from the raw `chat_id`, since that would be unbounded.
+ */
+export function recordTelegramApiCall(method: string, binding: string): void {
+  telegramApiCalls.inc({ method, binding });
 }
 
 // --- HTTP server ---

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -1,4 +1,4 @@
-import { Bot } from "grammy";
+import { Bot, type Transformer } from "grammy";
 import { autoRetry } from "@grammyjs/auto-retry";
 import type { BotConfig, TelegramBinding } from "./types.js";
 import { outboxDir, type SessionManager } from "./session-manager.js";
@@ -105,9 +105,9 @@ export function resolveBindingLabel(
  * receives the `"unbound"` or `"none"` sentinel) so existing callers / tests
  * keep working unchanged.
  */
-export function createApiErrorLoggingTransformer(opts?: { bindings?: TelegramBinding[] }) {
+export function createApiErrorLoggingTransformer(opts?: { bindings?: TelegramBinding[] }): Transformer {
   const bindings = opts?.bindings ?? [];
-  return async (prev: (method: string, payload: unknown, signal?: AbortSignal) => Promise<{ ok: boolean; error_code?: number; parameters?: { retry_after?: number }; result?: unknown }>, method: string, payload: unknown, signal?: AbortSignal) => {
+  return async (prev, method, payload, signal) => {
     const ctx = extractChatContext(payload);
     const ctxStr = formatChatContextForLog(ctx);
     recordTelegramApiCall(String(method), resolveBindingLabel(ctx, bindings));
@@ -610,7 +610,7 @@ export function createTelegramBot(
   // Log Telegram API errors, especially 429 rate limits, and count every API
   // call attempt by binding (inner transformer — sees each individual attempt
   // before autoRetry decides whether to retry)
-  bot.api.config.use(createApiErrorLoggingTransformer({ bindings: config.bindings }) as Parameters<typeof bot.api.config.use>[0]);
+  bot.api.config.use(createApiErrorLoggingTransformer({ bindings: config.bindings }));
 
   // Auto-retry on rate limits (outermost transformer — retries after inner errors)
   bot.api.config.use(autoRetry(AUTO_RETRY_OPTIONS));

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -9,7 +9,7 @@ import { tempFilePath, downloadFile, transcribeAudio, cleanupTempFile } from "./
 import { allocateMediaPath, enforceMediaCap, releaseMediaPath, discardMediaPath } from "./media-store.js";
 import { isImageMimeType, imageExtensionForMime } from "./mime.js";
 import { log } from "./logger.js";
-import { recordTelegramApiError, messagesReceived, messagesSent } from "./metrics.js";
+import { recordTelegramApiError, recordTelegramApiCall, messagesReceived, messagesSent } from "./metrics.js";
 import { setThread, getThread } from "./message-thread-cache.js";
 import { recordMessage, lookupMessage } from "./message-content-index.js";
 import type { MessageRecord } from "./message-content-index.js";
@@ -34,6 +34,99 @@ export const BOT_COMMANDS = [
   { command: "clean", description: "Clean session (fresh start)" },
   { command: "status", description: "Show bot status" },
 ] as const;
+
+/**
+ * Extract Telegram chat-targeting fields from an API request payload for
+ * inclusion in error logs and metric context. Returns an empty object when the
+ * method does not target a chat (e.g. getUpdates, getMe).
+ */
+export function extractChatContext(payload: unknown): { chatId?: number | string; messageThreadId?: number } {
+  if (!payload || typeof payload !== "object") return {};
+  const p = payload as { chat_id?: number | string | null; message_thread_id?: number | null };
+  const out: { chatId?: number | string; messageThreadId?: number } = {};
+  if (p.chat_id !== undefined && p.chat_id !== null) out.chatId = p.chat_id;
+  if (typeof p.message_thread_id === "number") out.messageThreadId = p.message_thread_id;
+  return out;
+}
+
+/**
+ * Format chat-context fields for inclusion in a log line. Returns an empty
+ * string when no chat context is present, so methods without `chat_id` log
+ * cleanly without `chat_id=undefined`. The returned string has a leading space
+ * so it can be concatenated directly after `method=...`.
+ */
+export function formatChatContextForLog(ctx: { chatId?: number | string; messageThreadId?: number }): string {
+  const parts: string[] = [];
+  if (ctx.chatId !== undefined) parts.push(`chat_id=${ctx.chatId}`);
+  if (ctx.messageThreadId !== undefined) parts.push(`message_thread_id=${ctx.messageThreadId}`);
+  return parts.length ? ` ${parts.join(" ")}` : "";
+}
+
+/** Sentinel `binding` label for API calls with no `chat_id` in the payload (getUpdates, getMe, etc). */
+export const BINDING_LABEL_NONE = "none";
+/** Sentinel `binding` label for API calls whose `chat_id` does not resolve to any configured binding. */
+export const BINDING_LABEL_UNBOUND = "unbound";
+
+/**
+ * Map an API payload's chat context to a low-cardinality `binding` label
+ * suitable for the `bot_telegram_api_calls_total` counter. The value MUST come
+ * from the resolved binding (preferring `label`, falling back to `agentId` —
+ * both are bounded by config) or one of the two sentinels above. Returning the
+ * raw `chat_id` is forbidden: it would balloon cardinality as new chats appear.
+ */
+export function resolveBindingLabel(
+  ctx: { chatId?: number | string; messageThreadId?: number },
+  bindings: TelegramBinding[],
+): string {
+  if (ctx.chatId === undefined) return BINDING_LABEL_NONE;
+  let numericChatId: number;
+  if (typeof ctx.chatId === "number") {
+    numericChatId = ctx.chatId;
+  } else {
+    // Numeric strings (rare but valid per Bot API) — resolve normally.
+    // Channel-username strings (@-prefixed) cannot match a numeric binding.
+    const parsed = Number(ctx.chatId);
+    if (!Number.isInteger(parsed)) return BINDING_LABEL_UNBOUND;
+    numericChatId = parsed;
+  }
+  const binding = resolveBinding(numericChatId, bindings, ctx.messageThreadId);
+  if (!binding) return BINDING_LABEL_UNBOUND;
+  return binding.label ?? binding.agentId;
+}
+
+/**
+ * Build the inner Telegram API transformer that logs rate-limit and HTTP
+ * errors with chat context, records error metrics, and increments the
+ * per-binding API call counter. Extracted from the bot constructor so it can
+ * be unit-tested without spinning up a Bot instance.
+ *
+ * `bindings` is used to map outgoing `chat_id` to a bounded-cardinality label
+ * for `bot_telegram_api_calls_total`. Defaults to an empty list (every call
+ * receives the `"unbound"` or `"none"` sentinel) so existing callers / tests
+ * keep working unchanged.
+ */
+export function createApiErrorLoggingTransformer(opts?: { bindings?: TelegramBinding[] }) {
+  const bindings = opts?.bindings ?? [];
+  return async (prev: (method: string, payload: unknown, signal?: AbortSignal) => Promise<{ ok: boolean; error_code?: number; parameters?: { retry_after?: number }; result?: unknown }>, method: string, payload: unknown, signal?: AbortSignal) => {
+    const ctx = extractChatContext(payload);
+    const ctxStr = formatChatContextForLog(ctx);
+    recordTelegramApiCall(String(method), resolveBindingLabel(ctx, bindings));
+    try {
+      const res = await prev(method, payload, signal);
+      if (!res.ok && res.error_code === 429) {
+        log.warn("telegram-api", `Rate limited: method=${String(method)}${ctxStr} retry_after=${res.parameters?.retry_after ?? "unknown"}`);
+        recordTelegramApiError(String(method), 429);
+      } else if (!res.ok && res.error_code) {
+        recordTelegramApiError(String(method), res.error_code);
+      }
+      return res;
+    } catch (err) {
+      log.warn("telegram-api", `HTTP error: method=${String(method)}${ctxStr} ${err instanceof Error ? err.message : err}`);
+      recordTelegramApiError(String(method), "http_error");
+      throw err;
+    }
+  };
+}
 
 /**
  * Build a session key from chatId and optional topicId.
@@ -514,24 +607,10 @@ export function createTelegramBot(
   const token = config.telegramToken;
   const bot = new Bot(token);
 
-// Log Telegram API errors, especially 429 rate limits (inner transformer —
-  // sees each individual attempt before autoRetry decides whether to retry)
-  bot.api.config.use(async (prev, method, payload, signal) => {
-    try {
-      const res = await prev(method, payload, signal);
-      if (!res.ok && res.error_code === 429) {
-        log.warn("telegram-api", `Rate limited: method=${String(method)} retry_after=${res.parameters?.retry_after ?? "unknown"}`);
-        recordTelegramApiError(String(method), 429);
-      } else if (!res.ok && res.error_code) {
-        recordTelegramApiError(String(method), res.error_code);
-      }
-      return res;
-    } catch (err) {
-      log.warn("telegram-api", `HTTP error: method=${String(method)} ${err instanceof Error ? err.message : err}`);
-      recordTelegramApiError(String(method), "http_error");
-      throw err;
-    }
-  });
+  // Log Telegram API errors, especially 429 rate limits, and count every API
+  // call attempt by binding (inner transformer — sees each individual attempt
+  // before autoRetry decides whether to retry)
+  bot.api.config.use(createApiErrorLoggingTransformer({ bindings: config.bindings }) as Parameters<typeof bot.api.config.use>[0]);
 
   // Auto-retry on rate limits (outermost transformer — retries after inner errors)
   bot.api.config.use(autoRetry(AUTO_RETRY_OPTIONS));

--- a/docs/plans/completed/2026-05-15-telegram-api-call-observability.md
+++ b/docs/plans/completed/2026-05-15-telegram-api-call-observability.md
@@ -1,5 +1,7 @@
 # Telegram API call observability — chat_id in logs, binding-labelled metric — Round 1
 
+> **Note (completed):** Reference sections below describe the pre-PR codebase state at the time the plan was written. File:line citations point at the legacy inline transformer; the merged implementation refactored it into the `createApiErrorLoggingTransformer` factory. See the merge commit on this branch for the post-implementation code.
+
 ## Goal
 
 Add diagnostic data to Telegram API error logging and introduce a baseline call counter so future 429 bursts can be traced to a specific binding without having to cross-reference session JSONL timestamps. Observability-only change — no retry/throttle behavior is modified.

--- a/docs/plans/completed/2026-05-15-telegram-api-call-observability.md
+++ b/docs/plans/completed/2026-05-15-telegram-api-call-observability.md
@@ -1,0 +1,138 @@
+# Telegram API call observability — chat_id in logs, binding-labelled metric — Round 1
+
+## Goal
+
+Add diagnostic data to Telegram API error logging and introduce a baseline call counter so future 429 bursts can be traced to a specific binding without having to cross-reference session JSONL timestamps. Observability-only change — no retry/throttle behavior is modified.
+
+## Validation Commands
+
+```bash
+cd bot && npx tsc --noEmit && npm test
+```
+
+## Reference: Current rate-limit logging
+
+`bot/src/telegram-bot.ts:519-534` — inner transformer that logs 429s and records `bot_telegram_api_errors_total`:
+
+```ts
+bot.api.config.use(async (prev, method, payload, signal) => {
+  try {
+    const res = await prev(method, payload, signal);
+    if (!res.ok && res.error_code === 429) {
+      log.warn("telegram-api", `Rate limited: method=${String(method)} retry_after=${res.parameters?.retry_after ?? "unknown"}`);
+      recordTelegramApiError(String(method), 429);
+    } else if (!res.ok && res.error_code) {
+      recordTelegramApiError(String(method), res.error_code);
+    }
+    return res;
+  } catch (err) {
+    log.warn("telegram-api", `HTTP error: method=${String(method)} ${err instanceof Error ? err.message : err}`);
+    recordTelegramApiError(String(method), "http_error");
+    throw err;
+  }
+});
+```
+
+The `payload` argument carries `chat_id` and `message_thread_id` for chat-targeting methods (sendMessage, sendMessageDraft, sendChatAction, editMessageText, deleteMessage, etc.) but neither value is included in the log line or the error metric.
+
+## Reference: Current metric
+
+`bot/src/metrics.ts:54-60`:
+
+```ts
+export const telegramApiErrors = new client.Counter({
+  name: "bot_telegram_api_errors_total",
+  help: "Total Telegram API errors",
+  labelNames: ["method", "error_code"] as const,
+});
+```
+
+`bot/src/metrics.ts:123-128` — sole recorder, called from the transformer above:
+
+```ts
+export function recordTelegramApiError(method: string, errorCode: number | string): void {
+  telegramApiErrors.inc({ method, error_code: String(errorCode) });
+}
+```
+
+No counter exists for successful (non-error) API calls. Error rate cannot be expressed as a ratio (`errors / total_calls`) — only as an absolute rate.
+
+## Reference: Live error counter snapshot (2026-05-15)
+
+`curl -s http://127.0.0.1:9091/metrics | grep bot_telegram_api_errors_total`:
+
+```
+bot_telegram_api_errors_total{method="sendMessageDraft",error_code="429"} 78
+bot_telegram_api_errors_total{method="sendChatAction",error_code="429"} 12
+bot_telegram_api_errors_total{method="getUpdates",error_code="http_error"} 6
+```
+
+Sample log lines from the 19:15 MSK burst (bot stderr log):
+
+```
+2026-05-15T16:15:17.160Z WARN [telegram-api] Rate limited: method=sendMessageDraft retry_after=3
+2026-05-15T16:15:17.199Z WARN [telegram-api] Rate limited: method=sendMessageDraft retry_after=3
+2026-05-15T16:15:17.622Z WARN [telegram-api] Rate limited: method=sendMessageDraft retry_after=3
+```
+
+Determining which binding produced these required cross-referencing Claude session JSONL modification times — log alone had no chat context.
+
+## Reference: Binding labels are bounded
+
+`bot/src/types.ts:22-32`:
+
+```ts
+export interface TelegramBinding {
+  chatId: number;
+  agentId: string;
+  kind: "dm" | "group";
+  topicId?: number;
+  label?: string;
+  requireMention?: boolean;
+  topics?: TopicOverride[];
+  voiceTranscriptEcho?: boolean;
+  typingIndicator?: boolean;
+}
+```
+
+`label` is a human-readable string assigned in config (e.g. `"User1 DM"`, `"MyGroup"`). The runtime binding set is bounded (typical production deployments have on the order of 5-15 entries plus per-topic overrides), making `label` a safe Prometheus label dimension. Raw `chat_id` is not — it would balloon cardinality as new chats are added.
+
+`bot/src/telegram-bot.ts:52-87` — `resolveBinding(chatId, bindings, topicId?)` already returns the resolved binding (including topic overrides) for a given chat/topic pair.
+
+## Reference: Existing test coverage
+
+`bot/src/__tests__/telegram-bot.test.ts` — `resolveBinding` has ~10 describe blocks covering chatId-only, topicId match, topics-array overrides, unlisted topics, and DM bindings.
+
+`bot/src/__tests__/metrics.test.ts` exists and tests recorder functions.
+
+Both test files are the conventional location for the work in this plan.
+
+## Tasks
+
+### Task 1: Add chat context to Telegram API rate-limit and HTTP-error logs (telegram-api-chat-id-log, P1)
+
+**Problem:** A recent `TelegramAPIErrors` alert (78 × `sendMessageDraft` 429 + 12 × `sendChatAction` 429 + 6 × `getUpdates` http_error within a few minutes) could not be attributed to a binding from the log lines alone. The diagnosis required correlating burst timestamps against modification times of Claude session JSONL files under `~/.claude/projects/` to identify which DM binding was the source. This correlation is fragile, manual, and fails if multiple DMs stream concurrently.
+
+**What we want:** Every `Rate limited` and `HTTP error` warning produced by the inner Telegram API transformer (`bot/src/telegram-bot.ts:519-534`) carries the originating `chat_id` and (when present) `message_thread_id`, so a single `grep` over `telegram-bot.stderr.log` answers "which chat triggered this burst" without external correlation.
+
+- [x] `Rate limited` log line includes `chat_id` when the API payload contains one
+- [x] `Rate limited` log line includes `message_thread_id` when present in the payload
+- [x] `HTTP error` log line includes the same `chat_id` / `message_thread_id` context
+- [x] Methods without a `chat_id` payload (`getUpdates`, `getMe`, `setWebhook`, etc.) continue to log cleanly without the chat fields, not with `chat_id=undefined`
+- [x] Add tests covering: rate-limit with chat-targeted payload, rate-limit with non-chat payload, http_error with chat-targeted payload
+- [x] Verify existing tests pass
+
+### Task 2: Introduce binding-labelled call counter `bot_telegram_api_calls_total` (telegram-api-calls-metric, P1)
+
+**Problem:** `bot_telegram_api_errors_total` reports absolute error rate but no denominator. `rate(bot_telegram_api_errors_total[5m]) > 0.1` (the current alert at `monitoring/prometheus/rules.yml:22-23`) fires identically whether the bot made 1 API call (100% error) or 10,000 calls (≪1% error). Without a baseline counter, we cannot decide whether the 429s on `sendMessageDraft` represent a meaningful fraction of draft traffic or are noise relative to a high-volume baseline — and therefore cannot judge whether `DRAFT_DEBOUNCE_MS` (`bot/src/stream-relay.ts:124`) or `AUTO_RETRY_OPTIONS` (`bot/src/telegram-bot.ts:497-501`) needs adjustment.
+
+**What we want:** Every Telegram API call (success or failure) is counted in a new Prometheus counter, labelled by `method` and by a low-cardinality identifier of the originating binding. The error counter remains as-is — they are complementary, not a replacement.
+
+- [x] A new counter `bot_telegram_api_calls_total` is exposed at `/metrics`
+- [x] Counter is labelled with `method` and one bounded-cardinality binding identifier — pick what fits the existing binding model (e.g. `binding.label`, falling back to a fixed sentinel when no binding applies); the value MUST come from the resolved binding, never the raw `chat_id`
+- [x] Counter increments exactly once per call, regardless of outcome
+- [x] Calls without an originating binding (poll loop like `getUpdates`, system methods like `getMe`) increment with a stable sentinel label (e.g. `"none"`) — they do not silently drop
+- [x] Methods that target a chat but whose `chat_id` does not resolve to any configured binding (incoming message from an unbound chat, cron sending to an unknown chat) use a distinct sentinel (e.g. `"unbound"`) so they are visible in metrics but separable from `"none"`
+- [x] Documentation in `README.md` metrics section lists the new counter alongside the existing error counter
+- [x] Add tests covering: counter increments on success, counter increments on 429, counter uses correct binding label for a chat-targeted call, counter uses sentinel for non-chat-targeted call, counter uses unbound sentinel for chat_id with no matching binding
+- [x] Verify existing tests pass


### PR DESCRIPTION
## Summary

Observability-only changes for diagnosing Telegram API 429 cascades (issue #117):

- `Rate limited` and `HTTP error` warn logs now carry `chat_id` and `message_thread_id` (when the payload has them), so a single `grep` over `telegram-bot.stderr.log` identifies the originating binding without external correlation.
- New Prometheus counter `bot_telegram_api_calls_total{method, binding}` exposes the denominator for error-rate ratios. The `binding` label uses the resolved binding's `label` for chat-targeted methods, `"none"` for chatless methods (`getUpdates`, `getMe`), and `"unbound"` for chat-targeted calls whose chat_id has no configured binding.

No retry/throttle behavior changed. The autoRetry skip for `sendMessageDraft` (the actual fix for the 429 cascade) is a separate follow-up — this PR is the data plane that lets us measure the effect.

## Plan and review

- Plan: `docs/plans/completed/2026-05-15-telegram-api-call-observability.md` (moved to `completed/` by ralphex after pipeline)
- Ralphex multi-agent pipeline: 4 review rounds (Claude quality+implementation × 2, codex × 1, final pass), all clean — no critical/major issues found.

## Test plan

- [x] `cd bot && npx tsc --noEmit` — passes
- [x] `cd bot && npm test` — 1055/1056 tests pass; one unrelated pre-existing failure in whisper-model path test
- [ ] After merge: restart bot, send a message in any DM, trigger a streaming reply, then `grep "Rate limited" telegram-bot.stderr.log` should show `chat_id=<id>` on rate-limit lines (if any fire)
- [ ] After merge: `curl -s http://127.0.0.1:9091/metrics | grep bot_telegram_api_calls_total` should expose the new counter with per-binding labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)