### PR TITLE
ci: pii-scan needs explicit pull-requests:read for private consumers

### DIFF
--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -6,6 +6,15 @@ on:
   push:
     branches: [main]
 
+# gitleaks-action@v2 lists PR commits to determine scan scope. In private
+# repos, the default GITHUB_TOKEN does not grant pull-requests:read, so the
+# action returns 403 "Resource not accessible by integration" and fails
+# before scanning. Public repos worked under the more permissive default —
+# private consumers of this reusable workflow need the explicit grant.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   gitleaks:
     uses: ./.github/workflows/gitleaks-reusable.yml


### PR DESCRIPTION
## Summary
- Add explicit `permissions:` block to `pii-scan.yml` granting `contents: read` and `pull-requests: read`.
- Fixes `Resource not accessible by integration` (403) on private-repo consumers of the reusable gitleaks workflow.

## Why
`gitleaks-action@v2` calls `GET /repos/{owner}/{repo}/pulls/{number}/commits` to determine scan scope on PR events. The default `GITHUB_TOKEN` for private repos withholds `pull-requests: read`, so the call returns 403 and the action exits before scanning. Public repos (including this one) have been getting it under the more permissive default for public projects — but the moment a downstream private repo consumed the workflow via `workflow_call` it broke.

Repro: fitz123/Minime#35 — pii-scan run https://github.com/fitz123/Minime/actions/runs/25995425868 fails with the exact 403 message.

## Test plan
- [ ] Self-CI on this PR passes (since the workflow runs against this same repo).