### PR TITLE
test(voice): respect WHISPER_MODEL env override in path assertion

### DIFF
--- a/bot/src/__tests__/voice.test.ts
+++ b/bot/src/__tests__/voice.test.ts
@@ -142,7 +142,8 @@ describe("convertToWav", () => {
 describe("transcribeAudio", () => {
   it("exports correct whisper-cli paths", () => {
     assert.strictEqual(WHISPER_BIN, "/opt/homebrew/bin/whisper-cli");
-    assert.strictEqual(WHISPER_MODEL, join(homedir(), ".minime/models/ggml-medium.bin"));
+    const expectedModel = process.env.WHISPER_MODEL ?? join(homedir(), ".minime/models/ggml-medium.bin");
+    assert.strictEqual(WHISPER_MODEL, expectedModel);
   });
 
   it("rejects when given a nonexistent audio file", async () => {


### PR DESCRIPTION
## Summary

The `exports correct whisper-cli paths` test in `bot/src/__tests__/voice.test.ts` asserted a hardcoded default model path, ignoring that `WHISPER_MODEL` in `bot/src/voice.ts:12` resolves from `process.env.WHISPER_MODEL ?? <default>`. Anyone running the suite locally with a custom `WHISPER_MODEL` env var hit a spurious failure on every run.

Mirror the module's resolution rule in the assertion. Test now passes for any valid env state and still validates the default path when env is unset.

## Test plan

- [x] `npm test` with `WHISPER_MODEL=/path/to/ggml-large-v3-turbo.bin` → passes
- [x] `npm test` with `WHISPER_MODEL` unset → passes (default path branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)