### PR TITLE
feat: configurable metricsHost (default 127.0.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ All log output uses structured format: `TIMESTAMP LEVEL [tag] message`.
 
 ### Monitoring
 
-When `metricsPort` is set in `config.yaml`, the bot exposes a Prometheus-compatible `/metrics` endpoint on `127.0.0.1` at that port.
+When `metricsPort` is set in `config.yaml`, the bot exposes a Prometheus-compatible `/metrics` endpoint at that port. By default it binds to `127.0.0.1`. Set `metricsHost: "0.0.0.0"` when the scrape source is reachable only via a non-loopback interface (e.g. Linux when a Prometheus container scrapes via `host.docker.internal` — that resolves to the docker bridge gateway, not loopback like on macOS Docker Desktop). When exposing on `0.0.0.0`, the host firewall must restrict external access.
 
 ```yaml
 metricsPort: 9090

--- a/bot/src/__tests__/metrics.test.ts
+++ b/bot/src/__tests__/metrics.test.ts
@@ -248,4 +248,22 @@ describe("metrics HTTP server", () => {
     const res = await fetch(`http://localhost:${addr.port}/other`);
     assert.strictEqual(res.status, 404);
   });
+
+  it("defaults host to 127.0.0.1 when not specified", async () => {
+    const server = startMetricsServer(0);
+    await new Promise((r) => setTimeout(r, 100));
+    const addr = server.address() as { address: string; port: number };
+    assert.strictEqual(addr.address, "127.0.0.1");
+  });
+
+  it("binds to provided host (0.0.0.0 for Linux Docker scrape)", async () => {
+    const server = startMetricsServer(0, "0.0.0.0");
+    await new Promise((r) => setTimeout(r, 100));
+    const addr = server.address() as { address: string; port: number };
+    assert.strictEqual(addr.address, "0.0.0.0");
+
+    // Verify still reachable on loopback even when bound to 0.0.0.0
+    const res = await fetch(`http://127.0.0.1:${addr.port}/metrics`);
+    assert.strictEqual(res.status, 200);
+  });
 });

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -67,6 +67,7 @@ interface RawConfig {
   sessionDefaults?: unknown;
   logLevel?: string;
   metricsPort?: number;
+  metricsHost?: string;
   discord?: {
     tokenService?: string;
     bindings?: unknown[];
@@ -393,6 +394,19 @@ export function loadConfig(configPath?: string): BotConfig {
     metricsPort = raw.metricsPort;
   }
 
+  // Metrics listen host (optional — defaults to "127.0.0.1" in startMetricsServer).
+  // Set to "0.0.0.0" when scrape source is reachable only via a non-loopback
+  // interface (e.g. on Linux when Prometheus container scrapes via
+  // host.docker.internal — that resolves to docker bridge gateway, not loopback).
+  // Firewall must restrict external access separately.
+  let metricsHost: string | undefined;
+  if (raw.metricsHost !== undefined) {
+    if (typeof raw.metricsHost !== "string" || raw.metricsHost.trim() === "") {
+      throw new Error(`Invalid metricsHost: must be a non-empty string`);
+    }
+    metricsHost = raw.metricsHost.trim();
+  }
+
   // adminChatId (optional — used by cron-runner for delivery failure notifications)
   let adminChatId: number | undefined;
   if (raw.adminChatId !== undefined) {
@@ -420,7 +434,7 @@ export function loadConfig(configPath?: string): BotConfig {
     defaultDeliveryThreadId = raw.defaultDeliveryThreadId;
   }
 
-  return { telegramToken, agents, bindings, sessionDefaults, logLevel, metricsPort, discord, adminChatId, defaultDeliveryChatId, defaultDeliveryThreadId };
+  return { telegramToken, agents, bindings, sessionDefaults, logLevel, metricsPort, metricsHost, discord, adminChatId, defaultDeliveryChatId, defaultDeliveryThreadId };
 }
 
 // CLI: validate config

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
 
   // Start Prometheus metrics server if configured
   if (config.metricsPort !== undefined) {
-    startMetricsServer(config.metricsPort);
+    startMetricsServer(config.metricsPort, config.metricsHost);
   }
 
   // Restore caches from disk (survives restarts)

--- a/bot/src/metrics.ts
+++ b/bot/src/metrics.ts
@@ -156,7 +156,7 @@ let metricsServer: Server | null = null;
  * Serves /metrics in standard Prometheus text format.
  * Returns the server instance.
  */
-export function startMetricsServer(port: number): Server {
+export function startMetricsServer(port: number, host: string = "127.0.0.1"): Server {
   const server = createServer(async (req, res) => {
     if (req.url === "/metrics" && req.method === "GET") {
       try {
@@ -178,8 +178,8 @@ export function startMetricsServer(port: number): Server {
     log.error("metrics", `Metrics server error: ${err.message}`);
   });
 
-  server.listen(port, "127.0.0.1", () => {
-    log.info("metrics", `Prometheus metrics server listening on 127.0.0.1:${port}`);
+  server.listen(port, host, () => {
+    log.info("metrics", `Prometheus metrics server listening on ${host}:${port}`);
   });
 
   metricsServer = server;

--- a/bot/src/metrics.ts
+++ b/bot/src/metrics.ts
@@ -156,7 +156,8 @@ let metricsServer: Server | null = null;
  * Serves /metrics in standard Prometheus text format.
  * Returns the server instance.
  */
-export function startMetricsServer(port: number, host: string = "127.0.0.1"): Server {
+export function startMetricsServer(port: number, host?: string): Server {
+  const listenHost = host ?? "127.0.0.1";
   const server = createServer(async (req, res) => {
     if (req.url === "/metrics" && req.method === "GET") {
       try {
@@ -178,8 +179,8 @@ export function startMetricsServer(port: number, host: string = "127.0.0.1"): Se
     log.error("metrics", `Metrics server error: ${err.message}`);
   });
 
-  server.listen(port, host, () => {
-    log.info("metrics", `Prometheus metrics server listening on ${host}:${port}`);
+  server.listen(port, listenHost, () => {
+    log.info("metrics", `Prometheus metrics server listening on ${listenHost}:${port}`);
   });
 
   metricsServer = server;

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -90,6 +90,7 @@ export interface BotConfig {
   sessionDefaults: SessionDefaults;
   logLevel?: LogLevel;
   metricsPort?: number;
+  metricsHost?: string;
   discord?: DiscordConfig;
   adminChatId?: number;
   defaultDeliveryChatId?: number;


### PR DESCRIPTION
## Summary

Adds optional `metricsHost` field to `BotConfig` schema. Defaults to `127.0.0.1` (preserves macOS Docker Desktop behavior). Set to `0.0.0.0` when scrape source is reachable only via non-loopback interface (e.g. Linux Prometheus container scraping via `host.docker.internal` which resolves to docker bridge gateway, not loopback).

## Why

On macOS Docker Desktop, `host.docker.internal` magically tunnels to loopback, so the bot binding 127.0.0.1 is scrapeable. On Linux, `host.docker.internal` resolves to the docker bridge gateway IP — bot bound to 127.0.0.1 refuses that connection. Scrape silently fails. This was discovered during NixOS VPS migration prep.

## Changes

- `bot/src/types.ts`: `BotConfig.metricsHost?: string`
- `bot/src/config.ts`: `RawConfig.metricsHost` validation (non-empty string)
- `bot/src/metrics.ts`: `startMetricsServer(port, host = '127.0.0.1')`
- `bot/src/main.ts`: passes `config.metricsHost` through
- `bot/src/__tests__/metrics.test.ts`: 2 new tests (default 127.0.0.1 + 0.0.0.0 override + reachability)

## Backward compatibility

Existing configs without `metricsHost` continue to bind to 127.0.0.1 — no behavior change for current macOS users.

## Test plan

- [x] Existing 17 tests still pass
- [x] New test: default binds to 127.0.0.1
- [x] New test: explicit '0.0.0.0' binds AND is reachable via 127.0.0.1 (verifies dual-stack)
- [ ] On Linux VPS: Prometheus container scrapes `host.docker.internal:9091` succeeds with `metricsHost: 0.0.0.0`