### PR TITLE
chore: disable memory-lint Phase B.5 (trial rolled back)

### DIFF
--- a/.claude/skills/memory-consolidation/SKILL.md
+++ b/.claude/skills/memory-consolidation/SKILL.md
@@ -4,7 +4,7 @@
 
 ## Feature Flags
 
-- `LINT_PHASE_B5_ENABLED=true` — Trial: 2026-05-17 → 2026-06-17. **The line above is the sole source of truth** — not an environment variable, not external config, not a settings file lookup. To roll back: edit that line to `LINT_PHASE_B5_ENABLED=false`, commit; the next nightly run reads this skill file and respects the new value. No data migration. See ADR-069.
+- `LINT_PHASE_B5_ENABLED=false` — Trial CONCLUDED 2026-05-28, rolled back. **The line above is the sole source of truth** — not an environment variable, not external config, not a settings file lookup. The 2026-05-17→05-28 trial found Phase B.5 did not earn its keep: 0 contradictions detected across 8 runs (~1500 candidate evaluations), and it structurally missed the one real cross-type contradiction that arose (the candidate filter uses "same type" as a signal, so cross-type drift can't reach the ≥2-signal threshold). The pre-existing narrative "Noted for Review" digest caught that case instead. See ADR-069 (SUPERSEDED) and `reference/tasks/workspace-txyu/retrospective.md`. To re-enable for a future redesign: flip to `true`, commit.
 
 When the flag value (as read from the line above) is `false`, the skill executes Phases 0/A/B/C/D as before — no cross-file lint, no Pending Review writes to MEMORY.md, no appends to `memory/lint-stats.jsonl`. Phase C still applies the new frontmatter fields (`confidence`, `revisit_if`) when creating or updating files, since those are forward-compatible regardless of the lint pass.
 


### PR DESCRIPTION
## Summary

Roll back the memory-lint Phase B.5 trial introduced in #124. Single-line flag flip: `LINT_PHASE_B5_ENABLED=true` → `false`.

## Trial result (ADR-069, 2026-05-17 → 2026-05-28, ended day 11 of planned 30)

| Metric | Value over 8 nightly runs |
|---|---|
| Candidates evaluated | ~1500 (unstable: 12→179→128→353) |
| Contradictions detected by B.5 | **0** |
| Auto-resolved | 0 |
| False positives | 0 |

**Decisive finding:** a real cross-type contradiction arose (a `user`-type file claimed an activity was active while the related `project`-type file was marked SETTLED). Phase B.5 **missed it** — its candidate filter uses "same type" as a match signal, so cross-type pairs can't reach the ≥2-signal threshold. Cross-type drift is the most dangerous class, and the filter is structurally blind to it. The pre-existing narrative "Noted for Review" digest (predates this trial) caught the case instead.

**Conclusion:** the algorithmic cross-file lint found nothing in ~1500 evaluations and missed the one real case, while burning LLM judgment calls on up to 36% of all file pairs nightly. The free, pre-existing narrative digest does the actual work. Rolled back.

## What changes

- `LINT_PHASE_B5_ENABLED` flag → `false` (skill skips Phase B.5; Phases 0/A/B/C/D run as before)
- `confidence` / `revisit_if` frontmatter still applied by Phase C (forward-compatible, harmless, kept)
- Narrative "Noted for Review" digest retained — unchanged, it's the part that works

## Test plan

- [ ] `grep -q 'LINT_PHASE_B5_ENABLED=false' .claude/skills/memory-consolidation/SKILL.md`
- [ ] Next nightly consolidation run: no Phase B.5 lint, no `memory/lint-stats.jsonl` append, no Pending Review writes

## Notes

The trial harness (feature flag + stats file + reminder + pre-defined rollback criteria) worked exactly as intended — reached a confident rollback in 11 days with zero damage. Reusable pattern for future experiments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)