### PR TITLE
feat: env-var secret reading with macOS Keychain fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,10 @@ Token resolution accepts either form (env var wins when both are set):
 
 Example (NixOS deploy):
 ```yaml
-telegramTokenService: telegram-bot-token   # Mac fallback (no-op on Linux)
+telegramTokenService: telegram-bot-token   # macOS fallback (ignored when tokenEnv resolves on Linux)
 telegramTokenEnv: TELEGRAM_BOT_TOKEN       # Linux uses this from sops-decrypted env file
 discord:
-  tokenService: discord-bot-token
+  tokenService: discord-bot-token          # macOS fallback (same pattern)
   tokenEnv: DISCORD_BOT_TOKEN
 ```
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,26 @@ To remove: `launchctl bootout gui/$(id -u)/ai.minime.cron.<name>`, delete from `
 
 `telegramTokenService` is optional — the bot can run Discord-only.
 
+### Secrets: macOS Keychain vs env vars
+
+Token resolution accepts either form (env var wins when both are set):
+
+| Field | Source | When to use |
+|---|---|---|
+| `telegramTokenService` / `discord.tokenService` | macOS Keychain via `security find-generic-password` | macOS dev workflow (existing) |
+| `telegramTokenEnv` / `discord.tokenEnv` | Environment variable name (read via `process.env`) | Linux / containers / systemd `EnvironmentFile` (preferred for production) |
+
+Example (NixOS deploy):
+```yaml
+telegramTokenService: telegram-bot-token   # Mac fallback (no-op on Linux)
+telegramTokenEnv: TELEGRAM_BOT_TOKEN       # Linux uses this from sops-decrypted env file
+discord:
+  tokenService: discord-bot-token
+  tokenEnv: DISCORD_BOT_TOKEN
+```
+
+If neither is set when Telegram bindings are present (or for Discord config), the bot throws a clear error at startup.
+
 ## Memory architecture
 
 The bot maintains persistent context across sessions through a memory system rooted at the workspace.

--- a/bot/src/__tests__/config-secrets.test.ts
+++ b/bot/src/__tests__/config-secrets.test.ts
@@ -1,0 +1,163 @@
+import { test, describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig } from "../config.js";
+
+/**
+ * Tests for the env-var / Keychain secret resolver (resolveSecret) introduced
+ * in PR feat/env-var-secrets. Covers the env path exclusively — Keychain path
+ * is unchanged behavior and not testable here without a real macOS Keychain
+ * entry (which would couple tests to host state).
+ */
+
+describe("config secret resolution: env var + Keychain priority", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "config-secrets-test-"));
+    configPath = join(tmpDir, "config.yaml");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.TEST_TELEGRAM_TOKEN_ENV;
+    delete process.env.TEST_DISCORD_TOKEN_ENV;
+  });
+
+  const minimalAgentsYaml = `
+defaultModel: opus
+agents:
+  main:
+    workspaceCwd: /tmp/foo
+    maxTurns: 10
+`;
+
+  it("reads telegramToken from env var when telegramTokenEnv set", () => {
+    process.env.TEST_TELEGRAM_TOKEN_ENV = "tg-token-from-env";
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+telegramTokenEnv: TEST_TELEGRAM_TOKEN_ENV
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`
+    );
+    const config = loadConfig(configPath);
+    assert.strictEqual(config.telegramToken, "tg-token-from-env");
+  });
+
+  it("env wins over Keychain when both telegramTokenService and telegramTokenEnv set", () => {
+    process.env.TEST_TELEGRAM_TOKEN_ENV = "env-wins";
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+telegramTokenService: this-keychain-service-would-fail-if-read
+telegramTokenEnv: TEST_TELEGRAM_TOKEN_ENV
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`
+    );
+    // If env did not win, Keychain lookup of nonexistent service would throw.
+    const config = loadConfig(configPath);
+    assert.strictEqual(config.telegramToken, "env-wins");
+  });
+
+  it("throws when telegramTokenEnv set but env var is empty string", () => {
+    process.env.TEST_TELEGRAM_TOKEN_ENV = "";
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+telegramTokenEnv: TEST_TELEGRAM_TOKEN_ENV
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`
+    );
+    // Empty env => skip env, no service => throws with helpful message
+    assert.throws(
+      () => loadConfig(configPath),
+      /telegramToken requires either a Keychain service name or an env var name/
+    );
+  });
+
+  it("throws when bindings present but neither telegramTokenService nor telegramTokenEnv set", () => {
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`
+    );
+    assert.throws(
+      () => loadConfig(configPath),
+      /Telegram bindings require telegramTokenService/
+    );
+  });
+
+  it("reads discord.token from env var when tokenEnv set", () => {
+    process.env.TEST_DISCORD_TOKEN_ENV = "dc-token-from-env";
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+discord:
+  tokenEnv: TEST_DISCORD_TOKEN_ENV
+  bindings:
+    - guildId: "999"
+      agentId: main
+      kind: channel
+`
+    );
+    const config = loadConfig(configPath);
+    assert.ok(config.discord, "discord config should exist");
+    assert.strictEqual(config.discord!.token, "dc-token-from-env");
+  });
+
+  it("throws when discord.tokenService AND tokenEnv both missing", () => {
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+discord:
+  bindings:
+    - guildId: "999"
+      agentId: main
+      kind: channel
+`
+    );
+    assert.throws(
+      () => loadConfig(configPath),
+      /discord requires either tokenService.*or tokenEnv/
+    );
+  });
+
+  it("validates discord.tokenEnv type (must be string)", () => {
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+discord:
+  tokenEnv: 123
+  bindings:
+    - guildId: "999"
+      agentId: main
+      kind: channel
+`
+    );
+    assert.throws(() => loadConfig(configPath), /discord.tokenEnv must be a string/);
+  });
+});

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -100,11 +100,14 @@ function resolveSecret(opts: {
   envVar?: string;
   fieldName: string;
 }): string {
-  // 1. Env var wins if set (Linux/NixOS path — preferred for production deploy)
+  // 1. Env var wins if set (Linux/NixOS path — preferred for production deploy).
+  // Trim whitespace and treat blank as unset — sops-nix EnvironmentFile and
+  // systemd often leave trailing newlines or accidental quoting that would
+  // otherwise produce a "valid-but-garbage" token that fails much later.
   if (opts.envVar) {
     const val = process.env[opts.envVar];
-    if (val !== undefined && val !== "") {
-      return val;
+    if (val !== undefined && val.trim() !== "") {
+      return val.trim();
     }
   }
   // 2. Fall back to Keychain (macOS dev workflow — preserves existing behavior)
@@ -391,11 +394,19 @@ export function loadConfig(configPath?: string): BotConfig {
 
   // Resolve Telegram token from env var (Linux/NixOS) or Keychain (macOS).
   // Optional — not needed for Discord-only setups.
+  // Explicit type validation (mirrors discord.tokenService/tokenEnv checks):
+  // catches `telegramTokenEnv: 123` early instead of silently falling through.
+  if (raw.telegramTokenService !== undefined && typeof raw.telegramTokenService !== "string") {
+    throw new Error("telegramTokenService must be a string");
+  }
+  if (raw.telegramTokenEnv !== undefined && typeof raw.telegramTokenEnv !== "string") {
+    throw new Error("telegramTokenEnv must be a string");
+  }
   let telegramToken: string | undefined;
-  if (typeof raw.telegramTokenService === "string" || typeof raw.telegramTokenEnv === "string") {
+  if (raw.telegramTokenService || raw.telegramTokenEnv) {
     telegramToken = resolveSecret({
-      service: typeof raw.telegramTokenService === "string" ? raw.telegramTokenService : undefined,
-      envVar: typeof raw.telegramTokenEnv === "string" ? raw.telegramTokenEnv : undefined,
+      service: raw.telegramTokenService,
+      envVar: raw.telegramTokenEnv,
       fieldName: "telegramToken",
     });
   }
@@ -404,7 +415,7 @@ export function loadConfig(configPath?: string): BotConfig {
   let bindings: TelegramBinding[] = [];
   if (Array.isArray(raw.bindings) && raw.bindings.length > 0) {
     if (!telegramToken) {
-      throw new Error("Telegram bindings require telegramTokenService");
+      throw new Error("Telegram bindings require telegramTokenService (macOS Keychain) or telegramTokenEnv (env var)");
     }
     bindings = raw.bindings.map((b, i) => {
       const binding = validateBinding(b, i);

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -62,6 +62,7 @@ export function loadRawMergedConfig(configPath?: string): Record<string, unknown
 
 interface RawConfig {
   telegramTokenService?: string;
+  telegramTokenEnv?: string;
   agents?: Record<string, unknown>;
   bindings?: unknown[];
   sessionDefaults?: unknown;
@@ -70,6 +71,7 @@ interface RawConfig {
   metricsHost?: string;
   discord?: {
     tokenService?: string;
+    tokenEnv?: string;
     bindings?: unknown[];
   };
   adminChatId?: number;
@@ -79,16 +81,47 @@ interface RawConfig {
   defaultFallbackModel?: unknown;
 }
 
-function resolveKeychainSecret(service: string): string {
-  try {
-    return execFileSync(
-      "security",
-      ["find-generic-password", "-s", service, "-w"],
-      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
-    ).trim();
-  } catch {
-    throw new Error(`Failed to read Keychain service: ${service}`);
+/**
+ * Resolve a secret from either an environment variable (Linux/NixOS) or
+ * the macOS Keychain (legacy Mac workflow). Env var wins if set.
+ *
+ * Designed for cross-platform bot deployment:
+ *   - macOS: `tokenService:` (existing) → security find-generic-password
+ *   - Linux/NixOS: `tokenEnv:` → process.env[envVar] (e.g. sops-nix injected)
+ *   - Both set: env wins (lets NixOS override Keychain for testing)
+ *   - Neither set: throw
+ *
+ * @param opts.service   Keychain service name (macOS fallback)
+ * @param opts.envVar    Env var name (preferred when set)
+ * @param opts.fieldName Human-readable config field name (for error messages)
+ */
+function resolveSecret(opts: {
+  service?: string;
+  envVar?: string;
+  fieldName: string;
+}): string {
+  // 1. Env var wins if set (Linux/NixOS path — preferred for production deploy)
+  if (opts.envVar) {
+    const val = process.env[opts.envVar];
+    if (val !== undefined && val !== "") {
+      return val;
+    }
   }
+  // 2. Fall back to Keychain (macOS dev workflow — preserves existing behavior)
+  if (opts.service) {
+    try {
+      return execFileSync(
+        "security",
+        ["find-generic-password", "-s", opts.service, "-w"],
+        { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
+      ).trim();
+    } catch {
+      const envHint = opts.envVar ? ` (env var '${opts.envVar}' also unset)` : "";
+      throw new Error(`Failed to read Keychain service '${opts.service}' for ${opts.fieldName}${envHint}`);
+    }
+  }
+  // 3. Neither configured — config error
+  throw new Error(`${opts.fieldName} requires either a Keychain service name or an env var name`);
 }
 
 export function validateAgent(
@@ -244,10 +277,22 @@ export function validateDiscordBinding(raw: unknown, index: number): DiscordBind
 
 function validateDiscordConfig(raw: RawConfig["discord"], agents: Record<string, AgentConfig>): DiscordConfig | undefined {
   if (!raw) return undefined;
-  if (typeof raw.tokenService !== "string") {
+  // Accept either tokenService (Keychain — macOS) or tokenEnv (env var — Linux/NixOS).
+  // At least one must be set.
+  if (raw.tokenService !== undefined && typeof raw.tokenService !== "string") {
     throw new Error("discord.tokenService must be a string");
   }
-  const token = resolveKeychainSecret(raw.tokenService);
+  if (raw.tokenEnv !== undefined && typeof raw.tokenEnv !== "string") {
+    throw new Error("discord.tokenEnv must be a string");
+  }
+  if (!raw.tokenService && !raw.tokenEnv) {
+    throw new Error("discord requires either tokenService (macOS Keychain) or tokenEnv (env var)");
+  }
+  const token = resolveSecret({
+    service: raw.tokenService,
+    envVar: raw.tokenEnv,
+    fieldName: "discord.token",
+  });
   if (!Array.isArray(raw.bindings) || raw.bindings.length === 0) {
     throw new Error("discord.bindings must be a non-empty array");
   }
@@ -344,10 +389,15 @@ export function loadConfig(configPath?: string): BotConfig {
     agents[id] = validateAgent(agentRaw, id, defaultModel, defaultFallbackModel);
   }
 
-  // Resolve Telegram token from Keychain (optional — not needed for Discord-only setups)
+  // Resolve Telegram token from env var (Linux/NixOS) or Keychain (macOS).
+  // Optional — not needed for Discord-only setups.
   let telegramToken: string | undefined;
-  if (typeof raw.telegramTokenService === "string") {
-    telegramToken = resolveKeychainSecret(raw.telegramTokenService);
+  if (typeof raw.telegramTokenService === "string" || typeof raw.telegramTokenEnv === "string") {
+    telegramToken = resolveSecret({
+      service: typeof raw.telegramTokenService === "string" ? raw.telegramTokenService : undefined,
+      envVar: typeof raw.telegramTokenEnv === "string" ? raw.telegramTokenEnv : undefined,
+      fieldName: "telegramToken",
+    });
   }
 
   // Validate Telegram bindings (optional if Discord is configured)


### PR DESCRIPTION
## Summary

Adds optional `tokenEnv:` fields (`telegramTokenEnv`, `discord.tokenEnv`) next to existing `tokenService:` Keychain fields. Resolution priority: **env var > Keychain**. Backward compatible.

## Why

Linux/NixOS deployment via sops-nix injects secrets as systemd `EnvironmentFile` env vars. The bot previously could only read from macOS Keychain (`security find-generic-password`), blocking Linux deployment.

This PR adds env-var alternative so the same bot code works on both:
- **macOS dev:** `tokenService: telegram-bot-token` → Keychain (existing)
- **Linux/NixOS:** `tokenEnv: TELEGRAM_BOT_TOKEN` → env var (new)
- **Both set:** env wins (lets NixOS override Keychain when testing on Mac)
- **Neither set:** clear startup error

## Changes

- `bot/src/config.ts`:
  - `RawConfig` adds `telegramTokenEnv?: string` and `discord.tokenEnv?: string`
  - `resolveKeychainSecret` renamed to `resolveSecret({service?, envVar?, fieldName})` with env-priority resolution
  - Both call sites (`telegramToken`, `validateDiscordConfig`) updated
  - Schema validation: at least one of service/env required when bindings/discord present
- `bot/src/__tests__/config-secrets.test.ts`: NEW — 7 tests (env path, env-wins, empty env fallback, missing both, discord variants, type validation)
- `README.md`: new "Secrets: macOS Keychain vs env vars" section with comparison table + NixOS example

## Backward compatibility

Existing Mac configs (`tokenService` only, no `tokenEnv`) work unchanged. Keychain path code unchanged (renamed only). No env var lookup occurs unless `tokenEnv` field explicitly set.

## Test plan

- [x] 7 new tests pass (env wins, fallback, error messages, discord variant)
- [x] Existing test suite passes (no regression; pre-existing hot-reload.test.ts `mock.module` flake is unrelated to this PR)
- [ ] Manual Mac verification: existing Keychain config still works
- [ ] On Linux VPS (Stage E): systemd EnvironmentFile from sops-decrypted env file injects tokens, bot starts cleanly