### PR TITLE
fix(restart-bot): brace-delimit $BOT_PLIST before U+2026 ellipsis (set -u unbound var)

### DIFF
--- a/bot/scripts/restart-bot.sh
+++ b/bot/scripts/restart-bot.sh
@@ -150,7 +150,7 @@ _pred_running_pid() {
 }
 
 validate_plist() {
-  log "Validating plist at $BOT_PLIST…"
+  log "Validating plist at ${BOT_PLIST}…"
   if ! "$PLUTIL_BIN" -lint "$BOT_PLIST" >/dev/null 2>&1; then
     err "plist is malformed: $BOT_PLIST"
     err "run: $PLUTIL_BIN -lint \"$BOT_PLIST\" for details"
@@ -246,7 +246,7 @@ plist_restart() {
     log "Service not currently registered; skipping bootout."
   fi
 
-  log "Bootstrapping from $BOT_PLIST…"
+  log "Bootstrapping from ${BOT_PLIST}…"
   if ! "$LAUNCHCTL_BIN" bootstrap "$DOMAIN" "$BOT_PLIST"; then
     err "launchctl bootstrap failed"
     return 1


### PR DESCRIPTION
## Bug

`bot/scripts/restart-bot.sh` lines 153 & 249 write `"...$BOT_PLIST…"` — the variable abuts a U+2026 ellipsis with no delimiter. Under **bash 5.3.9 + `set -u`** the first byte of the multibyte ellipsis (`0xE2`) is absorbed into the variable name, so bash dereferences `BOT_PLIST<0xE2>` (an unset name) and aborts:

```
restart-bot.sh: line 153: BOT_PLIST<U+2026-byte>: unbound variable
```

This breaks the canonical `restart-bot.sh --plist` restart path on bash 5.3.9 and is the root cause of 5 failing full-suite tests.

## Fix

`${BOT_PLIST}…` — brace-delimit the variable name so the ellipsis bytes stay literal. Applied to both occurrences (lines 153, 249). The other `…` log lines already use `${VAR}…` or `$VAR ` (space-delimited) and are unaffected.

## Verification (system bash 5.3.9)

```
$ bash -c 'set -u; BOT_PLIST=/tmp/x; printf "%s\n" "at $BOT_PLIST…"'
bash: BOT_PLIST<0xE2>: unbound variable        # bug reproduced
$ bash -c 'set -u; BOT_PLIST=/tmp/x; printf "%s\n" "at ${BOT_PLIST}…"'
at /tmp/x…                                      # fixed
```

`bash -n` clean. Found incidentally during the Pi RPC Plan A migration work (it surfaced as 5 pre-existing full-suite failures, byte-identical to main, outside that plan's scope — fixed here separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)