### PR TITLE
feat: Pi RPC dispatch wiring + multi-turn fix (Plan B — session-manager, steer, resume-recovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Telegram Cloud          Discord Gateway
 
 Both platforms share one Session Manager and use the same stream-relay logic via the `PlatformContext` interface. Each platform provides an adapter that handles platform-specific message I/O (Telegram: grammY Context, Discord: discord.js Channel).
 
-**Message queue** sits between platform bots and Session Manager. Rapid messages are debounced (3s window) into a single prompt. Messages arriving while Claude is processing are collected (up to 20) and delivered as a combined followup after the current turn completes.
+**Message queue** sits between platform bots and Session Manager. Rapid messages are debounced (3s window) into a single prompt. Messages arriving while a `claude` session is processing are collected (up to 20) and delivered as a combined followup after the current turn completes; a `pi` session instead has each mid-turn message steered into it live via the Pi RPC channel (see [Provider backends](#provider-backends)).
 
 **Context injection:** Each message includes metadata — current time, chat type (DM/group/topic), topic name, sender username, and emoji reactions. The agent knows where it is, when it is, and who it's talking to. Reactions are delivered as messages so the agent can respond to a thumbs-up or a ❤️ without the user typing anything.
 
@@ -330,6 +330,8 @@ agents:
     # ...
     # provider: claude   # or "pi"; omit to default to "claude"
 ```
+
+A `pi` agent must set an explicit, Pi-appropriate `model` (e.g. `model: gpt-5.5`). Unlike a `claude` agent it does **not** inherit the top-level `defaultModel` — that value is Claude-oriented (e.g. `opus`) and the Pi spawn path would otherwise prefix it into a nonsensical `openai-codex/opus` string. The bot refuses to start if a `pi` agent omits `model`.
 
 Pi support is rolling out incrementally. The protocol layer is the typed Pi RPC module ([bot/src/pi-rpc-protocol.ts](bot/src/pi-rpc-protocol.ts)) — a newline-only JSONL splitter, spawn/send helpers, and a `parsePiEvent` translator that maps Pi RPC events into the bot's existing `StreamLine` shapes — plus the Pi Prometheus metrics listed under [Monitoring](#monitoring). **Session dispatch is now wired**: the [Session Manager](#architecture) branches on `agent.provider`, so a chat bound to a `pi` agent spawns via Pi RPC, streams to Telegram/Discord, persists and resumes its session across restarts, and is steerable mid-turn — while the `claude` path stays byte-identical. Specifically, this stage adds:
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Each agent runs through a coding-agent backend selected by the optional per-agen
 | `provider` | Backend | Status |
 |---|---|---|
 | `claude` (default, omit) | `claude -p` / Agent SDK | Active — the path every agent uses today |
-| `pi` | Pi RPC + OpenAI Codex (`pi --mode rpc`) | Protocol layer only — dispatch lands in a follow-up |
+| `pi` | Pi RPC + OpenAI Codex (`pi --mode rpc`) | Dispatch wired — runs end-to-end; no agent flipped to `pi` yet |
 
 ```yaml
 agents:
@@ -331,7 +331,14 @@ agents:
     # provider: claude   # or "pi"; omit to default to "claude"
 ```
 
-Pi support is rolling out incrementally. This stage ships the **protocol layer only**: the typed Pi RPC module ([bot/src/pi-rpc-protocol.ts](bot/src/pi-rpc-protocol.ts)) — a newline-only JSONL splitter, spawn/send helpers, and a `parsePiEvent` translator that maps Pi RPC events into the bot's existing `StreamLine` shapes — plus the Pi Prometheus metrics listed under [Monitoring](#monitoring). **Session dispatch is not wired yet**, so setting `provider: pi` has no runtime effect until the dispatch layer lands; the `claude` path is unchanged. The Pi binary (`@earendil-works/pi-coding-agent`) is resolved from `PATH`; like the Claude path, the bot prepends `/opt/homebrew/bin` to the spawned process's `PATH`, so ensure `pi` is reachable there or on the inherited `PATH`. Auth is managed by Pi itself, which reads `~/.pi/agent/auth.json` (the bot does not create or manage that file).
+Pi support is rolling out incrementally. The protocol layer is the typed Pi RPC module ([bot/src/pi-rpc-protocol.ts](bot/src/pi-rpc-protocol.ts)) — a newline-only JSONL splitter, spawn/send helpers, and a `parsePiEvent` translator that maps Pi RPC events into the bot's existing `StreamLine` shapes — plus the Pi Prometheus metrics listed under [Monitoring](#monitoring). **Session dispatch is now wired**: the [Session Manager](#architecture) branches on `agent.provider`, so a chat bound to a `pi` agent spawns via Pi RPC, streams to Telegram/Discord, persists and resumes its session across restarts, and is steerable mid-turn — while the `claude` path stays byte-identical. Specifically, this stage adds:
+
+- a multi-turn translator fix — only Pi's `agent_end` event terminates a turn (`turn_end` is a per-turn boundary), so a tool-using response delivers its final answer instead of truncating;
+- `get_state` session-id capture — the bot reads the Pi-generated session id after spawn, persists it, and resumes via `--session <uuid>`;
+- graceful resume-recovery — a stored id that Pi reports as `No session found matching` is discarded for exactly one fresh start (logged + counted via `bot_pi_session_resume_discarded_total`) instead of crash-looping the chat; any other startup failure keeps the existing crash-backoff and preserves the stored id and chat media;
+- Pi mid-turn steer — a message arriving while Pi is mid-turn is delivered via the Pi RPC steer channel (the `claude` path keeps its `inject-message.sh` file mechanism).
+
+No agent ships on `provider: pi` by default; flipping one is a deliberate per-deployment step. The Pi binary (`@earendil-works/pi-coding-agent`) is resolved from `PATH`; like the Claude path, the bot prepends `/opt/homebrew/bin` to the spawned process's `PATH`, so ensure `pi` is reachable there or on the inherited `PATH`. Auth is managed by Pi itself, which reads `~/.pi/agent/auth.json` (the bot does not create or manage that file).
 
 ### Logging
 
@@ -352,7 +359,7 @@ metricsPort: 9090
 
 See [bot/src/metrics.ts](bot/src/metrics.ts) for the full list of exported metrics.
 
-The Pi RPC provider (see [Provider backends](#provider-backends)) registers its own metrics now so dashboards and alerts are ready before dispatch lands: `bot_pi_turn_duration_seconds` (histogram, label `agent_id`, same buckets as the Claude turn histogram for direct comparison) and the retry counters `bot_pi_retry_total`, `bot_pi_429_total`, `bot_pi_overload_total`, and `bot_pi_retry_unknown_total` (every retry increments `bot_pi_retry_total` plus exactly one signal-specific counter). They read zero until an agent runs with `provider: pi`.
+The Pi RPC provider (see [Provider backends](#provider-backends)) registers its own metrics: `bot_pi_turn_duration_seconds` (histogram, label `agent_id`, same buckets as the Claude turn histogram for direct comparison), the retry counters `bot_pi_retry_total`, `bot_pi_429_total`, `bot_pi_overload_total`, and `bot_pi_retry_unknown_total` (every retry increments `bot_pi_retry_total` plus exactly one signal-specific counter), and `bot_pi_session_resume_discarded_total` (label `agent_id`, incremented once per graceful resume-recovery — a stored Pi session id Pi could not find, discarded for one fresh start). They read zero until an agent runs with `provider: pi`.
 
 #### Telegram API metrics
 

--- a/bot/src/__tests__/discord-bot.test.ts
+++ b/bot/src/__tests__/discord-bot.test.ts
@@ -561,10 +561,14 @@ function makeLiveChild(): FakeChild {
   };
 }
 
-function fakeManager(provider: "claude" | "pi" | null, child: FakeChild): Pick<SessionManager, "getActive"> {
+function fakeManager(
+  provider: "claude" | "pi" | null,
+  child: FakeChild,
+  processingStartedAt: number | null = Date.now(),
+): Pick<SessionManager, "getActive"> {
   return {
     getActive: (_chatId: string) =>
-      (provider === null ? undefined : ({ child, provider } as unknown)) as never,
+      (provider === null ? undefined : ({ child, provider, processingStartedAt } as unknown)) as never,
   };
 }
 
@@ -595,6 +599,16 @@ describe("makeSteerFn (discord)", () => {
     const child = makeLiveChild();
     child.exitCode = 0;
     const steerFn = makeSteerFn(fakeManager("pi", child));
+    assert.strictEqual(steerFn("discord:chat-1", "main", "x"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
+  });
+
+  it("returns false when a pinned-pi session is not actively processing (idle window after agent_end)", () => {
+    // processingStartedAt === null: session-manager has cleared it after
+    // agent_end but MessageQueue.busy may still be true. Steering here would
+    // hand the message to an idle Pi child and lose it; buffer instead.
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("pi", child, null));
     assert.strictEqual(steerFn("discord:chat-1", "main", "x"), false);
     assert.strictEqual(child.stdin.writes.length, 0);
   });

--- a/bot/src/__tests__/discord-bot.test.ts
+++ b/bot/src/__tests__/discord-bot.test.ts
@@ -8,9 +8,11 @@ import {
   shouldRespondInDiscord,
   buildDiscordSourcePrefix,
   installDiscordErrorHandlers,
+  makeSteerFn,
 } from "../discord-bot.js";
 import { validateDiscordBinding } from "../config.js";
 import type { DiscordBinding } from "../types.js";
+import type { SessionManager } from "../session-manager.js";
 
 // --- discordSessionKey ---
 
@@ -539,3 +541,61 @@ describe("installDiscordErrorHandlers", () => {
 
 // Streaming control flag tests are in discord-adapter.test.ts
 // where they verify actual adapter behavior, not just type shapes.
+
+// --- makeSteerFn (provider pinned to the session, not config) ---
+
+interface FakeChild {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  killed: boolean;
+  stdin: { destroyed: boolean; writes: string[]; write: (s: string) => void };
+}
+
+function makeLiveChild(): FakeChild {
+  const writes: string[] = [];
+  return {
+    exitCode: null,
+    signalCode: null,
+    killed: false,
+    stdin: { destroyed: false, writes, write: (s: string) => { writes.push(s); } },
+  };
+}
+
+function fakeManager(provider: "claude" | "pi" | null, child: FakeChild): Pick<SessionManager, "getActive"> {
+  return {
+    getActive: (_chatId: string) =>
+      (provider === null ? undefined : ({ child, provider } as unknown)) as never,
+  };
+}
+
+describe("makeSteerFn (discord)", () => {
+  it("steers (returns true) when the session is pinned provider:pi", () => {
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("pi", child));
+    // Only the session's pinned provider matters, so even a config snapshot
+    // claiming "claude" cannot mis-route this Pi session to the inject path.
+    assert.strictEqual(steerFn("discord:chat-1", "main", "mid-turn text"), true);
+    assert.strictEqual(child.stdin.writes.length, 1);
+    assert.ok(child.stdin.writes[0].includes("mid-turn text"));
+  });
+
+  it("falls to inject (returns false) when the session is pinned provider:claude", () => {
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("claude", child));
+    assert.strictEqual(steerFn("discord:chat-1", "main", "mid-turn text"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
+  });
+
+  it("returns false when there is no active session", () => {
+    const steerFn = makeSteerFn(fakeManager(null, makeLiveChild()));
+    assert.strictEqual(steerFn("discord:chat-1", "main", "x"), false);
+  });
+
+  it("returns false when the pinned-pi child has already exited", () => {
+    const child = makeLiveChild();
+    child.exitCode = 0;
+    const steerFn = makeSteerFn(fakeManager("pi", child));
+    assert.strictEqual(steerFn("discord:chat-1", "main", "x"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
+  });
+});

--- a/bot/src/__tests__/message-queue.test.ts
+++ b/bot/src/__tests__/message-queue.test.ts
@@ -1092,6 +1092,77 @@ describe("MessageQueue provider-aware steer", () => {
 
     queue.clearAll();
   });
+
+  it("caps live steers per turn at queueCap and falls back to the collect buffer for overflow (pi)", async () => {
+    const mock = createMockProcess();
+    let steerCalls = 0;
+    const steerFn = () => { steerCalls++; return true; };
+    // queueCap=2: at most 2 live steers per turn, overflow buffered (and re-
+    // delivered as a followup), past 2*queueCap dropped.
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30, queueCap: 2, steerFn });
+    const platform = mockPlatform();
+
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "initial", platform);
+    await wait(60);
+
+    // Five mid-turn messages: 2 steered live, 2 buffered (cap), 1 dropped.
+    queue.enqueue(INJECT_CHAT, "pi-agent", "s1", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "s2", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "b1", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "b2", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "drop", platform);
+
+    // Only queueCap (2) messages steered live — the flood is bounded.
+    assert.strictEqual(steerCalls, 2, "live steers are capped at queueCap per turn");
+    assert.strictEqual(queue.getCollectCount(INJECT_CHAT), 2, "overflow buffered up to queueCap");
+
+    // Drain: the 2 buffered overflow messages are delivered as a followup.
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(80);
+
+    // calls[0] = "initial"; calls[1] = buffered followup (b1+b2 combined).
+    assert.strictEqual(mock.calls.length, 2, "buffered overflow drains as one followup; dropped message is gone");
+    assert.ok(mock.calls[1].text.includes("b1"));
+    assert.ok(mock.calls[1].text.includes("b2"));
+    assert.ok(!mock.calls[1].text.includes("drop"), "the over-cap message was dropped, not delivered");
+
+    queue.clearAll();
+  });
+
+  it("resets the per-turn steer budget on each new turn (pi)", async () => {
+    const mock = createMockProcess();
+    let steerCalls = 0;
+    const steerFn = () => { steerCalls++; return true; };
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30, queueCap: 2, steerFn });
+    const platform = mockPlatform();
+
+    // Turn 1: exhaust the steer budget, then leave one buffered message so a
+    // second turn (drain) runs after this one completes.
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "initial", platform);
+    await wait(60);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "s1", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "s2", platform);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "buffered", platform);
+    assert.strictEqual(steerCalls, 2, "turn 1 steer budget exhausted at queueCap");
+
+    // Finish turn 1 → drain "buffered" as turn 2 (blocks again).
+    mock.unblock();
+    await wait(60);
+
+    // Turn 2 is now processing (the buffered followup). Its steer budget reset,
+    // so a fresh mid-turn message steers again rather than being capped.
+    queue.enqueue(INJECT_CHAT, "pi-agent", "s3", platform);
+    assert.strictEqual(steerCalls, 3, "steer budget reset for the new turn");
+
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(80);
+
+    queue.clearAll();
+  });
 });
 
 // -------------------------------------------------------------------

--- a/bot/src/__tests__/message-queue.test.ts
+++ b/bot/src/__tests__/message-queue.test.ts
@@ -952,6 +952,149 @@ describe("MessageQueue inject dedup", () => {
 });
 
 // -------------------------------------------------------------------
+// MessageQueue — provider-aware mid-turn steer (Pi path)
+// -------------------------------------------------------------------
+
+describe("MessageQueue provider-aware steer", () => {
+  afterEach(() => {
+    injectCleanup(INJECT_CHAT);
+  });
+
+  it("routes a mid-turn message to steerFn and skips buffering when handled (pi)", async () => {
+    const mock = createMockProcess();
+    const steerCalls: Array<{ chatId: string; agentId: string; text: string }> = [];
+    const steerFn = (chatId: string, agentId: string, text: string) => {
+      steerCalls.push({ chatId, agentId, text });
+      return true; // simulate a live Pi steer
+    };
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30, steerFn });
+    const platform = mockPlatform();
+
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "initial", platform);
+    await wait(60);
+
+    // Mid-turn message while busy
+    queue.enqueue(INJECT_CHAT, "pi-agent", "mid-turn steer", platform);
+
+    // steerFn received the message with the chat's agentId
+    assert.strictEqual(steerCalls.length, 1);
+    assert.deepStrictEqual(steerCalls[0], {
+      chatId: INJECT_CHAT,
+      agentId: "pi-agent",
+      text: "mid-turn steer",
+    });
+
+    // Pi path must NOT write an inject file (no PreToolUse hook for Pi)
+    const dir = injectDirForChat(INJECT_CHAT);
+    assert.ok(!existsSync(join(dir, "pending")), "pi steer should not write an inject file");
+
+    // Steered message is not buffered → not re-delivered on drain
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(60);
+    assert.strictEqual(mock.calls.length, 1, "steered message must not be re-delivered on drain");
+    assert.strictEqual(mock.calls[0].text, "initial");
+
+    queue.clearAll();
+  });
+
+  it("falls back to the inject-file path when steerFn declines (claude regression)", async () => {
+    const mock = createMockProcess();
+    let steerCallCount = 0;
+    const steerFn = () => {
+      steerCallCount++;
+      return false; // claude provider → not handled by steer
+    };
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30, steerFn });
+    const platform = mockPlatform();
+
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "main", "initial", platform);
+    await wait(60);
+
+    queue.enqueue(INJECT_CHAT, "main", "mid-turn msg", platform);
+
+    // steerFn was consulted but declined
+    assert.strictEqual(steerCallCount, 1);
+
+    // Inject file written (claude path preserved)
+    const dir = injectDirForChat(INJECT_CHAT);
+    assert.ok(existsSync(join(dir, "pending")), "claude path should still write the inject file");
+    const content = readFileSync(join(dir, "pending"), "utf-8");
+    assert.ok(content.includes("mid-turn msg"));
+
+    // No hook fires → message drains as a followup
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(80);
+    assert.strictEqual(mock.calls.length, 2);
+    assert.strictEqual(mock.calls[1].text, "mid-turn msg");
+
+    queue.clearAll();
+  });
+
+  it("uses the inject-file path when no steerFn is configured (default behavior unchanged)", async () => {
+    const mock = createMockProcess();
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30 });
+    const platform = mockPlatform();
+
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "main", "initial", platform);
+    await wait(60);
+
+    queue.enqueue(INJECT_CHAT, "main", "mid-turn msg", platform);
+
+    const dir = injectDirForChat(INJECT_CHAT);
+    assert.ok(existsSync(join(dir, "pending")), "default (no steerFn) writes the inject file");
+
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(80);
+    assert.strictEqual(mock.calls.length, 2);
+    assert.strictEqual(mock.calls[1].text, "mid-turn msg");
+
+    queue.clearAll();
+  });
+
+  it("defers turn-scoped cleanup and never runs drop-cleanup on a handled steer (pi)", async () => {
+    const mock = createMockProcess();
+    const steerFn = () => true;
+    const queue = new MessageQueue(mock.processFn, { debounceMs: 30, steerFn });
+    const platform = mockPlatform();
+
+    mock.setBlocking(true);
+    queue.enqueue(INJECT_CHAT, "pi-agent", "initial", platform);
+    await wait(60);
+
+    let cleaned = false;
+    let dropped = false;
+    queue.enqueue(
+      INJECT_CHAT,
+      "pi-agent",
+      "steered",
+      platform,
+      () => { cleaned = true; },
+      () => { dropped = true; },
+    );
+
+    // During the turn the cleanup is deferred and the drop-cleanup never runs
+    assert.strictEqual(cleaned, false, "turn-scoped cleanup is deferred during the turn");
+    assert.strictEqual(dropped, false, "drop-cleanup must not run for a delivered message");
+
+    mock.setBlocking(false);
+    mock.unblock();
+    await wait(60);
+
+    // After the turn completes the deferred cleanup runs; drop-cleanup still never ran
+    assert.strictEqual(cleaned, true, "deferred cleanup runs once the turn drains");
+    assert.strictEqual(dropped, false, "drop-cleanup never runs — the agent owns the media");
+
+    queue.clearAll();
+  });
+});
+
+// -------------------------------------------------------------------
 // MessageQueue — pre-stream typing indicator
 // -------------------------------------------------------------------
 

--- a/bot/src/__tests__/metrics.test.ts
+++ b/bot/src/__tests__/metrics.test.ts
@@ -19,6 +19,7 @@ import {
   pi429Total,
   piOverloadTotal,
   piRetryUnknownTotal,
+  piSessionResumeDiscarded,
   telegramApiErrors,
   telegramApiCalls,
   sessionsActive,
@@ -319,6 +320,26 @@ describe("recordPiTurnDuration", () => {
   });
 });
 
+describe("piSessionResumeDiscarded", () => {
+  async function bucketValue(agentId: string): Promise<number> {
+    const metric = await piSessionResumeDiscarded.get();
+    const entry = metric.values.find((v) => v.labels.agent_id === agentId);
+    return entry?.value ?? 0;
+  }
+
+  it("increments per agent_id when a Pi resume is discarded", async () => {
+    piSessionResumeDiscarded.inc({ agent_id: "pi" });
+    assert.strictEqual(await bucketValue("pi"), 1);
+    assert.strictEqual(await bucketValue("other"), 0);
+  });
+
+  it("accumulates across multiple discards for the same agent", async () => {
+    piSessionResumeDiscarded.inc({ agent_id: "pi" });
+    piSessionResumeDiscarded.inc({ agent_id: "pi" });
+    assert.strictEqual(await bucketValue("pi"), 2);
+  });
+});
+
 describe("Pi metrics registration", () => {
   it("registers all Pi metrics on the default registry", () => {
     const names = client.register.getMetricsAsArray().map((m) => m.name);
@@ -328,6 +349,7 @@ describe("Pi metrics registration", () => {
       "bot_pi_429_total",
       "bot_pi_overload_total",
       "bot_pi_retry_unknown_total",
+      "bot_pi_session_resume_discarded_total",
     ]) {
       assert.ok(names.includes(name), `expected ${name} to be registered`);
     }
@@ -336,6 +358,7 @@ describe("Pi metrics registration", () => {
   it("exposes Pi metrics in the scrape output", async () => {
     recordPiRetry("main", "429 rate limit");
     recordPiTurnDuration("main", 5);
+    piSessionResumeDiscarded.inc({ agent_id: "main" });
 
     const body = await client.register.metrics();
     assert.ok(body.includes("bot_pi_turn_duration_seconds"));
@@ -343,6 +366,7 @@ describe("Pi metrics registration", () => {
     assert.ok(body.includes("bot_pi_429_total"));
     assert.ok(body.includes("bot_pi_overload_total"));
     assert.ok(body.includes("bot_pi_retry_unknown_total"));
+    assert.ok(body.includes("bot_pi_session_resume_discarded_total"));
   });
 });
 

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -6,6 +6,7 @@ import type { ChildProcess } from "node:child_process";
 import { Readable } from "node:stream";
 import {
   NewlineOnlyJsonlSplitter,
+  buildGetStateCommand,
   buildPiPromptCommand,
   buildPiSpawnArgs,
   buildPiSpawnEnv,
@@ -13,6 +14,7 @@ import {
   extractPiTextDelta,
   parsePiEvent,
   readPiStream,
+  sendPiGetState,
   sendPiPrompt,
   sendPiSteer,
 } from "../pi-rpc-protocol.js";
@@ -152,6 +154,19 @@ describe("buildPiSpawnArgs", () => {
     assert.ok(!args.includes("--effort"));
     assert.ok(!args.includes("--add-dir"));
   });
+
+  it("appends --session with the resume session id when one is provided", () => {
+    const args = buildPiSpawnArgs(testAgent, "pi-sess-resume");
+    const idx = args.indexOf("--session");
+
+    assert.notStrictEqual(idx, -1, "should include --session on resume");
+    assert.strictEqual(args[idx + 1], "pi-sess-resume");
+  });
+
+  it("omits --session on a fresh start (no resume id, or a blank one)", () => {
+    assert.ok(!buildPiSpawnArgs(testAgent).includes("--session"), "no arg => fresh start");
+    assert.ok(!buildPiSpawnArgs(testAgent, "").includes("--session"), "blank id => fresh start");
+  });
 });
 
 describe("buildPiSpawnEnv", () => {
@@ -254,6 +269,27 @@ describe("Pi RPC prompt and steer commands", () => {
     assert.deepStrictEqual(buildPiSteerCommand("stop"), {
       type: "steer",
       message: "stop",
+    });
+  });
+
+  it("builds a no-argument get_state command object", () => {
+    assert.deepStrictEqual(buildGetStateCommand(), { type: "get_state" });
+  });
+
+  it("writes get_state commands to stdin", () => {
+    const chunks: Buffer[] = [];
+    const stdin = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(Buffer.from(chunk));
+        cb();
+      },
+    });
+    const child = createMockChild({ stdin });
+
+    sendPiGetState(child);
+
+    assert.deepStrictEqual(JSON.parse(Buffer.concat(chunks).toString().trim()), {
+      type: "get_state",
     });
   });
 
@@ -650,5 +686,46 @@ describe("readPiStream", () => {
   it("throws when stdout is unavailable", async () => {
     const child = new EventEmitter() as unknown as ChildProcess;
     await assert.rejects(readPiStream(child).next(), /stdout is not available/);
+  });
+
+  it("does not destroy stdout on early return, so a second consumer can resume (single-consumer handoff)", async () => {
+    // Models the spawn-path get_state capture: read exactly the SystemInit
+    // record, stop the generator, then open a FRESH readPiStream on the SAME
+    // child for the first sendSessionMessage. The first generator must leave
+    // child.stdout intact (destroyOnReturn:false) or the handoff breaks.
+    const stdout = new Readable({ read() {} });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(child, { stdout });
+
+    // First consumer: the get_state capture reads one SystemInit then stops.
+    const first = readPiStream(child);
+    stdout.push(
+      JSON.stringify({
+        type: "response",
+        command: "get_state",
+        success: true,
+        data: { sessionId: "pi-handoff-1" },
+      }) + "\n",
+    );
+    const r1 = await first.next();
+    assert.strictEqual(r1.done, false);
+    assert.strictEqual(r1.value.type, "system");
+    assert.strictEqual((r1.value as { session_id: string }).session_id, "pi-handoff-1");
+    await first.return(undefined);
+
+    assert.strictEqual(stdout.destroyed, false, "early return must NOT destroy stdout");
+
+    // Second consumer: a fresh readPiStream keeps reading the same stdout.
+    const second = readPiStream(child);
+    stdout.push(
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "after handoff" },
+      }) + "\n",
+    );
+    const r2 = await second.next();
+    assert.strictEqual(r2.done, false);
+    assert.strictEqual(extractPiTextDelta(r2.value), "after handoff");
+    await second.return(undefined);
   });
 });

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -375,23 +375,23 @@ describe("parsePiEvent", () => {
     assert.strictEqual(flipsSawNonTextBlock(line), true);
   });
 
-  it("translates turn_end into a ResultMessage, reconstructing text from the message object", () => {
-    // Pi sends `turn_end.message` as an AssistantMessage object, never a string.
-    const line = parsePiEvent({
-      type: "turn_end",
-      message: {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "hmm" },
-          { type: "text", text: "all " },
-          { type: "text", text: "done" },
-        ],
-      },
-    });
-
-    assert.ok(line);
-    assert.strictEqual(line.type, "result");
-    assert.strictEqual((line as { result: string }).result, "all done");
+  it("treats turn_end as a non-terminal per-turn boundary (returns null)", () => {
+    // turn_end fires once per turn; only agent_end is terminal. Mapping turn_end
+    // to a ResultMessage would truncate a multi-turn (tool-using) response at its
+    // first turn, so turn_end must translate to null regardless of its content.
+    assert.strictEqual(
+      parsePiEvent({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "hmm" },
+            { type: "text", text: "partial turn text" },
+          ],
+        },
+      }),
+      null,
+    );
   });
 
   it("translates agent_end into a ResultMessage with the last assistant message text", () => {
@@ -410,16 +410,72 @@ describe("parsePiEvent", () => {
     assert.strictEqual((line as { result: string }).result, "final answer");
   });
 
-  it("yields empty result text (not a crash) for a turn_end with no text blocks", () => {
+  it("yields empty result text (not a crash) for an agent_end with no assistant text", () => {
     const line = parsePiEvent({
-      type: "turn_end",
-      message: { role: "assistant", content: [{ type: "toolCall", id: "c1", name: "bash" }] },
+      type: "agent_end",
+      messages: [{ role: "assistant", content: [{ type: "toolCall", id: "c1", name: "bash" }] }],
     });
 
     assert.ok(line);
     assert.strictEqual((line as { result: string }).result, "");
-    // turn_end carries no session id — that comes from a get_state response.
+    // agent_end here carries no top-level sessionId — that comes from get_state.
     assert.strictEqual((line as { session_id: string }).session_id, "");
+  });
+
+  it("multi-turn sequence (2x turn_end + 1x agent_end) terminates exactly once with the FINAL text", () => {
+    // Verified live sequence: a tool-using response fires turn_end per turn, then
+    // a single agent_end. Only agent_end is terminal, and it carries the final answer.
+    const sequence = [
+      {
+        type: "turn_end",
+        message: { role: "assistant", content: [{ type: "text", text: "let me check" }] },
+      },
+      {
+        type: "turn_end",
+        message: { role: "assistant", content: [{ type: "text", text: "still working" }] },
+      },
+      {
+        type: "agent_end",
+        messages: [
+          { role: "user", content: "do the thing" },
+          { role: "assistant", content: [{ type: "text", text: "let me check" }] },
+          { role: "toolResult", content: [{ type: "text", text: "tool output" }] },
+          { role: "assistant", content: [{ type: "text", text: "the final answer" }] },
+        ],
+      },
+    ];
+
+    const lines = sequence.map((e) => parsePiEvent(e));
+    const terminals = lines.filter((l) => l?.type === "result");
+
+    assert.strictEqual(terminals.length, 1);
+    assert.strictEqual((terminals[0] as { result: string }).result, "the final answer");
+    // The two turn_end boundaries do not terminate.
+    assert.strictEqual(lines[0], null);
+    assert.strictEqual(lines[1], null);
+  });
+
+  it("single-turn sequence (1x turn_end + 1x agent_end) terminates exactly once", () => {
+    const sequence = [
+      {
+        type: "turn_end",
+        message: { role: "assistant", content: [{ type: "text", text: "quick answer" }] },
+      },
+      {
+        type: "agent_end",
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: [{ type: "text", text: "quick answer" }] },
+        ],
+      },
+    ];
+
+    const lines = sequence.map((e) => parsePiEvent(e));
+    const terminals = lines.filter((l) => l?.type === "result");
+
+    assert.strictEqual(terminals.length, 1);
+    assert.strictEqual((terminals[0] as { result: string }).result, "quick answer");
+    assert.strictEqual(lines[0], null);
   });
 
   it("captures the Pi session id from a successful get_state response", () => {
@@ -546,9 +602,14 @@ describe("readPiStream", () => {
         assistantMessageEvent: { type: "text_delta", delta: "hi" },
       }),
       JSON.stringify({ type: "tool_execution_update" }),
+      // A non-terminal turn_end is filtered out by the stream (returns null).
       JSON.stringify({
         type: "turn_end",
-        message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+        message: { role: "assistant", content: [{ type: "text", text: "mid" }] },
+      }),
+      JSON.stringify({
+        type: "agent_end",
+        messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }],
       }),
     ]);
 
@@ -562,6 +623,7 @@ describe("readPiStream", () => {
       ["system", "stream_event", "result"],
     );
     assert.strictEqual(extractPiTextDelta(lines[1]), "hi");
+    assert.strictEqual((lines[2] as { result: string }).result, "ok");
   });
 
   it("handles records split across stdout chunks", async () => {

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -537,20 +537,40 @@ describe("parsePiEvent", () => {
     );
   });
 
-  it("surfaces a failed command response as an error ResultMessage", () => {
+  it("surfaces a failed prompt response as a terminal error ResultMessage", () => {
     const line = parsePiEvent({
       type: "response",
-      command: "set_model",
+      command: "prompt",
       success: false,
-      error: "Model not found: invalid/model",
+      error: "prompt rejected",
     });
 
     assert.ok(line);
     assert.strictEqual(line.type, "result");
     const result = line as unknown as Record<string, unknown>;
     assert.strictEqual(result.subtype, "error_during_execution");
-    assert.strictEqual(result.result, "Model not found: invalid/model");
+    assert.strictEqual(result.result, "prompt rejected");
     assert.strictEqual(result.is_error, true);
+  });
+
+  it("ignores a failed side-command response so it cannot truncate the active turn", () => {
+    // A mid-turn `steer` rejection shares the active prompt turn's stdout.
+    // Mapping it to a terminal result would end the in-flight response early, so
+    // it must be ignored (returned null) rather than surfaced as a result.
+    assert.strictEqual(
+      parsePiEvent({ type: "response", command: "steer", success: false, error: "no active turn" }),
+      null,
+    );
+    assert.strictEqual(
+      parsePiEvent({ type: "response", command: "set_model", success: false, error: "Model not found" }),
+      null,
+    );
+    // A failed response with no command field is also ignored (cannot correlate
+    // it to the prompt; ignoring is safer than truncating an active turn).
+    assert.strictEqual(
+      parsePiEvent({ type: "response", success: false, error: "mystery failure" }),
+      null,
+    );
   });
 
   it("translates auto_retry_start into a rate_limit_event preserving the error message", () => {

--- a/bot/src/__tests__/provider-config.test.ts
+++ b/bot/src/__tests__/provider-config.test.ts
@@ -47,6 +47,36 @@ describe("validateAgent provider field", () => {
     );
   });
 
+  it("rejects a pi agent with no explicit model (must not inherit the Claude defaultModel)", () => {
+    assert.throws(
+      () => validateAgent(
+        { workspaceCwd: "/tmp/x", provider: "pi" },
+        "coder",
+        "opus", // Claude-oriented top-level defaultModel
+      ),
+      /Agent "coder" uses provider "pi" and must set an explicit model/,
+    );
+  });
+
+  it("accepts a pi agent with an explicit model and does not apply defaultModel", () => {
+    const agent = validateAgent(
+      { workspaceCwd: "/tmp/x", model: "gpt-5.5", provider: "pi" },
+      "coder",
+      "opus",
+    );
+    assert.strictEqual(agent.model, "gpt-5.5");
+    assert.strictEqual(agent.provider, "pi");
+  });
+
+  it("a claude agent still inherits the top-level defaultModel (regression)", () => {
+    const agent = validateAgent(
+      { workspaceCwd: "/tmp/x", provider: "claude" },
+      "main",
+      "claude-opus-4-7",
+    );
+    assert.strictEqual(agent.model, "claude-opus-4-7");
+  });
+
   it("does not change other field handling when provider is set", () => {
     const agent = validateAgent(
       {

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -13,7 +13,7 @@ import { ensureSessionMediaDir, sessionMediaDir, allocateMediaPath, releaseMedia
 // Real protocol helpers the spawn-path capture needs (parse get_state replies).
 // Resolved here BEFORE mock.module installs the stub, so these are the genuine
 // implementations; the stub below re-exports them so capture parses correctly.
-import { NewlineOnlyJsonlSplitter, parsePiEvent } from "../pi-rpc-protocol.js";
+import { NewlineOnlyJsonlSplitter, parsePiRecord } from "../pi-rpc-protocol.js";
 
 const TEST_DIR = "/tmp/minime-test-pi-spawn";
 const TEST_STORE_PATH = `${TEST_DIR}/sessions.json`;
@@ -233,7 +233,7 @@ mock.module("../pi-rpc-protocol.js", {
     },
     // Re-export the genuine parse helpers the capture uses.
     NewlineOnlyJsonlSplitter,
-    parsePiEvent,
+    parsePiRecord,
   },
 });
 

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -9,7 +9,7 @@ import type { AgentConfig, BotConfig, StreamLine } from "../types.js";
 // spy on log.warn and a read of piSessionResumeDiscarded observe its behavior.
 import { log } from "../logger.js";
 import { piSessionResumeDiscarded } from "../metrics.js";
-import { ensureSessionMediaDir, sessionMediaDir } from "../media-store.js";
+import { ensureSessionMediaDir, sessionMediaDir, allocateMediaPath, releaseMediaPath } from "../media-store.js";
 // Real protocol helpers the spawn-path capture needs (parse get_state replies).
 // Resolved here BEFORE mock.module installs the stub, so these are the genuine
 // implementations; the stub below re-exports them so capture parses correctly.
@@ -426,14 +426,16 @@ describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
     piSpawnOutcomes = [];
     nextPiSessionId = "pi-generated-id";
     getStateError = null;
-    // The media-preserved assertion writes into /tmp/bot-media; clear the chat's
-    // dir between runs so a prior run's file can't mask a regression.
+    // The media-preserved assertions write into /tmp/bot-media; clear each
+    // chat's dir between runs so a prior run's file can't mask a regression.
     try { rmSync(sessionMediaDir("pi-keep"), { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(sessionMediaDir("pi-inflight"), { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
   afterEach(() => {
     cleanup();
     try { rmSync(sessionMediaDir("pi-keep"), { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(sessionMediaDir("pi-inflight"), { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
   it("missing-session signal: discards once, warns once, increments metric, then starts fresh", async () => {
@@ -482,6 +484,53 @@ describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
     assert.strictEqual(recoveryWarns.length, 1, "exactly one recovery warning");
     assert.strictEqual((await discardedCount("pi")) - before, 1, "metric incremented exactly once");
 
+    await manager.closeAll();
+  });
+
+  it("resume-recovery preserves the current turn's in-flight media while discarding the stored id", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-inflight", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-inflight",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // The triggering turn already staged a media file under this chat's dir and
+    // it is tracked as in-flight (allocateMediaPath registers it). The fresh Pi
+    // session's prompt will reference this path, so recovery must NOT delete it.
+    const inflightPath = allocateMediaPath("pi-inflight", "photo", ".jpg");
+    writeFileSync(inflightPath, "current turn media");
+    // A leftover from the prior (now-unresumable) session — NOT in-flight. This
+    // SHOULD be swept by the stale cleanup.
+    const stalePath = `${sessionMediaDir("pi-inflight")}/prior-session.jpg`;
+    writeFileSync(stalePath, "stale leftover");
+
+    // Resume fails with the "No session found" signal → recovery fires; the
+    // inline fresh re-spawn then succeeds.
+    piSpawnOutcomes = [{ failStderr: "No session found matching stored-pi-id" }];
+    nextPiSessionId = "fresh-pi-id";
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    const warnSpy = mock.method(log, "warn", () => {});
+    let session;
+    try {
+      session = await manager.getOrCreateSession("pi-inflight", "pi");
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // Recovery happened: fresh id adopted, stored id discarded (then re-persisted
+    // with the fresh id by the successful spawn).
+    assert.strictEqual(session.sessionId, "fresh-pi-id", "recovered onto the fresh id");
+
+    // The in-flight file for the current turn SURVIVES (the bug fix): the fresh
+    // Pi session's prompt can still reach it.
+    assert.ok(existsSync(inflightPath), "in-flight media for the current turn is preserved across recovery");
+    // The prior-session leftover is swept (it was not in-flight).
+    assert.strictEqual(existsSync(stalePath), false, "prior-session media leftover is removed");
+
+    releaseMediaPath(inflightPath);
     await manager.closeAll();
   });
 

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import type { AgentConfig, BotConfig, StreamLine } from "../types.js";
+
+const TEST_DIR = "/tmp/minime-test-pi-spawn";
+const TEST_STORE_PATH = `${TEST_DIR}/sessions.json`;
+
+function cleanup() {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Captures + tunables driven by the module mocks below.
+// ---------------------------------------------------------------------------
+
+/** Opts captured from the mocked claude spawnClaudeSession. */
+interface ClaudeSpawnOpts {
+  agent: { model: string; [key: string]: unknown };
+  sessionId?: string;
+  resume?: boolean;
+  [key: string]: unknown;
+}
+
+/** Args captured from the mocked Pi spawnPiRpcSession. */
+interface PiSpawnCapture {
+  agent: AgentConfig;
+  resumeSessionId?: string;
+}
+
+const claudeSpawnCaptures: ClaudeSpawnOpts[] = [];
+const piSpawnCaptures: PiSpawnCapture[] = [];
+
+/**
+ * The session id the mocked readPiStream surfaces from get_state. Set to null to
+ * model a Pi process that goes idle without ever emitting a SystemInit record
+ * (capture must then fall back to the bot's local id).
+ */
+let nextPiSessionId: string | null = "pi-generated-id";
+
+/** Create a mock ChildProcess that auto-emits 'spawn' on next tick. */
+function createAutoSpawnChild(): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    stdin,
+    pid: Math.floor(Math.random() * 100000),
+    exitCode: null,
+    signalCode: null,
+    killed: false,
+    kill(signal?: string) {
+      (child as unknown as Record<string, unknown>).killed = true;
+      process.nextTick(() => {
+        (child as unknown as Record<string, unknown>).exitCode =
+          signal === "SIGKILL" ? 137 : 0;
+        child.emit("exit", signal === "SIGKILL" ? 137 : 0, signal ?? "SIGTERM");
+      });
+      return true;
+    },
+  });
+
+  process.nextTick(() => child.emit("spawn"));
+
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// Mock BOTH protocol modules BEFORE importing session-manager so the mocks are
+// in place when session-manager's static imports resolve. The spawn path needs
+// the REAL session-manager but stubbed protocol fns (mirrors hot-reload.test.ts).
+// ---------------------------------------------------------------------------
+mock.module("../cli-protocol.js", {
+  namedExports: {
+    spawnClaudeSession(opts: ClaudeSpawnOpts) {
+      claudeSpawnCaptures.push(opts);
+      return createAutoSpawnChild();
+    },
+    sendMessage() {},
+    async *readStream(): AsyncGenerator<StreamLine> {},
+  },
+});
+
+mock.module("../pi-rpc-protocol.js", {
+  namedExports: {
+    spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string) {
+      piSpawnCaptures.push({ agent, resumeSessionId });
+      return createAutoSpawnChild();
+    },
+    sendPiGetState() {},
+    sendPiPrompt() {},
+    async *readPiStream(): AsyncGenerator<StreamLine> {
+      if (nextPiSessionId !== null) {
+        yield { type: "system", subtype: "init", session_id: nextPiSessionId };
+      }
+    },
+  },
+});
+
+const { SessionManager } = await import("../session-manager.js");
+const { SessionStore } = await import("../session-store.js");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeConfig(): BotConfig {
+  return {
+    telegramToken: "test-token",
+    agents: {
+      main: {
+        id: "main",
+        workspaceCwd: "/tmp/test-workspace",
+        model: "claude-opus-4-6",
+      },
+      pi: {
+        id: "pi",
+        workspaceCwd: "/tmp/test-workspace-pi",
+        model: "gpt-5.5",
+        provider: "pi",
+      },
+    },
+    bindings: [
+      { chatId: 123, agentId: "main", kind: "dm" as const },
+      { chatId: 456, agentId: "pi", kind: "dm" as const },
+    ],
+    sessionDefaults: {
+      idleTimeoutMs: 60_000,
+      maxConcurrentSessions: 5,
+      maxMessageAgeMs: 300_000,
+      requireMention: false,
+      maxMediaBytes: 209715200,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionManager Pi session-id capture + resume", () => {
+  beforeEach(() => {
+    cleanup();
+    mkdirSync(TEST_DIR, { recursive: true });
+    claudeSpawnCaptures.length = 0;
+    piSpawnCaptures.length = 0;
+    nextPiSessionId = "pi-generated-id";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("captures the Pi-minted session id via get_state and persists it", async () => {
+    nextPiSessionId = "pi-generated-id";
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+
+    const session = await manager.getOrCreateSession("pi-chat", "pi");
+
+    // A fresh Pi spawn must NOT pass --session (no resume id).
+    assert.strictEqual(piSpawnCaptures.length, 1, "one Pi spawn");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, undefined, "fresh start: no resume id");
+
+    // The in-memory session adopts the Pi-minted id (not the local UUID).
+    assert.strictEqual(session.sessionId, "pi-generated-id", "session uses the captured Pi id");
+
+    // ...and the captured id is persisted for resume across restarts.
+    const store = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(
+      store.getSession("pi-chat")?.sessionId,
+      "pi-generated-id",
+      "captured Pi id is persisted to the store",
+    );
+
+    await manager.closeAll();
+  });
+
+  it("resumes a stored Pi session by spawning with the stored id as --session", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-resume", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-resume",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+    // On resume, Pi re-confirms the same id through get_state.
+    nextPiSessionId = "stored-pi-id";
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    const session = await manager.getOrCreateSession("pi-resume", "pi");
+
+    assert.strictEqual(piSpawnCaptures.length, 1, "one Pi spawn");
+    assert.strictEqual(
+      piSpawnCaptures[0].resumeSessionId,
+      "stored-pi-id",
+      "resume passes the stored Pi id as --session",
+    );
+    assert.strictEqual(session.sessionId, "stored-pi-id", "resumed session keeps its id");
+
+    await manager.closeAll();
+  });
+
+  it("falls back to the bot's local id when get_state surfaces no session id", async () => {
+    nextPiSessionId = null; // process goes idle without a SystemInit record
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    const session = await manager.getOrCreateSession("pi-noid", "pi");
+
+    // The session stays functional on its locally-generated id (resume just
+    // can't target it; Task 4 recovery handles a later "No session found").
+    assert.ok(session.sessionId.length > 0, "session keeps a usable local id");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, undefined, "fresh start: no resume id");
+
+    const store = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(
+      store.getSession("pi-noid")?.sessionId,
+      session.sessionId,
+      "the local id is persisted",
+    );
+
+    await manager.closeAll();
+  });
+
+  it("claude path bot-generates --session-id and never issues get_state (regression)", async () => {
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    const session = await manager.getOrCreateSession("claude-chat", "main");
+
+    assert.strictEqual(claudeSpawnCaptures.length, 1, "one claude spawn");
+    assert.strictEqual(claudeSpawnCaptures[0].resume, false, "fresh claude session does not resume");
+    assert.ok(
+      typeof claudeSpawnCaptures[0].sessionId === "string" && claudeSpawnCaptures[0].sessionId.length > 0,
+      "claude path bot-generates a --session-id",
+    );
+
+    // No get_state override: the session keeps the bot-generated id exactly.
+    assert.strictEqual(
+      session.sessionId,
+      claudeSpawnCaptures[0].sessionId,
+      "claude session keeps the bot-generated id (no Pi capture override)",
+    );
+    // The claude path must not have touched the Pi spawn path at all.
+    assert.strictEqual(piSpawnCaptures.length, 0, "claude path must not spawn a Pi process");
+
+    await manager.closeAll();
+  });
+});

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -48,6 +48,14 @@ const piSpawnCaptures: PiSpawnCapture[] = [];
  */
 let nextPiSessionId: string | null = "pi-generated-id";
 
+/**
+ * When set, the mocked sendPiGetState throws this error — models the
+ * spawn-then-exit race where the child dies after waitForSpawn resolves but
+ * before get_state is written (the real writePiCommand rejects a closed stdin).
+ * Capture must swallow it and fall back to the local id, never escaping spawn.
+ */
+let getStateError: Error | null = null;
+
 /** Create a mock ChildProcess that auto-emits 'spawn' on next tick. */
 function createAutoSpawnChild(): ChildProcess {
   const child = new EventEmitter() as unknown as ChildProcess;
@@ -149,7 +157,9 @@ mock.module("../pi-rpc-protocol.js", {
         ? createAutoSpawnChild()
         : createFailingPiChild(outcome.failStderr);
     },
-    sendPiGetState() {},
+    sendPiGetState() {
+      if (getStateError) throw getStateError;
+    },
     sendPiPrompt() {},
     async *readPiStream(): AsyncGenerator<StreamLine> {
       if (nextPiSessionId !== null) {
@@ -208,6 +218,7 @@ describe("SessionManager Pi session-id capture + resume", () => {
     piSpawnCaptures.length = 0;
     piSpawnOutcomes = [];
     nextPiSessionId = "pi-generated-id";
+    getStateError = null;
   });
 
   afterEach(() => {
@@ -284,6 +295,30 @@ describe("SessionManager Pi session-id capture + resume", () => {
     await manager.closeAll();
   });
 
+  it("get_state throwing (child died right after spawn) falls back to the local id, not an uncaught throw", async () => {
+    // Spawn succeeds (waitForSpawn resolves on 'spawn'), but the child dies before
+    // get_state is written, so sendPiGetState throws — the spawn-then-exit race.
+    getStateError = new Error("Pi RPC child process is not available");
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+
+    // getOrCreateSession must NOT reject: capture swallows the throw and the
+    // session falls back to the bot's local id.
+    const session = await manager.getOrCreateSession("pi-getstate-fail", "pi");
+
+    assert.strictEqual(piSpawnCaptures.length, 1, "one Pi spawn, no recovery loop");
+    assert.ok(session.sessionId.length > 0, "session keeps a usable local id");
+
+    const store = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(
+      store.getSession("pi-getstate-fail")?.sessionId,
+      session.sessionId,
+      "the local id is persisted",
+    );
+
+    await manager.closeAll();
+  });
+
   it("claude path bot-generates --session-id and never issues get_state (regression)", async () => {
     const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
     const session = await manager.getOrCreateSession("claude-chat", "main");
@@ -323,6 +358,7 @@ describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
     piSpawnCaptures.length = 0;
     piSpawnOutcomes = [];
     nextPiSessionId = "pi-generated-id";
+    getStateError = null;
     // The media-preserved assertion writes into /tmp/bot-media; clear the chat's
     // dir between runs so a prior run's file can't mask a regression.
     try { rmSync(sessionMediaDir("pi-keep"), { recursive: true, force: true }); } catch { /* ignore */ }

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -10,6 +10,10 @@ import type { AgentConfig, BotConfig, StreamLine } from "../types.js";
 import { log } from "../logger.js";
 import { piSessionResumeDiscarded } from "../metrics.js";
 import { ensureSessionMediaDir, sessionMediaDir } from "../media-store.js";
+// Real protocol helpers the spawn-path capture needs (parse get_state replies).
+// Resolved here BEFORE mock.module installs the stub, so these are the genuine
+// implementations; the stub below re-exports them so capture parses correctly.
+import { NewlineOnlyJsonlSplitter, parsePiEvent } from "../pi-rpc-protocol.js";
 
 const TEST_DIR = "/tmp/minime-test-pi-spawn";
 const TEST_STORE_PATH = `${TEST_DIR}/sessions.json`;
@@ -205,19 +209,30 @@ mock.module("../pi-rpc-protocol.js", {
       if ("failStderr" in outcome) return createFailingPiChild(outcome.failStderr);
       return createSpawnThenExitChild(outcome.spawnThenExitStderr);
     },
-    sendPiGetState() {
+    sendPiGetState(child: ChildProcess) {
       if (getStateError) throw getStateError;
-    },
-    sendPiPrompt() {},
-    async *readPiStream(child: ChildProcess): AsyncGenerator<StreamLine> {
-      // A child that spawned then died (createSpawnThenExitChild) emits no
-      // records — its stdout already ended. Force capture to return null so the
-      // post-spawn resume-failure path is exercised.
-      if ((child as unknown as { __resumeFailed?: boolean }).__resumeFailed) return;
+      // capturePiSessionId reads child.stdout directly (abortable), so model Pi's
+      // get_state reply by pushing the real JSONL record onto stdout. `null`
+      // models a process that answers without a session id: end the stream so
+      // capture returns promptly (close ends the read) instead of timing out.
+      const stdout = child.stdout as Readable | undefined;
+      if (!stdout) return;
       if (nextPiSessionId !== null) {
-        yield { type: "system", subtype: "init", session_id: nextPiSessionId };
+        stdout.push(
+          JSON.stringify({ type: "response", success: true, data: { sessionId: nextPiSessionId } }) + "\n",
+        );
+      } else {
+        stdout.push(null);
       }
     },
+    sendPiPrompt() {},
+    async *readPiStream(): AsyncGenerator<StreamLine> {
+      // Message-path reader (unused by the spawn-path capture, which now reads
+      // child.stdout directly). Present so session-manager's import resolves.
+    },
+    // Re-export the genuine parse helpers the capture uses.
+    NewlineOnlyJsonlSplitter,
+    parsePiEvent,
   },
 });
 
@@ -518,6 +533,46 @@ describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
     // The final failure feeds the normal crash backoff (restart count increments).
     const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
     assert.strictEqual(restartCounts.get("pi-doomed"), 1, "second failure increments the crash count");
+  });
+
+  it("preserves an accumulated crash count across a resume-recovery discard", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-flap", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-flap",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // Resume fails with the signal; the inline fresh re-spawn then succeeds.
+    piSpawnOutcomes = [{ failStderr: "No session found matching stored-pi-id" }];
+    nextPiSessionId = "fresh-pi-id";
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    // Seed a prior crash history. The recovery discard routes through
+    // destroySession → closeSession, which clears restartCounts; the fix must
+    // restore the count so a flapping chat keeps advancing toward the circuit
+    // breaker instead of resetting to zero on every recovery. (prevCrashCount=1
+    // triggers a ~5s crash backoff before the spawn — expected.)
+    const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
+    restartCounts.set("pi-flap", 1);
+
+    const warnSpy = mock.method(log, "warn", () => {});
+    let session;
+    try {
+      session = await manager.getOrCreateSession("pi-flap", "pi");
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    assert.strictEqual(session.sessionId, "fresh-pi-id", "recovered onto the fresh id");
+    assert.strictEqual(
+      restartCounts.get("pi-flap"),
+      1,
+      "prior crash count survives the recovery discard (not reset to 0)",
+    );
+
+    await manager.closeAll();
   });
 
   it("non-matching startup failure: no discard, stored id + media preserved, normal backoff", async () => {

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -89,13 +89,17 @@ function createAutoSpawnChild(): ChildProcess {
 
 /**
  * Per-spawn outcomes consumed FIFO by the mocked spawnPiRpcSession. Empty → the
- * default "ok" auto-spawn, so the Task 3 capture/resume tests are unaffected. A
- * `{ failStderr }` entry models a Pi process that fails startup: it never emits
- * 'spawn', exits 1, and exposes `failStderr` via the same piStartupStderr
- * accessor the real spawnPiRpcSession installs (Pi prints `No session found
- * matching <id>` and exits 1 when handed a stale --session).
+ * default "ok" auto-spawn, so the Task 3 capture/resume tests are unaffected.
+ *  - `{ failStderr }` models a Pi process that fails BEFORE 'spawn' (it never
+ *    emits 'spawn', exits 1 → waitForSpawn rejects). This is the rare edge path.
+ *  - `{ spawnThenExitStderr }` models the REAL `pi` timing for a stale --session:
+ *    it execs cleanly (emits 'spawn', so waitForSpawn RESOLVES) and only THEN
+ *    exits 1. The resume failure surfaces during the get_state capture, not as a
+ *    spawn rejection — the production path the recovery must actually cover.
+ * Both expose their stderr via the same piStartupStderr accessor the real
+ * spawnPiRpcSession installs (Pi prints `No session found matching <id>`).
  */
-type PiSpawnOutcome = "ok" | { failStderr: string };
+type PiSpawnOutcome = "ok" | { failStderr: string } | { spawnThenExitStderr: string };
 let piSpawnOutcomes: PiSpawnOutcome[] = [];
 
 /** A Pi child that fails startup (no 'spawn', exit 1) with buffered stderr. */
@@ -132,6 +136,50 @@ function createFailingPiChild(failStderr: string): ChildProcess {
   return child;
 }
 
+/**
+ * A Pi child that execs successfully (emits 'spawn', so waitForSpawn RESOLVES)
+ * and only THEN exits 1 with buffered stderr — the REAL `pi` timing for a stale
+ * --session. Node guarantees 'spawn' fires before all other events, so the
+ * resume failure does NOT reach the waitForSpawn catch; it surfaces when the
+ * get_state capture finds the child already dead. Marked `__resumeFailed` so the
+ * mocked readPiStream yields no SystemInit (a dead process emits no records),
+ * forcing capture to return null.
+ */
+function createSpawnThenExitChild(failStderr: string): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    stdin,
+    pid: Math.floor(Math.random() * 100000),
+    exitCode: null,
+    signalCode: null,
+    killed: false,
+    kill() {
+      (child as unknown as Record<string, unknown>).killed = true;
+      return true;
+    },
+  });
+
+  (child as unknown as { piStartupStderr: () => string }).piStartupStderr = () => failStderr;
+  (child as unknown as { __resumeFailed: boolean }).__resumeFailed = true;
+
+  // Real timing: 'spawn' fires first (waitForSpawn resolves and drops its exit
+  // listener), THEN exit 1. Set exitCode synchronously alongside the spawn emit
+  // so hasExited(child) is already true by the time the capture completes.
+  process.nextTick(() => {
+    child.emit("spawn");
+    (child as unknown as Record<string, unknown>).exitCode = 1;
+    child.emit("exit", 1, null);
+  });
+
+  return child;
+}
+
 // ---------------------------------------------------------------------------
 // Mock BOTH protocol modules BEFORE importing session-manager so the mocks are
 // in place when session-manager's static imports resolve. The spawn path needs
@@ -153,15 +201,19 @@ mock.module("../pi-rpc-protocol.js", {
     spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string) {
       piSpawnCaptures.push({ agent, resumeSessionId });
       const outcome = piSpawnOutcomes.shift() ?? "ok";
-      return outcome === "ok"
-        ? createAutoSpawnChild()
-        : createFailingPiChild(outcome.failStderr);
+      if (outcome === "ok") return createAutoSpawnChild();
+      if ("failStderr" in outcome) return createFailingPiChild(outcome.failStderr);
+      return createSpawnThenExitChild(outcome.spawnThenExitStderr);
     },
     sendPiGetState() {
       if (getStateError) throw getStateError;
     },
     sendPiPrompt() {},
-    async *readPiStream(): AsyncGenerator<StreamLine> {
+    async *readPiStream(child: ChildProcess): AsyncGenerator<StreamLine> {
+      // A child that spawned then died (createSpawnThenExitChild) emits no
+      // records — its stdout already ended. Force capture to return null so the
+      // post-spawn resume-failure path is exercised.
+      if ((child as unknown as { __resumeFailed?: boolean }).__resumeFailed) return;
       if (nextPiSessionId !== null) {
         yield { type: "system", subtype: "init", session_id: nextPiSessionId };
       }
@@ -523,5 +575,111 @@ describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
     // Existing crash backoff still applies.
     const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
     assert.strictEqual(restartCounts.get("pi-keep"), 1, "non-matching failure increments the crash count");
+  });
+
+  // The tests above drive failure via createFailingPiChild, which never emits
+  // 'spawn' — an edge that a real exec'd binary cannot produce. The tests below
+  // use createSpawnThenExitChild, which mirrors REAL `pi` timing: it execs
+  // (emits 'spawn', so waitForSpawn RESOLVES) and only THEN exits 1. This is the
+  // production path the recovery must cover — the failure surfaces during the
+  // get_state capture, not as a spawn rejection.
+
+  it("real pi timing (spawn then exit 1 with the signal): recovery still fires", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-real", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-real",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // The resume spawn execs then exits 1 with the signal (real timing); the
+    // inline fresh re-spawn then succeeds and get_state mints a new id.
+    piSpawnOutcomes = [{ spawnThenExitStderr: "No session found matching stored-pi-id" }];
+    nextPiSessionId = "fresh-pi-id";
+
+    const before = await discardedCount("pi");
+    const warnCalls: unknown[][] = [];
+    const warnSpy = mock.method(log, "warn", (...args: unknown[]) => { warnCalls.push(args); });
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    let session;
+    try {
+      session = await manager.getOrCreateSession("pi-real", "pi");
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // Exactly two spawns: the failed resume, then ONE inline fresh start — even
+    // though waitForSpawn RESOLVED for the failed resume (this is the bug fix).
+    assert.strictEqual(piSpawnCaptures.length, 2, "resume spawn + one inline fresh re-spawn");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, "stored-pi-id", "first spawn resumed the stored id");
+    assert.strictEqual(piSpawnCaptures[1].resumeSessionId, undefined, "recovery spawn starts fresh (no --session)");
+
+    assert.strictEqual(session.sessionId, "fresh-pi-id", "recovered session adopts the new Pi id");
+    const storeAfter = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(storeAfter.getSession("pi-real")?.sessionId, "fresh-pi-id", "fresh id persisted");
+
+    const recoveryWarns = warnCalls.filter(
+      (a) =>
+        a[0] === "session-manager" &&
+        typeof a[1] === "string" &&
+        (a[1] as string).includes("could not resume Pi session stored-pi-id — starting fresh"),
+    );
+    assert.strictEqual(recoveryWarns.length, 1, "exactly one recovery warning");
+    assert.strictEqual((await discardedCount("pi")) - before, 1, "metric incremented exactly once");
+
+    await manager.closeAll();
+  });
+
+  it("real pi timing (spawn then exit 1 with a non-matching error): no discard, crash count increments", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-real-keep", {
+      sessionId: "keep-pi-id",
+      chatId: "pi-real-keep",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // Execs then exits 1, but NOT with the "No session found" signal → no recovery.
+    piSpawnOutcomes = [{ spawnThenExitStderr: "codex: authentication token expired" }];
+
+    const before = await discardedCount("pi");
+    const warnCalls: unknown[][] = [];
+    const warnSpy = mock.method(log, "warn", (...args: unknown[]) => { warnCalls.push(args); });
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    try {
+      await assert.rejects(
+        () => manager.getOrCreateSession("pi-real-keep", "pi"),
+        /exited during startup/,
+        "a non-matching post-spawn exit propagates as a startup error",
+      );
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // Exactly one spawn — no inline recovery re-spawn.
+    assert.strictEqual(piSpawnCaptures.length, 1, "no recovery spawn for a non-matching failure");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, "keep-pi-id", "the resume attempt used the stored id");
+
+    // No discard: stored id preserved.
+    const storeAfter = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(storeAfter.getSession("pi-real-keep")?.sessionId, "keep-pi-id", "stored id preserved");
+
+    const recoveryWarns = warnCalls.filter(
+      (a) =>
+        a[0] === "session-manager" &&
+        typeof a[1] === "string" &&
+        (a[1] as string).includes("could not resume Pi session"),
+    );
+    assert.strictEqual(recoveryWarns.length, 0, "no recovery warning for a non-matching failure");
+    assert.strictEqual((await discardedCount("pi")) - before, 0, "metric not incremented");
+
+    // A post-spawn startup exit must still feed crash backoff (the bug fix also
+    // closes the gap where a spawned-then-died child created a session with no
+    // crash count and could tight-loop).
+    const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
+    assert.strictEqual(restartCounts.get("pi-real-keep"), 1, "post-spawn startup exit increments the crash count");
   });
 });

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -226,6 +226,7 @@ mock.module("../pi-rpc-protocol.js", {
       }
     },
     sendPiPrompt() {},
+    sendPiSteer() {},
     async *readPiStream(): AsyncGenerator<StreamLine> {
       // Message-path reader (unused by the spawn-path capture, which now reads
       // child.stdout directly). Present so session-manager's import resolves.

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, beforeEach, afterEach, mock } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { Readable, Writable } from "node:stream";
 import type { ChildProcess } from "node:child_process";
 import type { AgentConfig, BotConfig, StreamLine } from "../types.js";
+// Real (un-mocked) modules — the SAME singletons session-manager imports, so a
+// spy on log.warn and a read of piSessionResumeDiscarded observe its behavior.
+import { log } from "../logger.js";
+import { piSessionResumeDiscarded } from "../metrics.js";
+import { ensureSessionMediaDir, sessionMediaDir } from "../media-store.js";
 
 const TEST_DIR = "/tmp/minime-test-pi-spawn";
 const TEST_STORE_PATH = `${TEST_DIR}/sessions.json`;
@@ -74,6 +79,51 @@ function createAutoSpawnChild(): ChildProcess {
   return child;
 }
 
+/**
+ * Per-spawn outcomes consumed FIFO by the mocked spawnPiRpcSession. Empty → the
+ * default "ok" auto-spawn, so the Task 3 capture/resume tests are unaffected. A
+ * `{ failStderr }` entry models a Pi process that fails startup: it never emits
+ * 'spawn', exits 1, and exposes `failStderr` via the same piStartupStderr
+ * accessor the real spawnPiRpcSession installs (Pi prints `No session found
+ * matching <id>` and exits 1 when handed a stale --session).
+ */
+type PiSpawnOutcome = "ok" | { failStderr: string };
+let piSpawnOutcomes: PiSpawnOutcome[] = [];
+
+/** A Pi child that fails startup (no 'spawn', exit 1) with buffered stderr. */
+function createFailingPiChild(failStderr: string): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    stdin,
+    pid: Math.floor(Math.random() * 100000),
+    exitCode: null,
+    signalCode: null,
+    killed: false,
+    kill() {
+      (child as unknown as Record<string, unknown>).killed = true;
+      return true;
+    },
+  });
+
+  // Mirror spawnPiRpcSession: expose buffered startup stderr so the spawn-failure
+  // classifier can match Pi's "No session found matching" signal.
+  (child as unknown as { piStartupStderr: () => string }).piStartupStderr = () => failStderr;
+
+  // Fail startup: exit 1, never 'spawn' → waitForSpawn rejects with code=1.
+  process.nextTick(() => {
+    (child as unknown as Record<string, unknown>).exitCode = 1;
+    child.emit("exit", 1, null);
+  });
+
+  return child;
+}
+
 // ---------------------------------------------------------------------------
 // Mock BOTH protocol modules BEFORE importing session-manager so the mocks are
 // in place when session-manager's static imports resolve. The spawn path needs
@@ -94,7 +144,10 @@ mock.module("../pi-rpc-protocol.js", {
   namedExports: {
     spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string) {
       piSpawnCaptures.push({ agent, resumeSessionId });
-      return createAutoSpawnChild();
+      const outcome = piSpawnOutcomes.shift() ?? "ok";
+      return outcome === "ok"
+        ? createAutoSpawnChild()
+        : createFailingPiChild(outcome.failStderr);
     },
     sendPiGetState() {},
     sendPiPrompt() {},
@@ -153,6 +206,7 @@ describe("SessionManager Pi session-id capture + resume", () => {
     mkdirSync(TEST_DIR, { recursive: true });
     claudeSpawnCaptures.length = 0;
     piSpawnCaptures.length = 0;
+    piSpawnOutcomes = [];
     nextPiSessionId = "pi-generated-id";
   });
 
@@ -251,5 +305,187 @@ describe("SessionManager Pi session-id capture + resume", () => {
     assert.strictEqual(piSpawnCaptures.length, 0, "claude path must not spawn a Pi process");
 
     await manager.closeAll();
+  });
+});
+
+describe("SessionManager Pi graceful resume-recovery (Task 4)", () => {
+  /** Current value of the discard metric for an agent (0 if never set). */
+  async function discardedCount(agentId: string): Promise<number> {
+    const metric = await piSessionResumeDiscarded.get();
+    const entry = metric.values.find((v) => v.labels.agent_id === agentId);
+    return entry?.value ?? 0;
+  }
+
+  beforeEach(() => {
+    cleanup();
+    mkdirSync(TEST_DIR, { recursive: true });
+    claudeSpawnCaptures.length = 0;
+    piSpawnCaptures.length = 0;
+    piSpawnOutcomes = [];
+    nextPiSessionId = "pi-generated-id";
+    // The media-preserved assertion writes into /tmp/bot-media; clear the chat's
+    // dir between runs so a prior run's file can't mask a regression.
+    try { rmSync(sessionMediaDir("pi-keep"), { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    cleanup();
+    try { rmSync(sessionMediaDir("pi-keep"), { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("missing-session signal: discards once, warns once, increments metric, then starts fresh", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-stale", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-stale",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // The resume spawn fails with Pi's "No session found" signal; the inline
+    // fresh re-spawn then succeeds and get_state mints a new id.
+    piSpawnOutcomes = [{ failStderr: "No session found matching stored-pi-id" }];
+    nextPiSessionId = "fresh-pi-id";
+
+    const before = await discardedCount("pi");
+    const warnCalls: unknown[][] = [];
+    const warnSpy = mock.method(log, "warn", (...args: unknown[]) => { warnCalls.push(args); });
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    let session;
+    try {
+      session = await manager.getOrCreateSession("pi-stale", "pi");
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // Exactly two spawns: the failed resume, then ONE inline fresh start.
+    assert.strictEqual(piSpawnCaptures.length, 2, "resume spawn + one inline fresh re-spawn");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, "stored-pi-id", "first spawn resumed the stored id");
+    assert.strictEqual(piSpawnCaptures[1].resumeSessionId, undefined, "recovery spawn starts fresh (no --session)");
+
+    // The recovered session is live on the freshly-captured id, and it's persisted.
+    assert.strictEqual(session.sessionId, "fresh-pi-id", "recovered session adopts the new Pi id");
+    const storeAfter = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(storeAfter.getSession("pi-stale")?.sessionId, "fresh-pi-id", "fresh id persisted");
+
+    // Exactly one discard warning + one metric increment.
+    const recoveryWarns = warnCalls.filter(
+      (a) =>
+        a[0] === "session-manager" &&
+        typeof a[1] === "string" &&
+        (a[1] as string).includes("could not resume Pi session stored-pi-id — starting fresh"),
+    );
+    assert.strictEqual(recoveryWarns.length, 1, "exactly one recovery warning");
+    assert.strictEqual((await discardedCount("pi")) - before, 1, "metric incremented exactly once");
+
+    await manager.closeAll();
+  });
+
+  it("both spawns fail: discards once, warns once, then throws — no loop", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-doomed", {
+      sessionId: "stored-pi-id",
+      chatId: "pi-doomed",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // Resume fails with the signal; the inline fresh re-spawn ALSO fails. The
+    // second failure must propagate (no third spawn, no recursion).
+    piSpawnOutcomes = [
+      { failStderr: "No session found matching stored-pi-id" },
+      { failStderr: "still broken on the fresh start" },
+    ];
+
+    const before = await discardedCount("pi");
+    const warnCalls: unknown[][] = [];
+    const warnSpy = mock.method(log, "warn", (...args: unknown[]) => { warnCalls.push(args); });
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    try {
+      await assert.rejects(
+        () => manager.getOrCreateSession("pi-doomed", "pi"),
+        /exited during startup/,
+        "the second (fresh) failure propagates as a startup error",
+      );
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // At-most-once: exactly two spawn attempts (resume + one fresh), no loop.
+    assert.strictEqual(piSpawnCaptures.length, 2, "exactly two spawns — recovery does not loop");
+    assert.strictEqual(piSpawnCaptures[1].resumeSessionId, undefined, "recovery spawn was a fresh start");
+
+    // The discard + warn + metric ran exactly once despite the fresh start failing.
+    const recoveryWarns = warnCalls.filter(
+      (a) =>
+        a[0] === "session-manager" &&
+        typeof a[1] === "string" &&
+        (a[1] as string).includes("could not resume Pi session stored-pi-id — starting fresh"),
+    );
+    assert.strictEqual(recoveryWarns.length, 1, "exactly one recovery warning");
+    assert.strictEqual((await discardedCount("pi")) - before, 1, "metric incremented exactly once");
+
+    // The final failure feeds the normal crash backoff (restart count increments).
+    const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
+    assert.strictEqual(restartCounts.get("pi-doomed"), 1, "second failure increments the crash count");
+  });
+
+  it("non-matching startup failure: no discard, stored id + media preserved, normal backoff", async () => {
+    const store = new SessionStore(TEST_STORE_PATH);
+    store.setSession("pi-keep", {
+      sessionId: "keep-pi-id",
+      chatId: "pi-keep",
+      agentId: "pi",
+      lastActivity: Date.now(),
+    });
+
+    // A media file from a prior turn — a non-recovery failure must preserve it so
+    // a later successful resume can still reference it.
+    const mediaDir = ensureSessionMediaDir("pi-keep");
+    const mediaFile = `${mediaDir}/prior-turn.jpg`;
+    writeFileSync(mediaFile, "keep me");
+
+    // Resume fails, but NOT with the "No session found" signal → no recovery.
+    piSpawnOutcomes = [{ failStderr: "codex: authentication token expired" }];
+
+    const before = await discardedCount("pi");
+    const warnCalls: unknown[][] = [];
+    const warnSpy = mock.method(log, "warn", (...args: unknown[]) => { warnCalls.push(args); });
+
+    const manager = new SessionManager(() => makeConfig(), TEST_STORE_PATH);
+    try {
+      await assert.rejects(
+        () => manager.getOrCreateSession("pi-keep", "pi"),
+        /exited during startup/,
+        "a non-matching failure propagates unchanged",
+      );
+    } finally {
+      warnSpy.mock.restore();
+    }
+
+    // Exactly one spawn — no inline recovery re-spawn.
+    assert.strictEqual(piSpawnCaptures.length, 1, "no recovery spawn for a non-matching failure");
+    assert.strictEqual(piSpawnCaptures[0].resumeSessionId, "keep-pi-id", "the resume attempt used the stored id");
+
+    // No discard: stored id preserved (NOT deleted), media dir preserved.
+    const storeAfter = new SessionStore(TEST_STORE_PATH);
+    assert.strictEqual(storeAfter.getSession("pi-keep")?.sessionId, "keep-pi-id", "stored id preserved");
+    assert.ok(existsSync(mediaFile), "media file preserved on a non-recovery failure");
+
+    // No recovery warning, metric untouched.
+    const recoveryWarns = warnCalls.filter(
+      (a) =>
+        a[0] === "session-manager" &&
+        typeof a[1] === "string" &&
+        (a[1] as string).includes("could not resume Pi session"),
+    );
+    assert.strictEqual(recoveryWarns.length, 0, "no recovery warning for a non-matching failure");
+    assert.strictEqual((await discardedCount("pi")) - before, 0, "metric not incremented");
+
+    // Existing crash backoff still applies.
+    const restartCounts = (manager as unknown as Record<string, Map<string, number>>).restartCounts;
+    assert.strictEqual(restartCounts.get("pi-keep"), 1, "non-matching failure increments the crash count");
   });
 });

--- a/bot/src/__tests__/session-manager.test.ts
+++ b/bot/src/__tests__/session-manager.test.ts
@@ -1830,3 +1830,198 @@ describe("SessionManager gracefulShutdown", () => {
   });
 });
 
+describe("SessionManager provider dispatch", () => {
+  // Config with both a claude (absent provider) and a pi agent so the same
+  // manager can route either way depending on the message's agentId.
+  const dispatchConfig: BotConfig = {
+    ...testConfig,
+    agents: {
+      ...testConfig.agents,
+      pi: {
+        id: "pi",
+        workspaceCwd: "/tmp/test-workspace-pi",
+        model: "gpt-5.5",
+        provider: "pi",
+      },
+    },
+  };
+
+  beforeEach(() => {
+    cleanup();
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Build a mock child whose stdin writes are captured and whose stdout can be
+   * driven by the test. Mirrors the reuse-path pattern used elsewhere in this
+   * file (mock injected into the private active map — no module mocking).
+   */
+  function makeCapturingChild(): { child: ChildProcess; stdout: Readable; stdinWrites: string[] } {
+    const stdinWrites: string[] = [];
+    const stdout = new Readable({ read() {} });
+    const stderr = new Readable({ read() {} });
+    const stdin = new Writable({
+      write(chunk, _enc, cb) {
+        stdinWrites.push(chunk.toString());
+        cb();
+      },
+    });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(child, {
+      stdout, stderr, stdin,
+      pid: Math.floor(Math.random() * 100000),
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      kill(signal?: string) {
+        (child as unknown as Record<string, unknown>).killed = true;
+        process.nextTick(() => {
+          (child as unknown as Record<string, unknown>).exitCode = 0;
+          child.emit("exit", 0, signal ?? "SIGTERM");
+        });
+        return true;
+      },
+    });
+    return { child, stdout, stdinWrites };
+  }
+
+  function injectSession(
+    manager: InstanceType<typeof import("../session-manager.js").SessionManager>,
+    chatId: string,
+    agentId: string,
+    child: ChildProcess,
+  ): void {
+    const session: ActiveSession = {
+      child,
+      sessionId: `sid-${chatId}`,
+      agentId,
+      queue: new PQueue({ concurrency: 1 }),
+      idleTimer: null,
+      idleTimeoutMs: 60_000,
+      lastActivity: Date.now(),
+      processingStartedAt: null,
+      lastSuccessAt: null,
+      restartCount: 0,
+      outboxPath: `${TEST_DIR}/outbox-${chatId}`,
+      injectDir: `${TEST_DIR}/inject-${chatId}`,
+    };
+    (manager as unknown as Record<string, Map<string, ActiveSession>>).active.set(chatId, session);
+  }
+
+  it("routes a pi-provider session through sendPiPrompt + readPiStream", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const manager = new SessionManager(() => dispatchConfig, TEST_STORE_PATH);
+
+    const { child, stdout, stdinWrites } = makeCapturingChild();
+    injectSession(manager, "pi-chat", "pi", child);
+
+    const gen = manager.sendSessionMessage("pi-chat", "pi", "hello pi");
+
+    // Drive a multi-turn-shaped Pi run: per-turn boundary then the terminal
+    // agent_end. Only readPiStream/parsePiEvent translates agent_end into a
+    // terminal result — readStream would pass it through as a non-result line
+    // and the turn would never complete.
+    setTimeout(() => {
+      stdout.push(JSON.stringify({ type: "turn_end", sessionId: "pi-real" }) + "\n");
+      stdout.push(
+        JSON.stringify({
+          type: "agent_end",
+          sessionId: "pi-real",
+          messages: [
+            { role: "assistant", content: [{ type: "text", text: "final pi answer" }] },
+          ],
+        }) + "\n",
+      );
+    }, 30);
+
+    const lines: { type: string; result?: string }[] = [];
+    for await (const line of gen) {
+      lines.push(line as { type: string; result?: string });
+    }
+
+    // Send routed to sendPiPrompt → a Pi "prompt" command, NOT a claude user msg.
+    assert.ok(stdinWrites.length >= 1, "should have written to stdin");
+    const sent = JSON.parse(stdinWrites[0]);
+    assert.strictEqual(sent.type, "prompt", "pi path must write a Pi prompt command");
+    assert.strictEqual(sent.message, "hello pi");
+
+    // Read routed to readPiStream: agent_end became the single terminal result
+    // carrying the FINAL assistant text; turn_end produced no line.
+    const results = lines.filter((l) => l.type === "result");
+    assert.strictEqual(results.length, 1, "exactly one terminal result from agent_end");
+    assert.strictEqual(results[0].result, "final pi answer");
+
+    await manager.closeAll();
+  });
+
+  it("routes a claude/absent-provider session through sendMessage + readStream (regression)", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const manager = new SessionManager(() => dispatchConfig, TEST_STORE_PATH);
+
+    const { child, stdout, stdinWrites } = makeCapturingChild();
+    injectSession(manager, "claude-chat", "main", child);
+
+    const gen = manager.sendSessionMessage("claude-chat", "main", "hello claude");
+
+    // Claude path: a native stream-json result line terminates the turn.
+    setTimeout(() => {
+      stdout.push(
+        JSON.stringify({ type: "result", result: "ok claude", session_id: "sid-claude-chat" }) + "\n",
+      );
+    }, 30);
+
+    const lines: { type: string; result?: string }[] = [];
+    for await (const line of gen) {
+      lines.push(line as { type: string; result?: string });
+    }
+
+    // Send routed to sendMessage → a claude stream-json user message, NOT a Pi prompt.
+    assert.ok(stdinWrites.length >= 1, "should have written to stdin");
+    const sent = JSON.parse(stdinWrites[0]);
+    assert.strictEqual(sent.type, "user", "claude path must write a stream-json user message");
+    assert.deepStrictEqual(sent.message, { role: "user", content: "hello claude" });
+    assert.strictEqual(sent.session_id, "sid-claude-chat", "claude send must carry the session id");
+
+    // Read routed to readStream: the native result line passed through unchanged.
+    const results = lines.filter((l) => l.type === "result");
+    assert.strictEqual(results.length, 1, "claude result line terminates the turn");
+    assert.strictEqual(results[0].result, "ok claude");
+
+    await manager.closeAll();
+  });
+
+  it("claude path does not treat a Pi agent_end as terminal (proves readStream was used)", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const manager = new SessionManager(() => dispatchConfig, TEST_STORE_PATH);
+
+    const { child, stdout } = makeCapturingChild();
+    injectSession(manager, "claude-noterm", "main", child);
+
+    const gen = manager.sendSessionMessage("claude-noterm", "main", "hi");
+
+    // Push a Pi-only agent_end then close stdout. Under readStream this is a
+    // non-result line, so the turn never gets a result and the generator throws.
+    setTimeout(() => {
+      stdout.push(
+        JSON.stringify({
+          type: "agent_end",
+          messages: [{ role: "assistant", content: [{ type: "text", text: "nope" }] }],
+        }) + "\n",
+      );
+      stdout.push(null);
+    }, 30);
+
+    await assert.rejects(async () => {
+      for await (const _line of gen) {
+        // consume
+      }
+    }, /subprocess exited before sending a result/);
+
+    await manager.closeAll();
+  });
+});
+

--- a/bot/src/__tests__/session-manager.test.ts
+++ b/bot/src/__tests__/session-manager.test.ts
@@ -6,6 +6,7 @@ import { Readable, Writable, PassThrough } from "node:stream";
 import type { ChildProcess } from "node:child_process";
 import type { BotConfig } from "../types.js";
 import { waitForSpawn, outboxDir, type ActiveSession } from "../session-manager.js";
+import { piRetryTotal, piTurnDuration } from "../metrics.js";
 import PQueue from "p-queue";
 
 const TEST_DIR = "/tmp/minime-test-session-manager";
@@ -1830,6 +1831,70 @@ describe("SessionManager gracefulShutdown", () => {
     await taskPromise;
     await shutdownPromise;
   });
+
+  it("steers the shutdown notice into a busy Pi session instead of writing an inject file", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const manager = new SessionManager(() => testConfig, TEST_STORE_PATH);
+
+    const injectDir = `${TEST_DIR}/inject-pi-shutdown`;
+    mkdirSync(injectDir, { recursive: true });
+
+    // Capturing Pi child: the steer command lands on stdin (sendPiSteer writes it).
+    const stdinWrites: string[] = [];
+    const child = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(child, {
+      stdout: new Readable({ read() {} }),
+      stderr: new Readable({ read() {} }),
+      stdin: new Writable({ write(chunk, _enc, cb) { stdinWrites.push(chunk.toString()); cb(); } }),
+      pid: 4321,
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      kill() {
+        (child as unknown as Record<string, unknown>).killed = true;
+        (child as unknown as Record<string, unknown>).exitCode = 0;
+        child.emit("exit", 0, "SIGTERM");
+        return true;
+      },
+    });
+    child.emit("spawn");
+
+    const queue = new PQueue({ concurrency: 1 });
+    (manager as unknown as Record<string, Map<string, ActiveSession>>).active.set("pi-busy", {
+      child,
+      sessionId: "sid-pi-busy",
+      agentId: "main",
+      provider: "pi",
+      queue,
+      idleTimer: null,
+      idleTimeoutMs: 60_000,
+      lastActivity: Date.now(),
+      processingStartedAt: Date.now(),
+      lastSuccessAt: null,
+      restartCount: 0,
+      outboxPath: `${TEST_DIR}/outbox-pi-busy`,
+      injectDir,
+    });
+
+    // Keep the queue busy so gracefulShutdown has something to await.
+    let resolveTask!: () => void;
+    const taskPromise = queue.add(() => new Promise<void>((r) => { resolveTask = r; }));
+
+    const shutdownPromise = manager.gracefulShutdown(200);
+
+    // Pi path steered the notice into stdin as a `steer` command...
+    assert.strictEqual(stdinWrites.length, 1, "exactly one steer write to the Pi child");
+    const sent = JSON.parse(stdinWrites[0]);
+    assert.strictEqual(sent.type, "steer", "shutdown notice steered (not inject-file) for Pi");
+    assert.ok(sent.message.includes("shutting down"), "steer carries the shutdown notice");
+
+    // ...and did NOT fall back to the claude inject-file mechanism.
+    assert.strictEqual(existsSync(`${injectDir}/pending`), false, "Pi session must not get an inject file");
+
+    resolveTask();
+    await taskPromise;
+    await shutdownPromise;
+  });
 });
 
 describe("SessionManager provider dispatch", () => {
@@ -1958,6 +2023,56 @@ describe("SessionManager provider dispatch", () => {
     const results = lines.filter((l) => l.type === "result");
     assert.strictEqual(results.length, 1, "exactly one terminal result from agent_end");
     assert.strictEqual(results[0].result, "final pi answer");
+
+    await manager.closeAll();
+  });
+
+  it("records Pi read-loop telemetry: one retry per auto_retry_start (not auto_retry_end) + one turn duration", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    const manager = new SessionManager(() => dispatchConfig, TEST_STORE_PATH);
+
+    // Metrics are global/cumulative — measure this turn's contribution as a delta.
+    const retryCount = async (): Promise<number> =>
+      (await piRetryTotal.get()).values.find((v) => v.labels.agent_id === "pi")?.value ?? 0;
+    const turnDurationCount = async (): Promise<number> =>
+      (await piTurnDuration.get()).values.find(
+        (v) => v.metricName === "bot_pi_turn_duration_seconds_count" && v.labels.agent_id === "pi",
+      )?.value ?? 0;
+    const retryBefore = await retryCount();
+    const durBefore = await turnDurationCount();
+
+    const { child, stdout } = makeCapturingChild();
+    injectSession(manager, "pi-telemetry", "pi", child, "pi");
+
+    // A retry pair (start → end) followed by the terminal agent_end. The read
+    // loop must count the retry exactly once (on auto_retry_start; auto_retry_end
+    // signals recovery and would double-count) and record one turn duration.
+    setTimeout(() => {
+      stdout.push(JSON.stringify({ type: "auto_retry_start", errorMessage: "HTTP 429 rate limit" }) + "\n");
+      stdout.push(JSON.stringify({ type: "auto_retry_end", errorMessage: "HTTP 429 rate limit" }) + "\n");
+      stdout.push(
+        JSON.stringify({
+          type: "agent_end",
+          sessionId: "pi-real",
+          messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+        }) + "\n",
+      );
+    }, 30);
+
+    for await (const _line of manager.sendSessionMessage("pi-telemetry", "pi", "go")) {
+      void _line;
+    }
+
+    assert.strictEqual(
+      (await retryCount()) - retryBefore,
+      1,
+      "exactly one retry counted (auto_retry_start only; auto_retry_end must not double-count)",
+    );
+    assert.strictEqual(
+      (await turnDurationCount()) - durBefore,
+      1,
+      "exactly one Pi turn duration recorded on the terminal result",
+    );
 
     await manager.closeAll();
   });

--- a/bot/src/__tests__/session-manager.test.ts
+++ b/bot/src/__tests__/session-manager.test.ts
@@ -312,6 +312,7 @@ describe("SessionManager", () => {
       child: slowChild,
       sessionId: "race-sid",
       agentId: "main",
+      provider: "claude",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 100000,
@@ -1685,6 +1686,7 @@ describe("SessionManager gracefulShutdown", () => {
       child,
       sessionId: "test-session-" + chatId,
       agentId: "main",
+      provider: "claude",
       queue,
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1894,11 +1896,13 @@ describe("SessionManager provider dispatch", () => {
     chatId: string,
     agentId: string,
     child: ChildProcess,
+    provider: "claude" | "pi" = "claude",
   ): void {
     const session: ActiveSession = {
       child,
       sessionId: `sid-${chatId}`,
       agentId,
+      provider,
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1917,7 +1921,7 @@ describe("SessionManager provider dispatch", () => {
     const manager = new SessionManager(() => dispatchConfig, TEST_STORE_PATH);
 
     const { child, stdout, stdinWrites } = makeCapturingChild();
-    injectSession(manager, "pi-chat", "pi", child);
+    injectSession(manager, "pi-chat", "pi", child, "pi");
 
     const gen = manager.sendSessionMessage("pi-chat", "pi", "hello pi");
 
@@ -2020,6 +2024,98 @@ describe("SessionManager provider dispatch", () => {
         // consume
       }
     }, /subprocess exited before sending a result/);
+
+    await manager.closeAll();
+  });
+
+  it("dispatches on the spawn-time provider, not a hot-reloaded config (Pi child survives a config flip to claude)", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    // A mutable config the manager reloads on demand. The agent "main" is a
+    // claude (absent-provider) agent here; we inject a session pinned to "pi"
+    // (as if it had been spawned under a prior provider setting) and then flip
+    // the config so a fresh read would report claude for "main".
+    let liveConfig: BotConfig = dispatchConfig;
+    const manager = new SessionManager(() => liveConfig, TEST_STORE_PATH);
+
+    const { child, stdout, stdinWrites } = makeCapturingChild();
+    // Pin the session to Pi even though config["main"] is a claude agent.
+    injectSession(manager, "flip-chat", "main", child, "pi");
+
+    // Hot-reload: config now (still) reports "main" as a claude agent. A
+    // config-reading dispatch would route this through sendMessage/readStream
+    // and never terminate on a Pi agent_end. Pinned dispatch routes via Pi.
+    liveConfig = {
+      ...dispatchConfig,
+      agents: { ...dispatchConfig.agents, main: { id: "main", workspaceCwd: "/tmp/test-workspace", model: "claude-opus-4-6" } },
+    };
+
+    const gen = manager.sendSessionMessage("flip-chat", "main", "hello");
+
+    setTimeout(() => {
+      stdout.push(
+        JSON.stringify({
+          type: "agent_end",
+          sessionId: "pi-real",
+          messages: [{ role: "assistant", content: [{ type: "text", text: "pi answer" }] }],
+        }) + "\n",
+      );
+    }, 30);
+
+    const lines: { type: string; result?: string }[] = [];
+    for await (const line of gen) {
+      lines.push(line as { type: string; result?: string });
+    }
+
+    // Send routed via Pi (a "prompt" command), proving the pinned provider was used.
+    const sent = JSON.parse(stdinWrites[0]);
+    assert.strictEqual(sent.type, "prompt", "must dispatch via Pi (spawn-time provider), not the reloaded claude config");
+
+    // Read routed via readPiStream: the Pi agent_end became the terminal result.
+    const results = lines.filter((l) => l.type === "result");
+    assert.strictEqual(results.length, 1, "Pi agent_end terminated the turn");
+    assert.strictEqual(results[0].result, "pi answer");
+
+    await manager.closeAll();
+  });
+
+  it("an active session does not re-read config for provider: a broken hot-reload does not break dispatch", async () => {
+    const { SessionManager } = await import("../session-manager.js");
+    // Manager boots on a valid config (constructor validates once), then the
+    // loader starts throwing — modelling a hot-reload that produced a broken
+    // config file. An ALREADY-LIVE session must still dispatch: getOrCreateSession
+    // returns the existing child without reloading, and dispatch keys off the
+    // pinned provider, so no config read happens on the message path.
+    let broken = false;
+    const manager = new SessionManager(() => {
+      if (broken) throw new Error("config reload failed");
+      return dispatchConfig;
+    }, TEST_STORE_PATH);
+
+    const { child, stdout, stdinWrites } = makeCapturingChild();
+    injectSession(manager, "broken-cfg-chat", "main", child, "claude");
+
+    broken = true; // any later getFreshConfig() would now throw
+
+    const gen = manager.sendSessionMessage("broken-cfg-chat", "main", "hello");
+
+    setTimeout(() => {
+      stdout.push(
+        JSON.stringify({ type: "result", result: "ok", session_id: "sid-broken-cfg-chat" }) + "\n",
+      );
+    }, 30);
+
+    const lines: { type: string; result?: string }[] = [];
+    for await (const line of gen) {
+      lines.push(line as { type: string; result?: string });
+    }
+
+    // The turn completed normally despite the broken loader — no config read on
+    // the dispatch path. Send routed via the claude path (a stream-json user msg).
+    const sent = JSON.parse(stdinWrites[0]);
+    assert.strictEqual(sent.type, "user", "claude dispatch used the pinned provider, no config read");
+    const results = lines.filter((l) => l.type === "result");
+    assert.strictEqual(results.length, 1, "turn completed despite broken config reload");
+    assert.strictEqual(results[0].result, "ok");
 
     await manager.closeAll();
   });

--- a/bot/src/__tests__/telegram-bot.test.ts
+++ b/bot/src/__tests__/telegram-bot.test.ts
@@ -1820,10 +1820,14 @@ function makeLiveChild(): FakeChild {
   };
 }
 
-function fakeManager(provider: "claude" | "pi" | null, child: FakeChild): Pick<SessionManager, "getActive"> {
+function fakeManager(
+  provider: "claude" | "pi" | null,
+  child: FakeChild,
+  processingStartedAt: number | null = Date.now(),
+): Pick<SessionManager, "getActive"> {
   return {
     getActive: (_chatId: string) =>
-      (provider === null ? undefined : ({ child, provider } as unknown)) as never,
+      (provider === null ? undefined : ({ child, provider, processingStartedAt } as unknown)) as never,
   };
 }
 
@@ -1854,6 +1858,16 @@ describe("makeSteerFn", () => {
     const child = makeLiveChild();
     child.exitCode = 0;
     const steerFn = makeSteerFn(fakeManager("pi", child));
+    assert.strictEqual(steerFn("chat-1", "main", "x"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
+  });
+
+  it("returns false when a pinned-pi session is not actively processing (idle window after agent_end)", () => {
+    // processingStartedAt === null: session-manager has cleared it after
+    // agent_end but MessageQueue.busy may still be true. Steering here would
+    // hand the message to an idle Pi child and lose it; buffer instead.
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("pi", child, null));
     assert.strictEqual(steerFn("chat-1", "main", "x"), false);
     assert.strictEqual(child.stdin.writes.length, 0);
   });

--- a/bot/src/__tests__/telegram-bot.test.ts
+++ b/bot/src/__tests__/telegram-bot.test.ts
@@ -1,7 +1,7 @@
 process.env.TZ = "UTC";
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { resolveBinding, isAuthorized, sessionKey, isImageMimeType, imageExtensionForMime, buildSourcePrefix, shouldRespondInGroup, BOT_COMMANDS, isStaleMessage, buildReplyContext, buildForwardContext, extensionForDocument, formatFileSize, formatDocumentMeta, buildReactionContext, AUTO_RETRY_OPTIONS, createDraftSkipAutoRetryTransformer, extractMediaInfo, extensionForMedia, formatMediaMeta, createTelegramBot, extractChatContext, formatChatContextForLog, createApiErrorLoggingTransformer, resolveBindingLabel, BINDING_LABEL_NONE, BINDING_LABEL_UNBOUND } from "../telegram-bot.js";
+import { resolveBinding, isAuthorized, sessionKey, isImageMimeType, imageExtensionForMime, buildSourcePrefix, shouldRespondInGroup, BOT_COMMANDS, isStaleMessage, buildReplyContext, buildForwardContext, extensionForDocument, formatFileSize, formatDocumentMeta, buildReactionContext, AUTO_RETRY_OPTIONS, createDraftSkipAutoRetryTransformer, extractMediaInfo, extensionForMedia, formatMediaMeta, createTelegramBot, extractChatContext, formatChatContextForLog, createApiErrorLoggingTransformer, resolveBindingLabel, BINDING_LABEL_NONE, BINDING_LABEL_UNBOUND, makeSteerFn } from "../telegram-bot.js";
 import client from "prom-client";
 import { telegramApiCalls, telegramApiErrors } from "../metrics.js";
 import type { TelegramBinding, BotConfig } from "../types.js";
@@ -1798,5 +1798,63 @@ describe("createApiErrorLoggingTransformer — call counter", () => {
     const val = await telegramApiCalls.get();
     assert.strictEqual(findCall(val.values, "sendMessage", "unbound"), 1);
     assert.strictEqual(findCall(val.values, "getUpdates", "none"), 1);
+  });
+});
+
+// --- makeSteerFn (provider pinned to the session, not config) ---
+
+interface FakeChild {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  killed: boolean;
+  stdin: { destroyed: boolean; writes: string[]; write: (s: string) => void };
+}
+
+function makeLiveChild(): FakeChild {
+  const writes: string[] = [];
+  return {
+    exitCode: null,
+    signalCode: null,
+    killed: false,
+    stdin: { destroyed: false, writes, write: (s: string) => { writes.push(s); } },
+  };
+}
+
+function fakeManager(provider: "claude" | "pi" | null, child: FakeChild): Pick<SessionManager, "getActive"> {
+  return {
+    getActive: (_chatId: string) =>
+      (provider === null ? undefined : ({ child, provider } as unknown)) as never,
+  };
+}
+
+describe("makeSteerFn", () => {
+  it("steers (returns true) when the session is pinned provider:pi", () => {
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("pi", child));
+    // agentId param is whatever — only the session's pinned provider matters,
+    // so even a config snapshot claiming "claude" cannot mis-route this.
+    assert.strictEqual(steerFn("chat-1", "main", "mid-turn text"), true);
+    assert.strictEqual(child.stdin.writes.length, 1);
+    assert.ok(child.stdin.writes[0].includes("mid-turn text"));
+  });
+
+  it("falls to inject (returns false) when the session is pinned provider:claude", () => {
+    const child = makeLiveChild();
+    const steerFn = makeSteerFn(fakeManager("claude", child));
+    assert.strictEqual(steerFn("chat-1", "main", "mid-turn text"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
+  });
+
+  it("returns false when there is no active session", () => {
+    const steerFn = makeSteerFn(fakeManager(null, makeLiveChild()));
+    assert.strictEqual(steerFn("chat-1", "main", "x"), false);
+  });
+
+  it("returns false when the pinned-pi child has already exited", () => {
+    const child = makeLiveChild();
+    child.exitCode = 0;
+    const steerFn = makeSteerFn(fakeManager("pi", child));
+    assert.strictEqual(steerFn("chat-1", "main", "x"), false);
+    assert.strictEqual(child.stdin.writes.length, 0);
   });
 });

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -143,6 +143,14 @@ export function validateAgent(
   if (obj.model !== undefined && typeof obj.model !== "string") {
     throw new Error(`Agent "${id}" has invalid model (must be a string)`);
   }
+  // A Pi agent must not inherit the fleet-wide defaultModel: it is Claude-oriented
+  // (e.g. "opus"), and the Pi spawn path would prefix it into a nonsensical
+  // "openai-codex/opus" model string. Require an explicit, Pi-appropriate model.
+  if (obj.model === undefined && obj.provider === "pi") {
+    throw new Error(
+      `Agent "${id}" uses provider "pi" and must set an explicit model (the top-level defaultModel is Claude-oriented); e.g. model: "gpt-5.5"`,
+    );
+  }
   const model = obj.model ?? defaultModel;
   if (typeof model !== "string") {
     throw new Error(`Agent "${id}" missing model (and no top-level defaultModel set)`);

--- a/bot/src/discord-bot.ts
+++ b/bot/src/discord-bot.ts
@@ -4,7 +4,7 @@ import type { BotConfig, DiscordBinding, DiscordConfig } from "./types.js";
 import { outboxDir, hasExited, type SessionManager } from "./session-manager.js";
 import { sendPiSteer } from "./pi-rpc-protocol.js";
 import { relayStream } from "./stream-relay.js";
-import { MessageQueue } from "./message-queue.js";
+import { MessageQueue, type SteerFn } from "./message-queue.js";
 import { createDiscordAdapter, type DiscordSendableChannel } from "./discord-adapter.js";
 import { tempFilePath, downloadFile, transcribeAudio, cleanupTempFile } from "./voice.js";
 import { log } from "./logger.js";
@@ -153,6 +153,32 @@ export function installDiscordErrorHandlers(client: Client): void {
 }
 
 /**
+ * Build the provider-aware mid-turn delivery decision (mirrors telegram-bot.ts).
+ * Pi sessions have no PreToolUse inject hook, so a mid-turn message must be
+ * steered live into the running Pi child; the claude path keeps the inject-file
+ * mechanism (returns false). The decision is gated on the session's PINNED
+ * provider (set at spawn time), NOT the live config snapshot: a session spawned
+ * under a since-hot-reloaded provider would otherwise mis-route to the dead
+ * inject path and lose the message.
+ */
+export function makeSteerFn(
+  sessionManager: Pick<SessionManager, "getActive">,
+): SteerFn {
+  return (chatId: string, _agentId: string, text: string): boolean => {
+    const session = sessionManager.getActive(chatId);
+    if (!session || hasExited(session.child)) return false;
+    if (session.provider !== "pi") return false;
+    try {
+      sendPiSteer(session.child, text);
+      return true;
+    } catch (err) {
+      log.warn("discord-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
+      return false;
+    }
+  };
+}
+
+/**
  * Create and configure the Discord bot.
  * Returns a Client (already logged in) and a MessageQueue.
  */
@@ -177,23 +203,8 @@ export async function createDiscordBot(
 
   const maxMessageAgeMs = config.sessionDefaults.maxMessageAgeMs;
 
-  // Provider-aware mid-turn delivery (mirrors telegram-bot.ts). Pi sessions have
-  // no PreToolUse inject hook, so a mid-turn message must be steered live into
-  // the running Pi child; the claude path keeps the inject-file mechanism
-  // (steerFn returns false). Without this, a Pi mid-turn message on Discord would
-  // fall to the dead inject-file path and never reach the agent.
-  const steerFn = (chatId: string, agentId: string, text: string): boolean => {
-    if (config.agents[agentId]?.provider !== "pi") return false;
-    const session = sessionManager.getActive(chatId);
-    if (!session || hasExited(session.child)) return false;
-    try {
-      sendPiSteer(session.child, text);
-      return true;
-    } catch (err) {
-      log.warn("discord-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
-      return false;
-    }
-  };
+  // Provider-aware mid-turn delivery, gated on the session's pinned provider.
+  const steerFn = makeSteerFn(sessionManager);
 
   const messageQueue = new MessageQueue(
     async (chatId, agentId, text, platform, onAgentOwnership) => {

--- a/bot/src/discord-bot.ts
+++ b/bot/src/discord-bot.ts
@@ -1,7 +1,8 @@
 import { Client, GatewayIntentBits, Partials, Events, REST, Routes, SlashCommandBuilder } from "discord.js";
 import type { Message as DiscordMessage } from "discord.js";
 import type { BotConfig, DiscordBinding, DiscordConfig } from "./types.js";
-import { outboxDir, type SessionManager } from "./session-manager.js";
+import { outboxDir, hasExited, type SessionManager } from "./session-manager.js";
+import { sendPiSteer } from "./pi-rpc-protocol.js";
 import { relayStream } from "./stream-relay.js";
 import { MessageQueue } from "./message-queue.js";
 import { createDiscordAdapter, type DiscordSendableChannel } from "./discord-adapter.js";
@@ -176,11 +177,30 @@ export async function createDiscordBot(
 
   const maxMessageAgeMs = config.sessionDefaults.maxMessageAgeMs;
 
+  // Provider-aware mid-turn delivery (mirrors telegram-bot.ts). Pi sessions have
+  // no PreToolUse inject hook, so a mid-turn message must be steered live into
+  // the running Pi child; the claude path keeps the inject-file mechanism
+  // (steerFn returns false). Without this, a Pi mid-turn message on Discord would
+  // fall to the dead inject-file path and never reach the agent.
+  const steerFn = (chatId: string, agentId: string, text: string): boolean => {
+    if (config.agents[agentId]?.provider !== "pi") return false;
+    const session = sessionManager.getActive(chatId);
+    if (!session || hasExited(session.child)) return false;
+    try {
+      sendPiSteer(session.child, text);
+      return true;
+    } catch (err) {
+      log.warn("discord-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
+      return false;
+    }
+  };
+
   const messageQueue = new MessageQueue(
     async (chatId, agentId, text, platform, onAgentOwnership) => {
       const stream = sessionManager.sendSessionMessage(chatId, agentId, text);
       await relayStream(stream, platform, outboxDir(chatId), onAgentOwnership);
     },
+    { steerFn },
   );
 
   // Thread support: join threads on creation so we receive their messages

--- a/bot/src/discord-bot.ts
+++ b/bot/src/discord-bot.ts
@@ -168,6 +168,14 @@ export function makeSteerFn(
     const session = sessionManager.getActive(chatId);
     if (!session || hasExited(session.child)) return false;
     if (session.provider !== "pi") return false;
+    // Only steer when a Pi turn is actively processing. After `agent_end`,
+    // session-manager clears `processingStartedAt` while MessageQueue.busy can
+    // still be true (relay/cleanup of the final response is finishing). A
+    // message arriving in that window must NOT be steered: the Pi child has no
+    // active turn, Pi may reject the steer, and the parser drops failed
+    // side-command responses (pi-rpc-protocol.ts) — losing the message.
+    // Returning false buffers it so the queue drains it as a normal followup.
+    if (session.processingStartedAt === null) return false;
     try {
       sendPiSteer(session.child, text);
       return true;

--- a/bot/src/message-queue.ts
+++ b/bot/src/message-queue.ts
@@ -67,6 +67,16 @@ interface ChatQueueState {
   /** Whether a message is currently being processed */
   busy: boolean;
 
+  /**
+   * Number of mid-turn messages steered live to the provider during the
+   * current turn (Pi path). Reset to 0 at each turn start. Bounds live steers
+   * by `queueCap` so an authorized-chat flood cannot push unbounded messages
+   * into the Pi child's stdin / work queue — the same protection the claude
+   * collect buffer provides. Overflow falls through to the (also capped)
+   * collect-buffer path and is delivered as a followup or dropped.
+   */
+  steerCount: number;
+
   /** Latest platform context for sending responses */
   latestPlatform: PlatformContext | null;
 
@@ -134,6 +144,7 @@ export class MessageQueue {
         collectDropCleanups: [],
         deferredCleanups: [],
         busy: false,
+        steerCount: 0,
         latestPlatform: null,
         agentId,
         injectConsumed: 0,
@@ -192,7 +203,20 @@ export class MessageQueue {
       // buffered message would be re-delivered as a followup on drain. For the
       // claude path (or when no live Pi child is available) steerFn returns
       // false and we fall through to the inject-file mechanism below.
-      if (this.steerFn && this.steerFn(chatId, state.agentId, text)) {
+      //
+      // Cap live steers per turn at `queueCap`: an unbounded steer path would
+      // remove the flood protection the claude collect buffer provides (each
+      // steer writes to the Pi child's stdin / work queue). Past the cap we do
+      // NOT consult steerFn — we fall through to the (also capped) collect
+      // buffer, which delivers the overflow as a followup or drops it. The
+      // claude path never increments steerCount (steerFn returns false), so it
+      // is unaffected by this guard.
+      if (
+        this.steerFn &&
+        state.steerCount < this.queueCap &&
+        this.steerFn(chatId, state.agentId, text)
+      ) {
+        state.steerCount++;
         // Defer the turn-scoped cleanup: the steered text may reference a temp
         // file the agent still reads this turn (runs when the turn drains).
         // Drop the persistent-media drop-cleanup — the agent now owns the file,
@@ -267,6 +291,8 @@ export class MessageQueue {
     const dropCleanups = state.pendingDropCleanups.splice(0);
     state.debounceTimer = null;
     state.busy = true;
+    // New turn → fresh per-turn steer budget.
+    state.steerCount = 0;
 
     const combinedText = texts.length === 1 ? texts[0] : texts.join("\n\n");
 
@@ -373,6 +399,8 @@ export class MessageQueue {
       const prompt = buildCollectPrompt(collected);
 
       state.busy = true;
+      // New turn → fresh per-turn steer budget.
+      state.steerCount = 0;
       log.debug(
         "message-queue",
         `Draining ${collected.length} collected message(s) for ${chatId}`,

--- a/bot/src/message-queue.ts
+++ b/bot/src/message-queue.ts
@@ -25,6 +25,21 @@ export type ProcessFn = (
 /** Fire-and-forget cleanup callback (e.g. delete a temp file after processing). */
 export type CleanupFn = () => void;
 
+/**
+ * Provider-aware mid-turn delivery hook, consulted in the busy-turn branch
+ * BEFORE the inject-file path.
+ *
+ * Returns `true` if the message was delivered live to the running session (the
+ * Pi `steer` path): the queue then skips buffering it, since Pi has no inject
+ * hook and no ack mechanism — buffering would re-deliver the message as a
+ * followup when the turn drains.
+ *
+ * Returns `false` for the claude path (or when no live Pi child is available):
+ * the queue falls back to the inject-file mechanism (PreToolUse hook). Omitting
+ * the hook entirely ⇒ always the inject-file path (claude behavior unchanged).
+ */
+export type SteerFn = (chatId: string, agentId: string, text: string) => boolean;
+
 interface ChatQueueState {
   /** Messages pending debounce timer (pre-send) */
   pendingTexts: string[];
@@ -94,14 +109,16 @@ export class MessageQueue {
   private debounceMs: number;
   private queueCap: number;
   private processFn: ProcessFn;
+  private steerFn: SteerFn | null;
 
   constructor(
     processFn: ProcessFn,
-    options?: { debounceMs?: number; queueCap?: number },
+    options?: { debounceMs?: number; queueCap?: number; steerFn?: SteerFn },
   ) {
     this.processFn = processFn;
     this.debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
     this.queueCap = options?.queueCap ?? DEFAULT_QUEUE_CAP;
+    this.steerFn = options?.steerFn ?? null;
   }
 
   private getState(chatId: string, agentId: string): ChatQueueState {
@@ -168,6 +185,24 @@ export class MessageQueue {
         state.collectDropCleanups.splice(0, consumed);
         state.deferredCleanups.push(...consumedCleanups);
         state.injectConsumed = 0;
+      }
+
+      // Provider-aware mid-turn delivery. For Pi, deliver the message live via
+      // `steer` and do NOT buffer it: Pi has no inject hook + no ack, so a
+      // buffered message would be re-delivered as a followup on drain. For the
+      // claude path (or when no live Pi child is available) steerFn returns
+      // false and we fall through to the inject-file mechanism below.
+      if (this.steerFn && this.steerFn(chatId, state.agentId, text)) {
+        // Defer the turn-scoped cleanup: the steered text may reference a temp
+        // file the agent still reads this turn (runs when the turn drains).
+        // Drop the persistent-media drop-cleanup — the agent now owns the file,
+        // exactly like a hook-consumed inject message.
+        if (cleanup) state.deferredCleanups.push(cleanup);
+        log.debug(
+          "message-queue",
+          `Steered mid-turn message for ${chatId} (provider delivery)`,
+        );
+        return;
       }
 
       // Mid-turn collect: buffer the message

--- a/bot/src/metrics.ts
+++ b/bot/src/metrics.ts
@@ -86,6 +86,12 @@ export const piRetryUnknownTotal = new client.Counter({
   labelNames: ["agent_id"] as const,
 });
 
+export const piSessionResumeDiscarded = new client.Counter({
+  name: "bot_pi_session_resume_discarded_total",
+  help: "Pi resume attempts discarded after the stored session id was not found (graceful fresh start)",
+  labelNames: ["agent_id"] as const,
+});
+
 // --- Telegram API errors ---
 
 export const telegramApiErrors = new client.Counter({

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -265,8 +265,13 @@ function extractFinalAssistantText(messages: unknown): string {
  *   `assistantMessageEvent.delta` chunk (drives live streaming).
  * - `tool_execution_start` → synthetic `StreamEvent` shaped as a
  *   `content_block_start` tool_use block so stream-relay flips `sawNonTextBlock`.
- * - `turn_end` / `agent_end` → `ResultMessage`; the result text is reconstructed
- *   from the assistant message object (Pi sends an `AgentMessage`, never a string).
+ * - `agent_end` → terminal `ResultMessage`; the result text is the FINAL assistant
+ *   message text reconstructed from `agent_end.messages`. `agent_end` fires exactly
+ *   once at the very end of a run.
+ * - `turn_end` → `null`. It is a per-turn boundary that fires once PER turn, so a
+ *   multi-turn (tool-using) response emits several `turn_end`s before its single
+ *   `agent_end`. Treating `turn_end` as terminal truncates such responses at their
+ *   first turn — only `agent_end` is terminal.
  * - `response` → a successful `get_state`/`get_session_stats` reply yields a
  *   `SystemInit` capturing `data.sessionId` (the ONLY place Pi exposes the
  *   session id — no event carries it); a failed reply (`success: false`) yields
@@ -313,13 +318,15 @@ export function parsePiEvent(rawEvent: PiRpcEvent | null | undefined): StreamLin
     }
 
     case "turn_end":
+      // Per-turn boundary, NOT terminal. A multi-turn (tool-using) response fires
+      // turn_end once per turn; the run only truly ends at agent_end (fires once).
+      // Mapping turn_end to a ResultMessage truncates such responses at turn 1.
+      return null;
+
     case "agent_end": {
       const result: ResultMessage = {
         type: "result",
-        result:
-          rawEvent.type === "agent_end"
-            ? extractFinalAssistantText(rawEvent.messages)
-            : extractAssistantText(rawEvent.message),
+        result: extractFinalAssistantText(rawEvent.messages),
         session_id: rawEvent.sessionId ?? "",
       };
       return result;

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -150,6 +150,17 @@ export function buildPiSpawnEnv(agent: AgentConfig): Record<string, string> {
   return env;
 }
 
+/**
+ * Startup diagnostics stashed on a Pi child by `spawnPiRpcSession` so the spawn
+ * caller can classify a startup failure WITHOUT re-piping stderr. `piStartupStderr()`
+ * returns the stderr buffered since spawn — the spawn caller matches it against
+ * `No session found matching` to detect an unresumable stored session (and start
+ * fresh once). The exit code is read directly from `child.exitCode`.
+ */
+export interface PiStartupDiagnostics {
+  piStartupStderr?: () => string;
+}
+
 export function spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string): ChildProcess {
   const child = spawn(PI_BIN, buildPiSpawnArgs(agent, resumeSessionId), {
     env: buildPiSpawnEnv(agent),
@@ -157,12 +168,19 @@ export function spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string):
     stdio: ["pipe", "pipe", "pipe"],
   });
 
+  // Buffer startup stderr so the spawn caller can classify a resume failure
+  // (Pi prints `No session found matching <id>` and exits 1 when handed a stale
+  // --session). Keep the existing log.warn so stderr stays visible in logs.
+  let stderrBuffer = "";
   child.stderr?.on("data", (chunk: Buffer | string) => {
-    const text = chunk.toString().trimEnd();
+    const raw = chunk.toString();
+    stderrBuffer += raw;
+    const text = raw.trimEnd();
     if (text) {
       log.warn("pi-rpc", text);
     }
   });
+  (child as unknown as PiStartupDiagnostics).piStartupStderr = () => stderrBuffer;
 
   return child;
 }

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -331,8 +331,11 @@ function extractFinalAssistantText(messages: unknown): string {
  *   first turn — only `agent_end` is terminal.
  * - `response` → a successful `get_state`/`get_session_stats` reply yields a
  *   `SystemInit` capturing `data.sessionId` (the ONLY place Pi exposes the
- *   session id — no event carries it); a failed reply (`success: false`) yields
- *   an error `ResultMessage` so a rejected command is not silently swallowed.
+ *   session id — no event carries it). A failed reply (`success: false`) is
+ *   correlated by `command`: a failed `prompt` yields an error `ResultMessage`
+ *   (the turn cannot proceed), but a failed side-command (`steer`, `get_state`,
+ *   `set_model`, …) returns null + logs — mapping it to a terminal result would
+ *   truncate the in-flight prompt turn whose stdout it shares.
  * - `auto_retry_start` / `auto_retry_end` → `RateLimitEvent` (raw error message
  *   preserved for the Task 4 retry classifier).
  * - `error` → error `ResultMessage` (`subtype: "error_during_execution"`).
@@ -390,18 +393,37 @@ export function parsePiEvent(rawEvent: PiRpcEvent | null | undefined): StreamLin
     }
 
     case "response": {
-      // Command responses are not stream content. Two are actionable: a failed
-      // command surfaces its error, and a successful get_state/get_session_stats
-      // reply carries the Pi-generated session id (no event exposes it).
+      // Command responses are side-channel replies, NOT prompt-turn stream
+      // content. The terminal event of a prompt turn is `agent_end` (or a
+      // top-level `error`). A `response` shares the same stdout the active turn
+      // is reading, so it must be correlated by `command` before being treated
+      // as terminal:
+      //  - a failed `prompt` response IS terminal — the prompt was rejected, so
+      //    no `agent_end` will ever arrive; surface it as an error result so the
+      //    turn ends now instead of hanging until the activity timeout.
+      //  - a failed side-command response (`steer`, `get_state`, `set_model`, …)
+      //    must NOT be mapped to a terminal result: a mid-turn `steer` rejection
+      //    would otherwise truncate the in-flight response (and the steered
+      //    message has already been dropped from the queue). Log + return null so
+      //    the failure is visible without ending the turn.
+      // A successful `get_state`/`get_session_stats` reply carries the Pi-minted
+      // session id (no event exposes it) and is captured below.
       if (rawEvent.success === false) {
-        const result: ResultMessage = {
-          type: "result",
-          subtype: "error_during_execution",
-          result: rawEvent.error ?? "Pi RPC command failed",
-          session_id: "",
-          is_error: true,
-        };
-        return result;
+        if (rawEvent.command === "prompt") {
+          const result: ResultMessage = {
+            type: "result",
+            subtype: "error_during_execution",
+            result: rawEvent.error ?? "Pi RPC command failed",
+            session_id: "",
+            is_error: true,
+          };
+          return result;
+        }
+        log.warn(
+          "pi-rpc",
+          `Pi RPC command failed (ignored in stream): command=${rawEvent.command ?? "unknown"} error=${rawEvent.error ?? "(none)"}`,
+        );
+        return null;
       }
       const sessionId = rawEvent.data?.sessionId;
       if (typeof sessionId === "string" && sessionId.length > 0) {

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -501,7 +501,7 @@ export async function* readPiStream(child: ChildProcess): AsyncGenerator<StreamL
   }
 }
 
-function parsePiRecord(record: string): StreamLine | null {
+export function parsePiRecord(record: string): StreamLine | null {
   const trimmed = record.trim();
   if (!trimmed || !trimmed.startsWith("{")) {
     return null;

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -161,6 +161,9 @@ export interface PiStartupDiagnostics {
   piStartupStderr?: () => string;
 }
 
+/** Cap on buffered startup stderr (the classifier only needs the startup tail). */
+const PI_STARTUP_STDERR_CAP = 64 * 1024;
+
 export function spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string): ChildProcess {
   const child = spawn(PI_BIN, buildPiSpawnArgs(agent, resumeSessionId), {
     env: buildPiSpawnEnv(agent),
@@ -171,10 +174,15 @@ export function spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string):
   // Buffer startup stderr so the spawn caller can classify a resume failure
   // (Pi prints `No session found matching <id>` and exits 1 when handed a stale
   // --session). Keep the existing log.warn so stderr stays visible in logs.
+  // Cap the buffer: the only consumer is the startup classifier, and the signal
+  // it matches appears in the first chunk(s); without a cap a long-lived, chatty
+  // Pi session would accumulate all stderr in memory for the child's lifetime.
   let stderrBuffer = "";
   child.stderr?.on("data", (chunk: Buffer | string) => {
     const raw = chunk.toString();
-    stderrBuffer += raw;
+    if (stderrBuffer.length < PI_STARTUP_STDERR_CAP) {
+      stderrBuffer += raw;
+    }
     const text = raw.trimEnd();
     if (text) {
       log.warn("pi-rpc", text);

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -24,7 +24,17 @@ export interface PiSteerCommand {
   message: string;
 }
 
-export type PiRpcCommand = PiPromptCommand | PiSteerCommand;
+/**
+ * `get_state` is a no-argument RPC command whose successful `response` is the
+ * ONLY place Pi exposes the session id it minted (no agent event carries it).
+ * Issued once right after spawn to capture + persist that id for `--session`
+ * resume across restarts.
+ */
+export interface PiGetStateCommand {
+  type: "get_state";
+}
+
+export type PiRpcCommand = PiPromptCommand | PiSteerCommand | PiGetStateCommand;
 
 /**
  * Pi RPC uses strict JSONL framing: LF is the only record delimiter.
@@ -92,7 +102,7 @@ function normalizePiModel(model: string | undefined): string {
   return trimmed.includes("/") ? trimmed : `${PI_PROVIDER}/${trimmed}`;
 }
 
-export function buildPiSpawnArgs(agent: AgentConfig): string[] {
+export function buildPiSpawnArgs(agent: AgentConfig, resumeSessionId?: string): string[] {
   const args = [
     "--mode", "rpc",
     "--provider", PI_PROVIDER,
@@ -101,6 +111,14 @@ export function buildPiSpawnArgs(agent: AgentConfig): string[] {
 
   if (agent.systemPrompt) {
     args.push("--append-system-prompt", agent.systemPrompt);
+  }
+
+  // Pi mints its own session id (the bot cannot pre-assign one as it does for
+  // claude via --session-id). When resuming a stored session, point Pi at the
+  // captured id with --session; on a fresh start, omit it entirely (passing an
+  // unknown id makes Pi exit 1 with "No session found matching").
+  if (resumeSessionId) {
+    args.push("--session", resumeSessionId);
   }
 
   return args;
@@ -132,8 +150,8 @@ export function buildPiSpawnEnv(agent: AgentConfig): Record<string, string> {
   return env;
 }
 
-export function spawnPiRpcSession(agent: AgentConfig): ChildProcess {
-  const child = spawn(PI_BIN, buildPiSpawnArgs(agent), {
+export function spawnPiRpcSession(agent: AgentConfig, resumeSessionId?: string): ChildProcess {
+  const child = spawn(PI_BIN, buildPiSpawnArgs(agent, resumeSessionId), {
     env: buildPiSpawnEnv(agent),
     cwd: agent.workspaceCwd,
     stdio: ["pipe", "pipe", "pipe"],
@@ -157,12 +175,25 @@ export function buildPiSteerCommand(text: string): PiSteerCommand {
   return { type: "steer", message: text };
 }
 
+export function buildGetStateCommand(): PiGetStateCommand {
+  return { type: "get_state" };
+}
+
 export function sendPiPrompt(child: ChildProcess, text: string): void {
   writePiCommand(child, buildPiPromptCommand(text));
 }
 
 export function sendPiSteer(child: ChildProcess, text: string): void {
   writePiCommand(child, buildPiSteerCommand(text));
+}
+
+/**
+ * Issue a `get_state` command. Its successful `response` carries the Pi-minted
+ * session id, which `parsePiEvent` surfaces as a `SystemInit` — the bot's only
+ * hook for capturing + persisting that id for resume.
+ */
+export function sendPiGetState(child: ChildProcess): void {
+  writePiCommand(child, buildGetStateCommand());
 }
 
 function writePiCommand(child: ChildProcess, command: PiRpcCommand): void {
@@ -393,13 +424,19 @@ export function parsePiEvent(rawEvent: PiRpcEvent | null | undefined): StreamLin
  * JSON records and untranslatable events are skipped (never throw mid-stream).
  */
 export async function* readPiStream(child: ChildProcess): AsyncGenerator<StreamLine> {
-  if (!child.stdout) {
+  const stdout = child.stdout;
+  if (!stdout) {
     throw new Error("Pi RPC child process stdout is not available");
   }
 
   const splitter = new NewlineOnlyJsonlSplitter();
 
-  for await (const chunk of child.stdout) {
+  // destroyOnReturn:false honors the single-consumer handoff contract: the
+  // spawn-path get_state capture opens this generator, reads the one SystemInit
+  // record, then calls generator.return() to stop. A default async iterator would
+  // destroy child.stdout on that early return, breaking every later
+  // sendSessionMessage (each opens a fresh readPiStream on the same stdout).
+  for await (const chunk of stdout.iterator({ destroyOnReturn: false })) {
     for (const record of splitter.push(chunk as Buffer)) {
       const line = parsePiRecord(record);
       if (line) {

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -28,7 +28,7 @@ export function outboxDir(chatId: string): string {
 }
 
 /** Check whether a child process has exited (by exit code or signal). */
-function hasExited(child: ChildProcess): boolean {
+export function hasExited(child: ChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
 }
 

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -3,10 +3,11 @@ import { createWriteStream, mkdirSync, rmSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { on } from "node:events";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig, AgentConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream, parsePiEvent, NewlineOnlyJsonlSplitter, type PiRpcEvent, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
 import { recordResultMetrics, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
@@ -43,15 +44,22 @@ function piStartupStderr(child: ChildProcess): string {
 }
 
 /**
- * Drive a translated Pi stream until the first SystemInit record and return its
- * session_id, or null if the generator ends without one. Used by the spawn-path
- * get_state capture to read exactly the id record.
+ * Parse one raw JSONL record from a Pi child's stdout and, if it is a SystemInit
+ * (get_state) record, return its non-empty session_id; otherwise null. Mirrors
+ * `parsePiRecord` in pi-rpc-protocol but yields only the id the capture needs.
  */
-async function readSystemInitSessionId(stream: AsyncGenerator<StreamLine>): Promise<string | null> {
-  for await (const line of stream) {
-    if (line.type === "system" && typeof line.session_id === "string" && line.session_id.length > 0) {
-      return line.session_id;
-    }
+function parsePiSystemInitId(record: string): string | null {
+  const trimmed = record.trim();
+  if (!trimmed.startsWith("{")) return null;
+  let parsed: PiRpcEvent;
+  try {
+    parsed = JSON.parse(trimmed) as PiRpcEvent;
+  } catch {
+    return null;
+  }
+  const line = parsePiEvent(parsed);
+  if (line && line.type === "system" && typeof line.session_id === "string" && line.session_id.length > 0) {
+    return line.session_id;
   }
   return null;
 }
@@ -183,27 +191,50 @@ export class SessionManager {
    * id, and a later resume that can't match falls to Task 4 recovery.
    */
   private async capturePiSessionId(child: ChildProcess): Promise<string | null> {
-    const stream = readPiStream(child);
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const timeout = new Promise<null>((resolve) => {
-      timer = setTimeout(() => resolve(null), STARTUP_TIMEOUT_MS);
-    });
+    const stdout = child.stdout;
+    // No stdout, or the child already died during/just-after spawn: nothing to
+    // read. Return null so the caller falls back to the local id (or, if the
+    // child exited, classifies the failure for recovery via hasExited).
+    if (!stdout || hasExited(child)) return null;
+
+    // Read stdout directly with an abortable listener rather than an
+    // async-generator over stdout.iterator(): a generator early-return/timeout
+    // leaves a queued return() blocked behind a pending next() on an
+    // alive-but-idle stdout (destroyOnReturn:false never forces it to settle),
+    // which would wedge session creation forever. `on(...)` removes its stdout
+    // listeners synchronously on abort/return, and `close` ends the read when
+    // the stream closes; a child 'exit' aborts promptly as a backstop.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), STARTUP_TIMEOUT_MS);
+    const onExit = () => controller.abort();
+    child.once("exit", onExit);
+    const splitter = new NewlineOnlyJsonlSplitter();
     try {
       sendPiGetState(child);
-      return await Promise.race([readSystemInitSessionId(stream), timeout]);
+      for await (const [chunk] of on(stdout, "data", { signal: controller.signal, close: ["close"] })) {
+        for (const record of splitter.push(chunk as Buffer)) {
+          const id = parsePiSystemInitId(record);
+          if (id) return id;
+        }
+      }
+      return null;
     } catch (err) {
-      // get_state can throw if the child died between waitForSpawn resolving and
-      // this write (a spawn-then-exit race): sendPiGetState rejects a closed
-      // stdin. Swallow it — capture is best-effort. The session stays usable on
-      // its local id and a dead child surfaces through normal crash recovery on
-      // the next message, rather than as an uncaught rejection out of spawn.
-      log.warn("session-manager", `Pi get_state capture failed: ${(err as Error).message}`);
+      // Aborted (timeout or child exit) is an expected best-effort end: the
+      // session stays usable on its local id. Otherwise sendPiGetState may have
+      // thrown on a closed stdin (a spawn-then-exit race) — swallow it too, but
+      // log, so a dead child surfaces via normal crash recovery on the next
+      // message rather than as an uncaught rejection out of spawn.
+      if (!controller.signal.aborted) {
+        log.warn("session-manager", `Pi get_state capture failed: ${(err as Error).message}`);
+      }
       return null;
     } finally {
-      if (timer) clearTimeout(timer);
-      // Stop the generator so child.stdout is handed off cleanly to the next
-      // reader (readPiStream uses destroyOnReturn:false, so stdout survives).
-      await stream.return(undefined);
+      clearTimeout(timer);
+      child.removeListener("exit", onExit);
+      controller.abort();
+      // Hand stdout back idle (no flowing listeners) so the next per-message
+      // readPiStream takes over cleanly; buffered chunks survive the pause.
+      stdout.pause();
     }
   }
 
@@ -229,9 +260,19 @@ export class SessionManager {
     agent: AgentConfig,
     staleSessionId: string,
   ): Promise<ChildProcess> {
+    // destroySession → closeSession clears restartCounts (so /reconnect can
+    // unblock a circuit-broken chat). A resume-recovery is NOT a clean reconnect:
+    // if this chat had already accumulated crashes, wiping that history would let
+    // a flapping session keep resetting toward zero and never trip the circuit
+    // breaker. Snapshot the count and restore it across the discard so startup
+    // failures stay cumulative.
+    const preservedCrashCount = this.restartCounts.get(chatId);
     // Discard the unresumable stored id (deletes the store record + wipes the
     // chat media dir, which is data-destructive by design here).
     await this.destroySession(chatId);
+    if (preservedCrashCount !== undefined) {
+      this.restartCounts.set(chatId, preservedCrashCount);
+    }
     // destroySession wiped the media dir; recreate it for the fresh start.
     ensureSessionMediaDir(chatId);
     log.warn("session-manager", `could not resume Pi session ${staleSessionId} — starting fresh`);

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, readPiStream } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
 import { recordResultMetrics, sessionsActive, sessionCrashes } from "./metrics.js";
@@ -30,6 +30,20 @@ export function outboxDir(chatId: string): string {
 /** Check whether a child process has exited (by exit code or signal). */
 function hasExited(child: ChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
+}
+
+/**
+ * Drive a translated Pi stream until the first SystemInit record and return its
+ * session_id, or null if the generator ends without one. Used by the spawn-path
+ * get_state capture to read exactly the id record.
+ */
+async function readSystemInitSessionId(stream: AsyncGenerator<StreamLine>): Promise<string | null> {
+  for await (const line of stream) {
+    if (line.type === "system" && typeof line.session_id === "string" && line.session_id.length > 0) {
+      return line.session_id;
+    }
+  }
+  return null;
 }
 
 export interface ActiveSession {
@@ -148,6 +162,34 @@ export class SessionManager {
   }
 
   /**
+   * Capture the Pi-minted session id by issuing get_state and reading the single
+   * SystemInit record it produces, then stopping the generator. Pi (unlike the
+   * claude path, where the bot pre-assigns --session-id) mints its own id and
+   * exposes it ONLY through a get_state response. Honors the single-consumer
+   * contract: this is the lone reader of child.stdout during spawn and is fully
+   * stopped (generator.return) before any sendSessionMessage opens its own fresh
+   * readPiStream. Returns null on timeout or if no id surfaces (e.g. the process
+   * went idle without a system record) — the session stays usable on its local
+   * id, and a later resume that can't match falls to Task 4 recovery.
+   */
+  private async capturePiSessionId(child: ChildProcess): Promise<string | null> {
+    const stream = readPiStream(child);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), STARTUP_TIMEOUT_MS);
+    });
+    try {
+      sendPiGetState(child);
+      return await Promise.race([readSystemInitSessionId(stream), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      // Stop the generator so child.stdout is handed off cleanly to the next
+      // reader (readPiStream uses destroyOnReturn:false, so stdout survives).
+      await stream.return(undefined);
+    }
+  }
+
+  /**
    * Get or create a session for a given chatId.
    * If a session exists in memory with a live process, reuse it.
    * If a session exists in store but process is dead, respawn with --resume.
@@ -222,11 +264,11 @@ export class SessionManager {
     ensureSessionMediaDir(chatId);
 
     // Spawn the agent subprocess. Pi dispatches via the Pi RPC protocol; the
-    // claude/absent path is byte-identical to before. (Pi resume — passing the
-    // captured session id — is wired by a later task; here a Pi spawn always
-    // starts fresh.)
+    // claude/absent path is byte-identical to before. For Pi, only a genuine
+    // resume points --session at the stored (Pi-minted) id; a fresh start omits
+    // it (an unknown id makes Pi exit with "No session found matching").
     const child = agent.provider === "pi"
-      ? spawnPiRpcSession(agent)
+      ? spawnPiRpcSession(agent, resume ? sessionId : undefined)
       : spawnClaudeSession({
           agent,
           sessionId,
@@ -267,6 +309,19 @@ export class SessionManager {
     // Pipe stderr to log file
     this.setupStderrLogging(chatId, child);
 
+    // For Pi, the session id is minted by the Pi process — capture it now via
+    // get_state (the only place Pi exposes it) so it can be persisted and used
+    // to --session-resume after a restart. The claude/absent path keeps the
+    // bot-generated id untouched. Falls back to the local id if capture yields
+    // nothing (session stays functional; a later resume just can't target it).
+    let effectiveSessionId = sessionId;
+    if (agent.provider === "pi") {
+      const piSessionId = await this.capturePiSessionId(child);
+      if (piSessionId) {
+        effectiveSessionId = piSessionId;
+      }
+    }
+
     // Restart/crash count accumulates via setupCrashRecovery and survives
     // active.delete(). Reset to 0 for fresh sessions (no existing, no resume).
     const restartCount = this.restartCounts.get(chatId) ?? 0;
@@ -276,7 +331,7 @@ export class SessionManager {
 
     const session: ActiveSession = {
       child,
-      sessionId,
+      sessionId: effectiveSessionId,
       agentId,
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, readPiStream } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
 import { recordResultMetrics, sessionsActive, sessionCrashes } from "./metrics.js";
@@ -220,15 +221,20 @@ export class SessionManager {
     // Cleanup happens on session close, crash recovery, and via the global cap.
     ensureSessionMediaDir(chatId);
 
-    // Spawn the claude subprocess
-    const child = spawnClaudeSession({
-      agent,
-      sessionId,
-      resume,
-      includePartialMessages: true,
-      outboxPath,
-      injectDir: injectPath,
-    });
+    // Spawn the agent subprocess. Pi dispatches via the Pi RPC protocol; the
+    // claude/absent path is byte-identical to before. (Pi resume — passing the
+    // captured session id — is wired by a later task; here a Pi spawn always
+    // starts fresh.)
+    const child = agent.provider === "pi"
+      ? spawnPiRpcSession(agent)
+      : spawnClaudeSession({
+          agent,
+          sessionId,
+          resume,
+          includePartialMessages: true,
+          outboxPath,
+          injectDir: injectPath,
+        });
 
     // Verify the subprocess actually started
     try {
@@ -310,6 +316,11 @@ export class SessionManager {
   ): AsyncGenerator<StreamLine> {
     const session = await this.getOrCreateSession(chatId, agentId);
 
+    // Select the dispatch backend for send/read. getOrCreateSession just
+    // validated config, so this reload cannot fail; default to the claude path
+    // when provider is absent. ActiveSession stays provider-agnostic.
+    const isPi = this.getFreshConfig().agents[agentId]?.provider === "pi";
+
     // Async channel: queue task pushes lines, generator yields them in real-time
     const buffer: StreamLine[] = [];
     let notify: (() => void) | null = null;
@@ -347,7 +358,11 @@ export class SessionManager {
         }
       };
       try {
-        sendMessage(session.child, text, session.sessionId);
+        if (isPi) {
+          sendPiPrompt(session.child, text);
+        } else {
+          sendMessage(session.child, text, session.sessionId);
+        }
         session.lastActivity = Date.now();
         session.processingStartedAt = Date.now();
         this.resetIdleTimer(chatId);
@@ -382,7 +397,7 @@ export class SessionManager {
           }, RESPONSE_ACTIVITY_TIMEOUT_MS);
         };
         resetActivityTimer();
-        const stream = readStream(session.child);
+        const stream = isPi ? readPiStream(session.child) : readStream(session.child);
         for await (const line of stream) {
           resetActivityTimer();
           push(line);

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -7,10 +7,10 @@ import { on } from "node:events";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig, AgentConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream, parsePiEvent, NewlineOnlyJsonlSplitter, type PiRpcEvent, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiSteer, sendPiGetState, readPiStream, parsePiEvent, NewlineOnlyJsonlSplitter, type PiRpcEvent, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
-import { recordResultMetrics, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
+import { recordResultMetrics, recordPiRetry, recordPiTurnDuration, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
 import { injectDirForChat, cleanupInjectDir, writeInjectFile } from "./inject-file.js";
 import { ensureSessionMediaDir, cleanupSessionMediaDir, cleanupStaleSessionMedia } from "./media-store.js";
 
@@ -603,10 +603,26 @@ export class SessionManager {
           }, RESPONSE_ACTIVITY_TIMEOUT_MS);
         };
         resetActivityTimer();
+        // Pi turns carry no duration_ms in their result (only the Claude CLI
+        // does), so measure wall-clock from the prompt send for the Pi-specific
+        // histogram. processingStartedAt is reset to null after the loop, so
+        // capture it now while it is still set.
+        const turnStartedAt = session.processingStartedAt ?? Date.now();
         const stream = isPi ? readPiStream(session.child) : readStream(session.child);
         for await (const line of stream) {
           resetActivityTimer();
           push(line);
+          // Pi auto-retry telemetry: increment once per retry on auto_retry_start
+          // (auto_retry_end signals recovery — counting it too would double-count).
+          if (
+            isPi &&
+            line.type === "assistant" &&
+            line.subtype === "rate_limit_event" &&
+            line.pi_event_type === "auto_retry_start"
+          ) {
+            const errorMessage = typeof line.error_message === "string" ? line.error_message : undefined;
+            recordPiRetry(session.agentId, errorMessage);
+          }
           if (line.type === "result") {
             gotResult = true;
             session.lastSuccessAt = Date.now();
@@ -614,6 +630,9 @@ export class SessionManager {
             // Reset crash backoff on successful response
             this.restartCounts.set(chatId, 0);
             recordResultMetrics(session.agentId, line);
+            if (isPi) {
+              recordPiTurnDuration(session.agentId, (Date.now() - turnStartedAt) / 1000);
+            }
             break;
           }
         }
@@ -745,13 +764,23 @@ export class SessionManager {
   async gracefulShutdown(timeoutMs: number): Promise<void> {
     const busySessions: { chatId: string; startedAt: number }[] = [];
 
+    const shutdownNotice =
+      "[System: Bot is shutting down for restart. Do NOT attempt to restart the bot — the restart is already in progress. Wrap up your current task.]";
     for (const [chatId, session] of this.active) {
       if (session.processingStartedAt !== null) {
-        // Inject shutdown notification so the agent knows not to re-trigger restart
+        // Deliver the shutdown notice through the provider's mid-turn channel.
+        // Pi has no PreToolUse inject hook (the inject file would never be read),
+        // so steer it live into the running Pi child; the claude path keeps the
+        // inject-file mechanism. Pinned provider, not config — never switch the
+        // protocol of an already-live child.
         try {
-          writeInjectFile(session.injectDir, [
-            "[System: Bot is shutting down for restart. Do NOT attempt to restart the bot — the restart is already in progress. Wrap up your current task.]",
-          ]);
+          if (session.provider === "pi") {
+            if (!hasExited(session.child)) {
+              sendPiSteer(session.child, shutdownNotice);
+            }
+          } else {
+            writeInjectFile(session.injectDir, [shutdownNotice]);
+          }
         } catch { /* best-effort */ }
         busySessions.push({ chatId, startedAt: session.processingStartedAt });
       }

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import PQueue from "p-queue";
-import type { SessionState, StreamLine, BotConfig } from "./types.js";
+import type { SessionState, StreamLine, BotConfig, AgentConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
 import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
@@ -208,6 +208,38 @@ export class SessionManager {
   }
 
   /**
+   * True when a Pi child exited with the "stored session not found" signal
+   * (exit 1 + matching stderr) — the trigger for graceful resume-recovery.
+   */
+  private isPiResumeNotFound(child: ChildProcess): boolean {
+    return child.exitCode === 1 && /No session found matching/.test(piStartupStderr(child));
+  }
+
+  /**
+   * Perform the Pi graceful resume-recovery action: discard the unresumable
+   * stored id (deletes the store record + wipes the chat media dir), recreate
+   * the media dir for a clean fresh start, log, bump the metric, and return a
+   * fresh (no --session) child. Callers gate this on the at-most-once
+   * `alreadyRetried` flag + the "session not found" signal; this performs only
+   * the discard + fresh re-spawn.
+   */
+  private async discardUnresumablePiSession(
+    chatId: string,
+    agentId: string,
+    agent: AgentConfig,
+    staleSessionId: string,
+  ): Promise<ChildProcess> {
+    // Discard the unresumable stored id (deletes the store record + wipes the
+    // chat media dir, which is data-destructive by design here).
+    await this.destroySession(chatId);
+    // destroySession wiped the media dir; recreate it for the fresh start.
+    ensureSessionMediaDir(chatId);
+    log.warn("session-manager", `could not resume Pi session ${staleSessionId} — starting fresh`);
+    piSessionResumeDiscarded.inc({ agent_id: agentId });
+    return spawnPiRpcSession(agent, undefined);
+  }
+
+  /**
    * Get or create a session for a given chatId.
    * If a session exists in memory with a live process, reuse it.
    * If a session exists in store but process is dead, respawn with --resume.
@@ -308,10 +340,45 @@ export class SessionManager {
     let effectiveSessionId = sessionId;
     let alreadyRetried = false;
 
-    // Verify the subprocess actually started.
+    // Verify the subprocess started — and for Pi, capture its minted session id.
+    // A real `pi` handed a stale --session does NOT fail at spawn: Node emits
+    // 'spawn' before all other events, so waitForSpawn RESOLVES, and only THEN
+    // does Pi print "No session found matching" and exit 1. So a resume failure
+    // surfaces during the get_state capture (the child is already dead by then),
+    // NOT as a spawn rejection. Detect that here and throw into the shared catch,
+    // which classifies BOTH a spawn rejection and a post-spawn startup exit the
+    // same way: the "session not found" signal → one inline fresh start;
+    // anything else → crash-backoff.
     for (;;) {
       try {
         await waitForSpawn(child, STARTUP_TIMEOUT_MS);
+
+        // Prevent EPIPE from becoming uncaughtException when the subprocess
+        // dies — wired before any capture write so a racing child death on the
+        // get_state stdin write is logged, not thrown.
+        child.stdin?.on("error", (err) => {
+          log.error("session-manager", `stdin error for chat ${chatId}: ${err.message}`);
+        });
+
+        // For Pi, the session id is minted by the process — capture it now via
+        // get_state (the only place Pi exposes it) so it can be persisted and
+        // used to --session-resume after a restart. The claude/absent path keeps
+        // its bot-generated id untouched.
+        if (isPi) {
+          const piSessionId = await this.capturePiSessionId(child);
+          if (piSessionId) {
+            // Capture succeeded — the process is alive and answered get_state.
+            effectiveSessionId = piSessionId;
+          } else if (hasExited(child)) {
+            // No id AND the child already exited: it spawned but died during
+            // startup (e.g. a stale --session). Throw into the shared catch for
+            // classification (recovery vs backoff), same as a spawn rejection.
+            throw new Error(`Pi subprocess exited during startup: code=${child.exitCode}`);
+          }
+          // Else: no id but the child is still alive — capture timed out or the
+          // process went idle without a SystemInit. The session stays functional
+          // on its local id (a later resume just can't target it).
+        }
         break;
       } catch (err) {
         // Ensure child is dead before inspecting/throwing.
@@ -324,24 +391,11 @@ export class SessionManager {
         // only once: discard the unresumable stored session and start fresh
         // INLINE (no recursion into getOrCreateSession, no --session). Any other
         // failure — and any second failure — falls through to crash-backoff.
-        if (
-          isPi &&
-          effectiveResume &&
-          !alreadyRetried &&
-          child.exitCode === 1 &&
-          /No session found matching/.test(piStartupStderr(child))
-        ) {
+        if (isPi && effectiveResume && !alreadyRetried && this.isPiResumeNotFound(child)) {
           alreadyRetried = true;
-          // Discard the unresumable stored id (deletes the store record + wipes
-          // the chat media dir, which is data-destructive by design here).
-          await this.destroySession(chatId);
-          // destroySession wiped the media dir; recreate it for the fresh start.
-          ensureSessionMediaDir(chatId);
-          log.warn("session-manager", `could not resume Pi session ${sessionId} — starting fresh`);
-          piSessionResumeDiscarded.inc({ agent_id: agentId });
+          child = await this.discardUnresumablePiSession(chatId, agentId, agent, sessionId);
           effectiveResume = false;
           effectiveSessionId = randomUUID();
-          child = spawnPiRpcSession(agent, undefined);
           continue;
         }
 
@@ -361,25 +415,8 @@ export class SessionManager {
       }
     }
 
-    // Prevent EPIPE from becoming uncaughtException when subprocess dies
-    child.stdin?.on("error", (err) => {
-      log.error("session-manager", `stdin error for chat ${chatId}: ${err.message}`);
-    });
-
-    // Pipe stderr to log file
+    // Pipe stderr to log file (on the child that ultimately started).
     this.setupStderrLogging(chatId, child);
-
-    // For Pi, the session id is minted by the Pi process — capture it now via
-    // get_state (the only place Pi exposes it) so it can be persisted and used
-    // to --session-resume after a restart. The claude/absent path keeps the
-    // bot-generated id untouched. Falls back to the local id if capture yields
-    // nothing (session stays functional; a later resume just can't target it).
-    if (isPi) {
-      const piSessionId = await this.capturePiSessionId(child);
-      if (piSessionId) {
-        effectiveSessionId = piSessionId;
-      }
-    }
 
     // Restart/crash count accumulates via setupCrashRecovery and survives
     // active.delete(). Reset to 0 for fresh sessions (no existing, no resume).

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -191,6 +191,14 @@ export class SessionManager {
     try {
       sendPiGetState(child);
       return await Promise.race([readSystemInitSessionId(stream), timeout]);
+    } catch (err) {
+      // get_state can throw if the child died between waitForSpawn resolving and
+      // this write (a spawn-then-exit race): sendPiGetState rejects a closed
+      // stdin. Swallow it — capture is best-effort. The session stays usable on
+      // its local id and a dead child surfaces through normal crash recovery on
+      // the next message, rather than as an uncaught rejection out of spawn.
+      log.warn("session-manager", `Pi get_state capture failed: ${(err as Error).message}`);
+      return null;
     } finally {
       if (timer) clearTimeout(timer);
       // Stop the generator so child.stdout is handed off cleanly to the next

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -7,7 +7,7 @@ import { on } from "node:events";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig, AgentConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, sendPiSteer, sendPiGetState, readPiStream, parsePiEvent, NewlineOnlyJsonlSplitter, type PiRpcEvent, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiSteer, sendPiGetState, readPiStream, parsePiRecord, NewlineOnlyJsonlSplitter, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
 import { recordResultMetrics, recordPiRetry, recordPiTurnDuration, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
@@ -44,20 +44,13 @@ function piStartupStderr(child: ChildProcess): string {
 }
 
 /**
- * Parse one raw JSONL record from a Pi child's stdout and, if it is a SystemInit
- * (get_state) record, return its non-empty session_id; otherwise null. Mirrors
- * `parsePiRecord` in pi-rpc-protocol but yields only the id the capture needs.
+ * Parse one raw JSONL record from a Pi child's stdout via the protocol module's
+ * shared `parsePiRecord` (single source of truth for the JSONL framing/guard
+ * rules) and, if it is a SystemInit (get_state) record, return its non-empty
+ * session_id; otherwise null.
  */
 function parsePiSystemInitId(record: string): string | null {
-  const trimmed = record.trim();
-  if (!trimmed.startsWith("{")) return null;
-  let parsed: PiRpcEvent;
-  try {
-    parsed = JSON.parse(trimmed) as PiRpcEvent;
-  } catch {
-    return null;
-  }
-  const line = parsePiEvent(parsed);
+  const line = parsePiRecord(record);
   if (line && line.type === "system" && typeof line.session_id === "string" && line.session_id.length > 0) {
     return line.session_id;
   }

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -68,6 +68,14 @@ export interface ActiveSession {
   child: ChildProcess;
   sessionId: string;
   agentId: string;
+  /**
+   * Provider the child was actually spawned under, pinned at spawn time. Used
+   * for send/read dispatch instead of re-reading config: a hot-reload that
+   * flips the agent's provider must NOT switch the protocol of an already-live
+   * child (which was spawned under the old provider), and a later config that
+   * fails to load must not break dispatch for a session that is still usable.
+   */
+  provider: "claude" | "pi";
   queue: PQueue;
   idleTimer: ReturnType<typeof setTimeout> | null;
   /** Idle timeout baked at spawn time from config. */
@@ -248,11 +256,18 @@ export class SessionManager {
 
   /**
    * Perform the Pi graceful resume-recovery action: discard the unresumable
-   * stored id (deletes the store record + wipes the chat media dir), recreate
-   * the media dir for a clean fresh start, log, bump the metric, and return a
-   * fresh (no --session) child. Callers gate this on the at-most-once
-   * `alreadyRetried` flag + the "session not found" signal; this performs only
-   * the discard + fresh re-spawn.
+   * stored id (deletes the store record so a fresh Pi session is spawned), log,
+   * bump the metric, and return a fresh (no --session) child. Callers gate this
+   * on the at-most-once `alreadyRetried` flag + the "session not found" signal;
+   * this performs only the discard + fresh re-spawn.
+   *
+   * Media: the triggering turn's media has ALREADY been staged under this chat's
+   * media dir and is still tracked as in-flight — the fresh Pi session's prompt
+   * will reference those paths. So we must NOT wipe the whole dir (the prior
+   * `destroySession` path did, leaving the prompt pointing at deleted files).
+   * Use `cleanupStaleSessionMedia`, which removes only prior-session leftovers
+   * (including orphans from the failed-resume child) and preserves in-flight
+   * files for the current turn.
    */
   private async discardUnresumablePiSession(
     chatId: string,
@@ -260,21 +275,16 @@ export class SessionManager {
     agent: AgentConfig,
     staleSessionId: string,
   ): Promise<ChildProcess> {
-    // destroySession → closeSession clears restartCounts (so /reconnect can
-    // unblock a circuit-broken chat). A resume-recovery is NOT a clean reconnect:
-    // if this chat had already accumulated crashes, wiping that history would let
-    // a flapping session keep resetting toward zero and never trip the circuit
-    // breaker. Snapshot the count and restore it across the discard so startup
-    // failures stay cumulative.
-    const preservedCrashCount = this.restartCounts.get(chatId);
-    // Discard the unresumable stored id (deletes the store record + wipes the
-    // chat media dir, which is data-destructive by design here).
-    await this.destroySession(chatId);
-    if (preservedCrashCount !== undefined) {
-      this.restartCounts.set(chatId, preservedCrashCount);
-    }
-    // destroySession wiped the media dir; recreate it for the fresh start.
-    ensureSessionMediaDir(chatId);
+    // Discard ONLY the unresumable stored id so a fresh Pi session is spawned.
+    // Deleting the store record directly (instead of destroySession) avoids the
+    // full media-dir wipe; in-flight files for the current turn must survive.
+    // The crash count is intentionally left untouched: a resume-recovery is NOT
+    // a clean reconnect, so a flapping chat keeps advancing toward the circuit
+    // breaker rather than resetting toward zero on every recovery.
+    this.store.deleteSession(chatId);
+    // Purge prior-session leftovers (including any orphan from the failed-resume
+    // child) WITHOUT deleting the file the handler just staged for this turn.
+    try { cleanupStaleSessionMedia(chatId); } catch { /* ignore */ }
     log.warn("session-manager", `could not resume Pi session ${staleSessionId} — starting fresh`);
     piSessionResumeDiscarded.inc({ agent_id: agentId });
     return spawnPiRpcSession(agent, undefined);
@@ -470,6 +480,8 @@ export class SessionManager {
       child,
       sessionId: effectiveSessionId,
       agentId,
+      // Pin the provider the child was actually spawned under (claude when absent).
+      provider: isPi ? "pi" : "claude",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: freshConfig.sessionDefaults.idleTimeoutMs,
@@ -508,10 +520,12 @@ export class SessionManager {
   ): AsyncGenerator<StreamLine> {
     const session = await this.getOrCreateSession(chatId, agentId);
 
-    // Select the dispatch backend for send/read. getOrCreateSession just
-    // validated config, so this reload cannot fail; default to the claude path
-    // when provider is absent. ActiveSession stays provider-agnostic.
-    const isPi = this.getFreshConfig().agents[agentId]?.provider === "pi";
+    // Select the dispatch backend from the provider pinned at spawn time, not a
+    // fresh config read: getOrCreateSession may return an EXISTING live session
+    // without reloading config, so re-reading here could (a) throw on a broken
+    // hot-reloaded config even though the active session is fine, or (b) switch
+    // the protocol for a child spawned under the previous provider setting.
+    const isPi = session.provider === "pi";
 
     // Async channel: queue task pushes lines, generator yields them in real-time
     const buffer: StreamLine[] = [];

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -6,10 +6,10 @@ import { join } from "node:path";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiGetState, readPiStream, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
-import { recordResultMetrics, sessionsActive, sessionCrashes } from "./metrics.js";
+import { recordResultMetrics, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
 import { injectDirForChat, cleanupInjectDir, writeInjectFile } from "./inject-file.js";
 import { ensureSessionMediaDir, cleanupSessionMediaDir, cleanupStaleSessionMedia } from "./media-store.js";
 
@@ -30,6 +30,16 @@ export function outboxDir(chatId: string): string {
 /** Check whether a child process has exited (by exit code or signal). */
 function hasExited(child: ChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
+}
+
+/**
+ * Read the startup stderr buffered on a Pi child by `spawnPiRpcSession`. Returns
+ * "" for a claude child (no accessor) or before any stderr arrived. Used by the
+ * spawn-failure classifier to detect Pi's "No session found matching" signal.
+ */
+function piStartupStderr(child: ChildProcess): string {
+  const reader = (child as unknown as PiStartupDiagnostics).piStartupStderr;
+  return typeof reader === "function" ? reader() : "";
 }
 
 /**
@@ -267,7 +277,8 @@ export class SessionManager {
     // claude/absent path is byte-identical to before. For Pi, only a genuine
     // resume points --session at the stored (Pi-minted) id; a fresh start omits
     // it (an unknown id makes Pi exit with "No session found matching").
-    const child = agent.provider === "pi"
+    const isPi = agent.provider === "pi";
+    let child = isPi
       ? spawnPiRpcSession(agent, resume ? sessionId : undefined)
       : spawnClaudeSession({
           agent,
@@ -278,27 +289,68 @@ export class SessionManager {
           injectDir: injectPath,
         });
 
-    // Verify the subprocess actually started
-    try {
-      await waitForSpawn(child, STARTUP_TIMEOUT_MS);
-    } catch (err) {
-      // Ensure child is dead before throwing
-      if (!hasExited(child) && !child.killed) {
-        child.kill("SIGKILL");
+    // Graceful Pi resume-recovery state (signal-matched, inline, at-most-once):
+    // Pi flushes a session to disk only after agent_end/SIGTERM, so a restart
+    // MID-turn legitimately yields "No session found matching". Rather than
+    // crash-loop a chat to BLOCKED on a stale stored id, discard it and start
+    // fresh EXACTLY once. `effectiveResume` flips false after the discard so the
+    // fresh spawn's media handling matches a fresh start; `alreadyRetried` caps
+    // the recovery at one attempt (any second failure falls through to backoff).
+    let effectiveResume = resume;
+    let effectiveSessionId = sessionId;
+    let alreadyRetried = false;
+
+    // Verify the subprocess actually started.
+    for (;;) {
+      try {
+        await waitForSpawn(child, STARTUP_TIMEOUT_MS);
+        break;
+      } catch (err) {
+        // Ensure child is dead before inspecting/throwing.
+        if (!hasExited(child) && !child.killed) {
+          child.kill("SIGKILL");
+        }
+
+        // Pi-only graceful resume-recovery. Only when resuming, only on the
+        // specific "session not found" signal (exit 1 + matching stderr), and
+        // only once: discard the unresumable stored session and start fresh
+        // INLINE (no recursion into getOrCreateSession, no --session). Any other
+        // failure — and any second failure — falls through to crash-backoff.
+        if (
+          isPi &&
+          effectiveResume &&
+          !alreadyRetried &&
+          child.exitCode === 1 &&
+          /No session found matching/.test(piStartupStderr(child))
+        ) {
+          alreadyRetried = true;
+          // Discard the unresumable stored id (deletes the store record + wipes
+          // the chat media dir, which is data-destructive by design here).
+          await this.destroySession(chatId);
+          // destroySession wiped the media dir; recreate it for the fresh start.
+          ensureSessionMediaDir(chatId);
+          log.warn("session-manager", `could not resume Pi session ${sessionId} — starting fresh`);
+          piSessionResumeDiscarded.inc({ agent_id: agentId });
+          effectiveResume = false;
+          effectiveSessionId = randomUUID();
+          child = spawnPiRpcSession(agent, undefined);
+          continue;
+        }
+
+        // No session will be created to own files just downloaded for this turn;
+        // wipe the dir so they don't sit around until the next startup/cap eviction.
+        // Skip when resuming: the stored session record stays intact, so a later
+        // successful resume will continue the same conversation history — and that
+        // history may reference files already in this dir from prior turns.
+        if (!effectiveResume) {
+          try { cleanupSessionMediaDir(chatId); } catch { /* ignore */ }
+        }
+        // Increment crash count so startup failures contribute to backoff
+        const count = (this.restartCounts.get(chatId) ?? 0) + 1;
+        this.restartCounts.set(chatId, count);
+        log.error("session-manager", `Startup failure for chat ${chatId} (crash #${count}): ${(err as Error).message}`);
+        throw err;
       }
-      // No session will be created to own files just downloaded for this turn;
-      // wipe the dir so they don't sit around until the next startup/cap eviction.
-      // Skip when resuming: the stored session record stays intact, so a later
-      // successful resume will continue the same conversation history — and that
-      // history may reference files already in this dir from prior turns.
-      if (!resume) {
-        try { cleanupSessionMediaDir(chatId); } catch { /* ignore */ }
-      }
-      // Increment crash count so startup failures contribute to backoff
-      const count = (this.restartCounts.get(chatId) ?? 0) + 1;
-      this.restartCounts.set(chatId, count);
-      log.error("session-manager", `Startup failure for chat ${chatId} (crash #${count}): ${(err as Error).message}`);
-      throw err;
     }
 
     // Prevent EPIPE from becoming uncaughtException when subprocess dies
@@ -314,8 +366,7 @@ export class SessionManager {
     // to --session-resume after a restart. The claude/absent path keeps the
     // bot-generated id untouched. Falls back to the local id if capture yields
     // nothing (session stays functional; a later resume just can't target it).
-    let effectiveSessionId = sessionId;
-    if (agent.provider === "pi") {
+    if (isPi) {
       const piSessionId = await this.capturePiSessionId(child);
       if (piSessionId) {
         effectiveSessionId = piSessionId;

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -3,7 +3,7 @@ import { autoRetry } from "@grammyjs/auto-retry";
 import type { BotConfig, TelegramBinding } from "./types.js";
 import { outboxDir, hasExited, type SessionManager } from "./session-manager.js";
 import { relayStream } from "./stream-relay.js";
-import { MessageQueue } from "./message-queue.js";
+import { MessageQueue, type SteerFn } from "./message-queue.js";
 import { sendPiSteer } from "./pi-rpc-protocol.js";
 import { createTelegramAdapter } from "./telegram-adapter.js";
 import { tempFilePath, downloadFile, transcribeAudio, cleanupTempFile } from "./voice.js";
@@ -595,6 +595,32 @@ export const AUTO_RETRY_OPTIONS = {
 } as const;
 
 /**
+ * Build the provider-aware mid-turn delivery decision. Pi sessions have no
+ * PreToolUse inject hook, so a mid-turn message must be steered live into the
+ * running Pi child; the claude path keeps the inject-file mechanism (returns
+ * false). The decision is gated on the session's PINNED provider (set at spawn
+ * time), NOT the live config snapshot: a session spawned under a since-
+ * hot-reloaded provider would otherwise mis-route to the dead inject path and
+ * lose the message.
+ */
+export function makeSteerFn(
+  sessionManager: Pick<SessionManager, "getActive">,
+): SteerFn {
+  return (chatId: string, _agentId: string, text: string): boolean => {
+    const session = sessionManager.getActive(chatId);
+    if (!session || hasExited(session.child)) return false;
+    if (session.provider !== "pi") return false;
+    try {
+      sendPiSteer(session.child, text);
+      return true;
+    } catch (err) {
+      log.warn("telegram-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
+      return false;
+    }
+  };
+}
+
+/**
  * Build a transformer that runs autoRetry for every Telegram API method EXCEPT
  * `sendMessageDraft`. Drafts are cosmetic fire-and-forget calls (see
  * stream-relay.ts) — a retry that fires after Telegram's 3-10s retry_after is
@@ -639,21 +665,8 @@ export function createTelegramBot(
 
   const maxMessageAgeMs = config.sessionDefaults.maxMessageAgeMs;
 
-  // Provider-aware mid-turn delivery. Pi sessions have no PreToolUse inject
-  // hook, so a mid-turn message must be steered live into the running Pi child;
-  // the claude path keeps the inject-file mechanism (steerFn returns false).
-  const steerFn = (chatId: string, agentId: string, text: string): boolean => {
-    if (config.agents[agentId]?.provider !== "pi") return false;
-    const session = sessionManager.getActive(chatId);
-    if (!session || hasExited(session.child)) return false;
-    try {
-      sendPiSteer(session.child, text);
-      return true;
-    } catch (err) {
-      log.warn("telegram-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
-      return false;
-    }
-  };
+  // Provider-aware mid-turn delivery, gated on the session's pinned provider.
+  const steerFn = makeSteerFn(sessionManager);
 
   // Message queue: debounce rapid messages and collect mid-turn messages
   const messageQueue = new MessageQueue(

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -610,6 +610,14 @@ export function makeSteerFn(
     const session = sessionManager.getActive(chatId);
     if (!session || hasExited(session.child)) return false;
     if (session.provider !== "pi") return false;
+    // Only steer when a Pi turn is actively processing. After `agent_end`,
+    // session-manager clears `processingStartedAt` while MessageQueue.busy can
+    // still be true (relay/cleanup of the final response is finishing). A
+    // message arriving in that window must NOT be steered: the Pi child has no
+    // active turn, Pi may reject the steer, and the parser drops failed
+    // side-command responses (pi-rpc-protocol.ts) — losing the message.
+    // Returning false buffers it so the queue drains it as a normal followup.
+    if (session.processingStartedAt === null) return false;
     try {
       sendPiSteer(session.child, text);
       return true;

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -1,9 +1,10 @@
 import { Bot, type Transformer } from "grammy";
 import { autoRetry } from "@grammyjs/auto-retry";
 import type { BotConfig, TelegramBinding } from "./types.js";
-import { outboxDir, type SessionManager } from "./session-manager.js";
+import { outboxDir, hasExited, type SessionManager } from "./session-manager.js";
 import { relayStream } from "./stream-relay.js";
 import { MessageQueue } from "./message-queue.js";
+import { sendPiSteer } from "./pi-rpc-protocol.js";
 import { createTelegramAdapter } from "./telegram-adapter.js";
 import { tempFilePath, downloadFile, transcribeAudio, cleanupTempFile } from "./voice.js";
 import { allocateMediaPath, enforceMediaCap, releaseMediaPath, discardMediaPath } from "./media-store.js";
@@ -638,12 +639,29 @@ export function createTelegramBot(
 
   const maxMessageAgeMs = config.sessionDefaults.maxMessageAgeMs;
 
+  // Provider-aware mid-turn delivery. Pi sessions have no PreToolUse inject
+  // hook, so a mid-turn message must be steered live into the running Pi child;
+  // the claude path keeps the inject-file mechanism (steerFn returns false).
+  const steerFn = (chatId: string, agentId: string, text: string): boolean => {
+    if (config.agents[agentId]?.provider !== "pi") return false;
+    const session = sessionManager.getActive(chatId);
+    if (!session || hasExited(session.child)) return false;
+    try {
+      sendPiSteer(session.child, text);
+      return true;
+    } catch (err) {
+      log.warn("telegram-bot", `Pi steer failed for ${chatId}: ${(err as Error).message}`);
+      return false;
+    }
+  };
+
   // Message queue: debounce rapid messages and collect mid-turn messages
   const messageQueue = new MessageQueue(
     async (chatId, agentId, text, platform, onAgentOwnership) => {
       const stream = sessionManager.sendSessionMessage(chatId, agentId, text);
       await relayStream(stream, platform, outboxDir(chatId), onAgentOwnership);
     },
+    { steerFn },
   );
 
   // Watchdog touch: notify liveness watchdog on every incoming update

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,8 @@ agents:
     effort: high      # Claude reasoning effort: low, medium, high (omit for default)
     # provider: claude  # coding backend: "claude" (default, omit) or "pi" (Pi RPC + OpenAI Codex).
                         # "pi" routes the agent through the Pi coding agent; "claude" uses `claude -p`.
+                        # A "pi" agent MUST set an explicit model (e.g. model: gpt-5.5) — it does
+                        # not inherit defaultModel (which is Claude-oriented).
 
   # Add more agents as needed:
   # coder:

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -88,10 +88,10 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 - Modify: `bot/src/pi-rpc-protocol.ts` (`parsePiEvent`, ~315-326)
 - Modify: `bot/src/__tests__/pi-rpc-protocol.test.ts`
 
-- [ ] split the shared case: `turn_end` → `null`; keep `agent_end` → `ResultMessage` via `extractFinalAssistantText(rawEvent.messages)`
-- [ ] confirm `extractFinalAssistantText` returns the correct final text for the real `agent_end.messages` shape (adjust if labels differ); verify THROUGH `parsePiEvent` output, do not import the private helper
-- [ ] write tests (verified sequences): multi-turn (2× turn_end + 1× agent_end) → exactly ONE terminal `ResultMessage` (from agent_end) with the FINAL text; single-turn → one terminal; `turn_end` alone → null
-- [ ] run tests — must pass before next task
+- [x] split the shared case: `turn_end` → `null`; keep `agent_end` → `ResultMessage` via `extractFinalAssistantText(rawEvent.messages)`
+- [x] confirm `extractFinalAssistantText` returns the correct final text for the real `agent_end.messages` shape (adjust if labels differ); verify THROUGH `parsePiEvent` output, do not import the private helper
+- [x] write tests (verified sequences): multi-turn (2× turn_end + 1× agent_end) → exactly ONE terminal `ResultMessage` (from agent_end) with the FINAL text; single-turn → one terminal; `turn_end` alone → null
+- [x] run tests — must pass before next task
 
 ### Task 2: Provider dispatch branch in session-manager
 

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -142,11 +142,11 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 - Modify: `bot/src/telegram-bot.ts` (~642 — inject `steerFn` at `MessageQueue` construction)
 - Modify: `bot/src/__tests__/message-queue.test.ts`
 
-- [ ] inject a `steerFn(chatId, text)` at `MessageQueue` construction: `const s = sessionManager.getActive(chatId); if (s && !hasExited(s.child)) sendPiSteer(s.child, text)`
-- [ ] make the busy-turn branch (~155-180) provider-aware: `pi` → `steerFn(chatId, text)`; else → existing `writeInject` path (claude unchanged)
-- [ ] thread the chat's provider into the queue (via state alongside `agentId`, or resolved in the callback)
-- [ ] write tests: pi busy-turn message → `steerFn`/`sendPiSteer`; claude busy-turn message → `writeInject` (regression)
-- [ ] run tests — must pass before next task
+- [x] inject a `steerFn(chatId, text)` at `MessageQueue` construction: `const s = sessionManager.getActive(chatId); if (s && !hasExited(s.child)) sendPiSteer(s.child, text)`
+- [x] make the busy-turn branch (~155-180) provider-aware: `pi` → `steerFn(chatId, text)`; else → existing `writeInject` path (claude unchanged)
+- [x] thread the chat's provider into the queue (resolved in the steer callback via `config.agents[agentId].provider`; queue passes `state.agentId` to `steerFn`)
+- [x] write tests: pi busy-turn message → `steerFn`/`sendPiSteer`; claude busy-turn message → `writeInject` (regression)
+- [x] run tests — must pass before next task
 
 ### Task 6: Verify acceptance criteria
 

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -128,12 +128,12 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 - Modify: `bot/src/__tests__/session-manager.test.ts`
 - Modify: `bot/src/__tests__/metrics.test.ts`
 
-- [ ] `spawnPiRpcSession`: buffer startup stderr (keep `log.warn`) and expose stderr+exit for the caller to inspect
-- [ ] add metric `pi_session_resume_discarded_total` (prom-client, already wired)
-- [ ] spawn catch (Pi branch, resuming only, LOCAL `alreadyRetried` flag): if `!alreadyRetried && exitCode===1 && /No session found matching/.test(stderr)` → `destroySession(chatId)` + INLINE single `spawnPiRpcSession`+`waitForSpawn` fresh (no `--session`) + `log.warn("could not resume Pi session <id> — starting fresh")` + metric inc. NO recursive `getOrCreateSession`.
-- [ ] second failure throws into the normal catch (increments `restartCounts`); non-matching failures preserve BOTH stored id AND media dir
-- [ ] write tests: missing-session signal → exactly ONE `destroySession` + ONE warn + metric inc, then success; both spawns fail identically → exactly ONE destroySession + ONE warn then a THROWN error, NO loop; non-matching failure → NO discard, stored id + media dir preserved, existing backoff
-- [ ] run tests — must pass before next task
+- [x] `spawnPiRpcSession`: buffer startup stderr (keep `log.warn`) and expose stderr+exit for the caller to inspect
+- [x] add metric `pi_session_resume_discarded_total` (prom-client, already wired)
+- [x] spawn catch (Pi branch, resuming only, LOCAL `alreadyRetried` flag): if `!alreadyRetried && exitCode===1 && /No session found matching/.test(stderr)` → `destroySession(chatId)` + INLINE single `spawnPiRpcSession`+`waitForSpawn` fresh (no `--session`) + `log.warn("could not resume Pi session <id> — starting fresh")` + metric inc. NO recursive `getOrCreateSession`.
+- [x] second failure throws into the normal catch (increments `restartCounts`); non-matching failures preserve BOTH stored id AND media dir
+- [x] write tests: missing-session signal → exactly ONE `destroySession` + ONE warn + metric inc, then success; both spawns fail identically → exactly ONE destroySession + ONE warn then a THROWN error, NO loop; non-matching failure → NO discard, stored id + media dir preserved, existing backoff
+- [x] run tests — must pass before next task
 
 ### Task 5: Mid-turn steer wiring for Pi (message-queue)
 

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -1,0 +1,175 @@
+# Pi RPC Integration — Plan B (session-manager dispatch)
+
+> **STATUS: ready to run (plan-readiness GO_WITH_FIXES applied 2026-05-31, run wrl7hok7v).** Plan A is MERGED (PR #130) on `main`. This file moves to `~/src/claude-code-bot/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md` and runs via ralphex (claude opus-4.8 executor + codex gpt-5.5 external review) on branch `feature/pi-rpc-plan-b`. Built to the `planning:make` canonical structure.
+>
+> **Aligned against the MERGED tree (read 2026-05-31).** Real `pi-rpc-protocol.ts` exports: `NewlineOnlyJsonlSplitter`, `buildPiSpawnArgs(agent)`, `buildPiSpawnEnv(agent)`, `spawnPiRpcSession(agent)`, `buildPiPromptCommand`/`buildPiSteerCommand`, `sendPiPrompt(child,text)`, `sendPiSteer(child,text)`, `parsePiEvent(rawEvent)`, `readPiStream(child)`, `extractPiTextDelta`. NOTE: `extractFinalAssistantText`/`extractAssistantText` are PRIVATE module helpers (no export) used inside `parsePiEvent`'s `agent_end` case — verify them via `parsePiEvent`'s public output, never import directly.
+>
+> **Decisions folded in (Notion review + live verification + readiness punch-list, 2026-05-31):**
+> 1. dropped the migration-only "MF4" provider-mismatch detector → replaced by a permanent, signal-matched graceful resume-recovery (Task 4).
+> 2. persona task DROPPED — already shipped in Plan A (`buildPiSpawnArgs` pushes `--append-system-prompt`).
+> 3. translator multi-turn fix is Task 1 (moved first: pure single-file, independent, highest-confidence — de-risks the gated chain). Live capture proved `turn_end` fires PER-TURN and `agent_end` ONCE; merged `parsePiEvent` wrongly maps BOTH to the terminal `ResultMessage` → any tool-using response truncates.
+> 4. steer (Task 5) re-scoped to `message-queue.ts` + the `MessageQueue` construction site — the mid-turn mechanism lives there, NOT in session-manager (verified). As originally scoped it would silently no-op for Pi.
+> 5. test-mocking guidance corrected (the suite injects mock children into the private active map; only `hot-reload.test.ts` uses `mock.module`).
+
+## Overview
+
+Wire the merged Pi RPC protocol module into the bot's live session lifecycle so a per-chat session with `provider: "pi"` runs end-to-end on Pi+Codex — correct multi-turn results, spawned, streamed to Telegram, resumed across restarts, steerable mid-turn — with the existing `claude` path untouched.
+
+- **Problem it solves:** Plan A built the protocol module but wired NO dispatch, and its `turn_end` handling truncates multi-turn responses. Plan B makes `provider: "pi"` functional and correct. It also hardens a pre-existing fragility: today a stored session that can't be resumed crash-loops the chat until BLOCKED, needing a manual `/reconnect`.
+- **Key benefit:** after Plan B merges, the coder PoC (flip `coder` → `provider: pi` + restart) is unblocked.
+- **Integration:** branches `session-manager.ts` (and the busy-turn branch of `message-queue.ts`) on `agent.provider`; reuses the merged Pi fns; `parsePiEvent` already emits the `StreamLine` shape `stream-relay.ts` consumes, so the relay is untouched.
+
+**Success criteria (testable):**
+1. `parsePiEvent` maps ONLY `agent_end` → terminal `ResultMessage`; `turn_end` → null. A multi-turn (tool-using) Pi response delivers the FINAL answer; single-turn still terminates once.
+2. With `agent.provider === "pi"`, `session-manager` spawns via `spawnPiRpcSession`, streams via `readPiStream`, sends via `sendPiPrompt`; with `provider` absent/`"claude"`, behavior is byte-identical to today.
+3. The bot captures the Pi-GENERATED sessionId (issue `get_state` after spawn → the `SystemInit.session_id` that `parsePiEvent` emits from the `response` case), persists it, and resumes via `--session <uuid>` after restart. (A restart MID-turn legitimately yields "No session found" because Pi flushes a session to disk only after `agent_end`/SIGTERM → that is a graceful fresh start via Task 4, NOT a defect.)
+4. A Pi resume failing specifically with exit 1 + stderr `No session found matching` → discard stored id, ONE fresh start, log `could not resume Pi session <id> — starting fresh`, increment a `pi_session_resume_discarded_total` metric. Any OTHER startup failure keeps the existing crash-backoff and preserves BOTH the stored id AND the chat media dir.
+5. A mid-turn message to a live Pi session is delivered via `sendPiSteer`; the claude path keeps the `inject-message.sh` file path.
+6. Full suite green; lint clean; no behavior change on the claude path.
+
+**Non-goals (Plan B):** `cron-runner.ts` (= Plan C); the Pi extensions (guardian / web-tools / subagent / codex-usage = Phase 2); flipping any agent to `pi` or restarting the bot (= coder PoC / cutover, gated on explicit the maintainer confirmation); extending graceful-recovery to the claude path (claude is being deprecated).
+
+## Context (verified against the merged tree 2026-05-31)
+
+- `bot/src/session-manager.ts` (~725 LOC): per-chat `ActiveSession { child, sessionId, agentId, queue, idleTimer, ... }`. Imports `spawnClaudeSession`/`sendMessage`/`readStream` from `cli-protocol.ts`; **3 call sites (~224 spawn, ~350 send, ~385 read)** branch on `agent.provider`. Exposes `getActive(chatId) → ActiveSession` (gives the live `.child`, needed by the steer callback).
+- Spawn path: `spawnClaudeSession(...)` (~224) → `await waitForSpawn(child, STARTUP_TIMEOUT_MS)` (~235); catch (~236-253) increments `restartCounts`, logs `Startup failure (crash #N)`, re-throws. Crash-count reset (266-268) runs ONLY after a successful `waitForSpawn` (unreachable on the catch path). `MAX_CRASH_RESTARTS` → BLOCKED, `throw "... use /reconnect"` (~197-199); else backoff 5s→60s (~201-205).
+- `resolveStoredSession()` (~625-650): discards (deleteSession + fresh `randomUUID()`) only on `agentMismatch || agentDeleted`, else `{ resume:true, sessionId: stored.sessionId }`.
+- `destroySession()` (~577-583): `store.deleteSession` + `closeSession(persist:false)` + **`cleanupSessionMediaDir` (WIPES the chat media dir, :582)**. Reuse for the recovery discard — but note it is data-destructive.
+- `SessionStore` (`bot/src/session-store.ts`): `Record<chatId, SessionState>` → `<workspace>/data/sessions.json` (atomic tmp+rename). `SessionState = { sessionId, chatId, agentId, lastActivity }`. **No `provider` field added.**
+- `bot/src/message-queue.ts`: `class MessageQueue`, constructor takes `processFn` (~98-102). The busy-turn branch `if (state.busy)` (~155-180) calls `this.writeInject(chatId, state)` → `writeInjectFile` (from `inject-file.js`) → PreToolUse hook delivers mid-turn. **MessageQueue has NO handle to SessionManager or the live child.** Constructed at `bot/src/telegram-bot.ts:~642` (`new MessageQueue(processFn, ...)`), which DOES have the config + sessionManager in scope. Pi has no PreToolUse hook → the inject-file path is a no-op for Pi.
+- **Merged `pi-rpc-protocol.ts` realities:**
+  - `buildPiSpawnArgs(agent)` → `--mode rpc --provider openai-codex --model <norm> [--append-system-prompt <systemPrompt>]`. **Takes ONLY `agent`, NO resume support.** Persona already handled.
+  - `spawnPiRpcSession(agent)` spawns with those args; **stderr is piped to `log.warn("pi-rpc", ...)` and NOT captured/returned.**
+  - sessionId exposed ONLY via a successful `get_state`/`get_session_stats` `response` → `parsePiEvent` (~328-350) emits `SystemInit { session_id }`. No `buildGetStateCommand` exists yet.
+  - `parsePiEvent` `turn_end`/`agent_end` share ONE terminal `ResultMessage` block (~315-326) — the bug.
+- **Verified Pi event sequence (live, 2026-05-31):** multi-turn = 2× `turn_end` + 1× `agent_end`; single-turn = 1× each; `agent_end` ALWAYS fires once at the end. Session persists to disk only after `agent_end` + on SIGTERM.
+- `stream-relay.ts`: UNCHANGED.
+
+## Development Approach
+
+- **Testing approach: Regular** (code-first, tests per task); tests in `bot/src/__tests__/*.test.ts` (the `npm test` glob).
+- **Test-mocking patterns (use the right one per task — verified against the real suite):**
+  - **Reuse / lifecycle path** (existing `session-manager.test.ts` pattern): build a mock `ChildProcess` (EventEmitter `createMockChild`-style) and inject it directly into SessionManager's private `active` map; drive events on it. Does NOT mock any module.
+  - **Spawn path** (Task 3/4 capture + recovery — needs the REAL spawn path): use `node:test` `mock.module` (run with `--experimental-test-module-mocks`, exactly as `hot-reload.test.ts` does) to stub `pi-rpc-protocol.js` exports (`spawnPiRpcSession`, `readPiStream`, `sendPiGetState`). There is NO existing `cli-protocol.js` module-mock to "mirror" — do not look for one.
+- Every task includes new/updated tests (success + error); all pass before the next.
+- **Backward-compat is sacred:** every change gated on `agent.provider === "pi"`; claude/absent path byte-identical; add explicit regression assertions.
+- DRY/YAGNI: no `provider` field in the store, no provider-mismatch detector.
+
+## Testing Strategy
+
+- **Unit:** translator turn_end→null / agent_end→terminal (via `parsePiEvent` public output, verified sequences); dispatch routing; get_state id capture + persist + resume (mock.module spawn path); graceful recovery (signal match → discard + ONE fresh retry + warn + metric; non-matching → backoff, NO discard, media preserved; at-most-once even when fresh re-spawn also fails); steer routing in message-queue.
+- **Regression:** claude-provider path unchanged (dispatch, store record, mid-turn inject-file).
+- **No e2e** (real end-to-end is the coder PoC, a later cutover task).
+
+## Progress Tracking
+- `[x]` on completion; ➕ new tasks; ⚠️ blockers; keep in sync.
+
+## Solution Overview
+
+First fix the independent translator bug (only `agent_end` terminates). Then `session-manager` gains a thin provider switch at its 3 `cli-protocol` call sites. For Pi, the bot issues `get_state` right after spawn and reads EXACTLY ONE record from a single `readPiStream(child)` consumer to capture the `SystemInit.session_id`, then stops that generator (a fresh `readPiStream` per later message is safe because the prior generator is fully drained); resume extends `buildPiSpawnArgs` to pass `--session <id>`. A narrow signal-matched recovery does an INLINE single re-spawn (not recursive) on a "session not found" failure. Mid-turn sends route to `sendPiSteer` via a steer callback wired into `MessageQueue` at construction. Everything else is provider-agnostic and reused unchanged.
+
+## Technical Details
+
+- **Translator fix (Task 1):** in `parsePiEvent`, split the shared `turn_end`/`agent_end` case — `turn_end` → `null` (per-turn boundary), `agent_end` → `ResultMessage` (via the private `extractFinalAssistantText(rawEvent.messages)`). Verify the result text against the real `agent_end.messages` shape through `parsePiEvent`'s output.
+- **Dispatch (Task 2):** at each call site select by `agent.provider === "pi"`. `ActiveSession` shape unchanged.
+- **Session-id capture + resume (Task 3):** add `buildGetStateCommand()` + `sendPiGetState(child)`. After `spawnPiRpcSession`, open ONE `readPiStream(child)`, `sendPiGetState`, read until the `SystemInit` record, capture `session_id` into `ActiveSession.sessionId` + `store.setSession`, then STOP that generator. Extend `buildPiSpawnArgs(agent, resumeSessionId?)` and `spawnPiRpcSession(agent, resumeSessionId?)` to push `--session <id>` when present; resume passes `stored.sessionId`. Document the single-consumer contract: per-message `readPiStream` is created fresh and the spawn-path generator is fully drained before any message read.
+- **Graceful resume-recovery (Task 4):** extend `spawnPiRpcSession` to buffer startup stderr (keep `log.warn`) and expose it + exit. In the spawn catch (Pi branch, resuming only) with a LOCAL `alreadyRetried` boolean: if `!alreadyRetried && exitCode === 1 && /No session found matching/.test(stderr)` → `destroySession(chatId)` + INLINE single `spawnPiRpcSession`+`waitForSpawn` fresh (no `--session`) + `log.warn(...)` + `pi_session_resume_discarded_total.inc()`. A second failure throws into the normal catch (increments `restartCounts`) — NO recursion into `getOrCreateSession`, NO loop. Non-matching failures: unchanged (preserve stored id AND media dir).
+- **Steer (Task 5):** add a provider-aware mid-turn delivery to `MessageQueue`. Inject a `steerFn(chatId, text)` at construction (telegram-bot.ts:~642), defined as `(chatId, text) => { const s = sessionManager.getActive(chatId); if (s && !hasExited(s.child)) sendPiSteer(s.child, text); }`. In the busy-turn branch, branch on the chat's provider: `pi` → `steerFn`; else → existing `writeInject`. (Provider available via the agent config the construction site holds, or threaded into queue state alongside `agentId`.)
+
+## What Goes Where
+- **Implementation Steps (`[ ]`):** in-repo — `pi-rpc-protocol.ts`, `session-manager.ts`, `message-queue.ts`, `telegram-bot.ts`, tests, docs.
+- **Post-Completion (no checkboxes):** merge to public main + upstream-sync to workspace (release-flow). Rollback: if the squash-merge surfaces a claude-path regression, `git revert <merge>` + re-run upstream-sync — no session data is at risk because no agent is flipped to pi until the gated cutover. Then the coder PoC (flip `coder` → `provider:pi` + restart + 24h soak; explicit the maintainer confirmation).
+
+## Implementation Steps
+
+### Task 1: Translator multi-turn fix — only agent_end is terminal
+
+**Files:**
+- Modify: `bot/src/pi-rpc-protocol.ts` (`parsePiEvent`, ~315-326)
+- Modify: `bot/src/__tests__/pi-rpc-protocol.test.ts`
+
+- [ ] split the shared case: `turn_end` → `null`; keep `agent_end` → `ResultMessage` via `extractFinalAssistantText(rawEvent.messages)`
+- [ ] confirm `extractFinalAssistantText` returns the correct final text for the real `agent_end.messages` shape (adjust if labels differ); verify THROUGH `parsePiEvent` output, do not import the private helper
+- [ ] write tests (verified sequences): multi-turn (2× turn_end + 1× agent_end) → exactly ONE terminal `ResultMessage` (from agent_end) with the FINAL text; single-turn → one terminal; `turn_end` alone → null
+- [ ] run tests — must pass before next task
+
+### Task 2: Provider dispatch branch in session-manager
+
+**Files:**
+- Modify: `bot/src/session-manager.ts`
+- Modify: `bot/src/__tests__/session-manager.test.ts`
+
+- [ ] import the Pi protocol fns; at the 3 `cli-protocol` call sites (~224/350/385), branch on `agent.provider === "pi"` → Pi fns, else claude fns
+- [ ] keep `ActiveSession` shape + lifecycle provider-agnostic
+- [ ] write tests (reuse-path pattern: mock child injected into private `active` map): pi routes to Pi fns; claude/absent routes to claude fns (regression)
+- [ ] run tests — must pass before next task
+
+### Task 3: Pi session-id capture (get_state, single-consumer) + resume
+
+**Files:**
+- Modify: `bot/src/pi-rpc-protocol.ts` (add `buildGetStateCommand`/`sendPiGetState`; extend `buildPiSpawnArgs`/`spawnPiRpcSession` with optional `resumeSessionId`)
+- Modify: `bot/src/session-manager.ts`
+- Modify: `bot/src/__tests__/pi-rpc-protocol.test.ts`
+- Modify: `bot/src/__tests__/session-manager.test.ts`
+
+- [ ] add `buildGetStateCommand()` + `sendPiGetState(child)` (writes `{type:"get_state"}`)
+- [ ] extend `buildPiSpawnArgs(agent, resumeSessionId?)` → push `--session <id>` iff present; thread through `spawnPiRpcSession(agent, resumeSessionId?)`
+- [ ] session-manager Pi spawn: open ONE `readPiStream(child)`, `sendPiGetState`, read until the `SystemInit` record, capture `session_id` → `ActiveSession.sessionId` + `store.setSession`, then STOP that generator (single-consumer contract: per-message `readPiStream` created fresh, prior generator fully drained)
+- [ ] resume path: stored Pi session → spawn with `resumeSessionId = stored.sessionId`
+- [ ] write tests (spawn path via `mock.module` stub of pi-rpc-protocol exports): `buildPiSpawnArgs` adds `--session` iff resume id; get_state SystemInit captured + persisted; single-consumer read terminates cleanly; claude path still bot-generates `--session-id` (regression)
+- [ ] run tests — must pass before next task
+
+### Task 4: Graceful resume-recovery (Pi-path, signal-matched, inline, at-most-once)
+
+**Files:**
+- Modify: `bot/src/pi-rpc-protocol.ts` (buffer + expose startup stderr/exit)
+- Modify: `bot/src/session-manager.ts`
+- Modify: `bot/src/metrics.ts` (add `pi_session_resume_discarded_total`)
+- Modify: `bot/src/__tests__/session-manager.test.ts`
+- Modify: `bot/src/__tests__/metrics.test.ts`
+
+- [ ] `spawnPiRpcSession`: buffer startup stderr (keep `log.warn`) and expose stderr+exit for the caller to inspect
+- [ ] add metric `pi_session_resume_discarded_total` (prom-client, already wired)
+- [ ] spawn catch (Pi branch, resuming only, LOCAL `alreadyRetried` flag): if `!alreadyRetried && exitCode===1 && /No session found matching/.test(stderr)` → `destroySession(chatId)` + INLINE single `spawnPiRpcSession`+`waitForSpawn` fresh (no `--session`) + `log.warn("could not resume Pi session <id> — starting fresh")` + metric inc. NO recursive `getOrCreateSession`.
+- [ ] second failure throws into the normal catch (increments `restartCounts`); non-matching failures preserve BOTH stored id AND media dir
+- [ ] write tests: missing-session signal → exactly ONE `destroySession` + ONE warn + metric inc, then success; both spawns fail identically → exactly ONE destroySession + ONE warn then a THROWN error, NO loop; non-matching failure → NO discard, stored id + media dir preserved, existing backoff
+- [ ] run tests — must pass before next task
+
+### Task 5: Mid-turn steer wiring for Pi (message-queue)
+
+**Files:**
+- Modify: `bot/src/message-queue.ts` (provider-aware busy-turn branch)
+- Modify: `bot/src/telegram-bot.ts` (~642 — inject `steerFn` at `MessageQueue` construction)
+- Modify: `bot/src/__tests__/message-queue.test.ts`
+
+- [ ] inject a `steerFn(chatId, text)` at `MessageQueue` construction: `const s = sessionManager.getActive(chatId); if (s && !hasExited(s.child)) sendPiSteer(s.child, text)`
+- [ ] make the busy-turn branch (~155-180) provider-aware: `pi` → `steerFn(chatId, text)`; else → existing `writeInject` path (claude unchanged)
+- [ ] thread the chat's provider into the queue (via state alongside `agentId`, or resolved in the callback)
+- [ ] write tests: pi busy-turn message → `steerFn`/`sendPiSteer`; claude busy-turn message → `writeInject` (regression)
+- [ ] run tests — must pass before next task
+
+### Task 6: Verify acceptance criteria
+
+- [ ] verify the 6 success criteria from Overview
+- [ ] regression gate: a claude-provider session byte-identical to pre-Plan-B behavior (dispatch, store record, mid-turn inject-file)
+- [ ] grep-confirm `cli-protocol.ts` and `cron-runner.ts` are NOT modified (cron = Plan C)
+- [ ] run full suite: `cd bot && npm test` ; lint: `cd bot && npm run lint`
+
+### Task 7: [Final] Update documentation
+
+**Files:**
+- Modify: `README.md` (repo ROOT — NOT bot/README.md)
+
+- [ ] short note: translator multi-turn fix + provider dispatch + get_state session-id capture + graceful resume-recovery + Pi steer; claude path unchanged
+- [ ] PR description: "Plan B — dispatch wiring; turn_end multi-turn truncation fix; get_state session-id capture + resume; graceful resume-recovery (replaces migration-only MF4); Pi mid-turn steer; claude path unchanged; coder PoC unblocked after merge"
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+*Items requiring manual intervention — no checkboxes, informational only*
+
+**Release:** merge to public main → `git fetch upstream && git merge upstream/main` in workspace (release-flow). **Rollback:** claude-path regression after merge → `git revert <merge>` + re-run upstream-sync; no session data at risk (no agent on pi until the gated cutover).
+
+**Next (separate cutover task — explicit the maintainer confirmation):** coder PoC — `agents.coder.provider: pi`, restart bot, 24h soak.
+- ⚠️ **Codex OAuth token (`~/.pi/agent/auth.json`) expires 2026-06-09** (before the June 15 deadline). Does NOT affect Plan B (tests mocked, no live Pi). At the coder-PoC cutover, verify the token AUTO-REFRESHES from inside the bot's launchd subprocess (write-permission to `~/.pi/agent/auth.json` under the bot's `$HOME`) — refresh was only verified from an interactive shell.
+
+**Still-unverified deferred item (low risk, verify during soak):** the exact Pi hard-error event shape (top-level `error` vs failed `response` vs `auto_retry_end` finalError) — `parsePiEvent` handles all three defensively; confirm against a real error if one surfaces.

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -99,10 +99,10 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 - Modify: `bot/src/session-manager.ts`
 - Modify: `bot/src/__tests__/session-manager.test.ts`
 
-- [ ] import the Pi protocol fns; at the 3 `cli-protocol` call sites (~224/350/385), branch on `agent.provider === "pi"` → Pi fns, else claude fns
-- [ ] keep `ActiveSession` shape + lifecycle provider-agnostic
-- [ ] write tests (reuse-path pattern: mock child injected into private `active` map): pi routes to Pi fns; claude/absent routes to claude fns (regression)
-- [ ] run tests — must pass before next task
+- [x] import the Pi protocol fns; at the 3 `cli-protocol` call sites (~224/350/385), branch on `agent.provider === "pi"` → Pi fns, else claude fns
+- [x] keep `ActiveSession` shape + lifecycle provider-agnostic
+- [x] write tests (reuse-path pattern: mock child injected into private `active` map): pi routes to Pi fns; claude/absent routes to claude fns (regression)
+- [x] run tests — must pass before next task
 
 ### Task 3: Pi session-id capture (get_state, single-consumer) + resume
 

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -150,10 +150,10 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 
 ### Task 6: Verify acceptance criteria
 
-- [ ] verify the 6 success criteria from Overview
-- [ ] regression gate: a claude-provider session byte-identical to pre-Plan-B behavior (dispatch, store record, mid-turn inject-file)
-- [ ] grep-confirm `cli-protocol.ts` and `cron-runner.ts` are NOT modified (cron = Plan C)
-- [ ] run full suite: `cd bot && npm test` ; lint: `cd bot && npm run lint`
+- [x] verify the 6 success criteria from Overview (1: parsePiEvent turn_end→null / agent_end→terminal ResultMessage, pi-rpc-protocol.ts:369-382; 2: provider dispatch at spawn/send/read, session-manager.ts:280-282/467-471/506, claude/absent byte-identical; 3: get_state capture → store.setSession:402 → resume via --session, buildPiSpawnArgs:120-122; 4: signal-matched recovery session-manager.ts:319-338 + pi_session_resume_discarded_total metric; 5: steerFn wiring telegram-bot.ts + message-queue.ts:195-206, claude keeps inject-file; 6: suite green + lint clean)
+- [x] regression gate: a claude-provider session byte-identical to pre-Plan-B behavior (dispatch, store record, mid-turn inject-file) — explicit assertions in session-manager.test.ts:1961/1997, session-manager-pi-spawn.test.ts:287, message-queue.test.ts:1002/1037
+- [x] grep-confirm `cli-protocol.ts` and `cron-runner.ts` are NOT modified (cron = Plan C) — both confirmed absent from `git diff --name-only main...HEAD`
+- [x] run full suite: `cd bot && npm test` (1149 pass / 0 fail) ; lint: `cd bot && npm run lint` (clean, exit 0)
 
 ### Task 7: [Final] Update documentation
 

--- a/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -112,12 +112,12 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 - Modify: `bot/src/__tests__/pi-rpc-protocol.test.ts`
 - Modify: `bot/src/__tests__/session-manager.test.ts`
 
-- [ ] add `buildGetStateCommand()` + `sendPiGetState(child)` (writes `{type:"get_state"}`)
-- [ ] extend `buildPiSpawnArgs(agent, resumeSessionId?)` → push `--session <id>` iff present; thread through `spawnPiRpcSession(agent, resumeSessionId?)`
-- [ ] session-manager Pi spawn: open ONE `readPiStream(child)`, `sendPiGetState`, read until the `SystemInit` record, capture `session_id` → `ActiveSession.sessionId` + `store.setSession`, then STOP that generator (single-consumer contract: per-message `readPiStream` created fresh, prior generator fully drained)
-- [ ] resume path: stored Pi session → spawn with `resumeSessionId = stored.sessionId`
-- [ ] write tests (spawn path via `mock.module` stub of pi-rpc-protocol exports): `buildPiSpawnArgs` adds `--session` iff resume id; get_state SystemInit captured + persisted; single-consumer read terminates cleanly; claude path still bot-generates `--session-id` (regression)
-- [ ] run tests — must pass before next task
+- [x] add `buildGetStateCommand()` + `sendPiGetState(child)` (writes `{type:"get_state"}`)
+- [x] extend `buildPiSpawnArgs(agent, resumeSessionId?)` → push `--session <id>` iff present; thread through `spawnPiRpcSession(agent, resumeSessionId?)`
+- [x] session-manager Pi spawn: open ONE `readPiStream(child)`, `sendPiGetState`, read until the `SystemInit` record, capture `session_id` → `ActiveSession.sessionId` + `store.setSession`, then STOP that generator (single-consumer contract: per-message `readPiStream` created fresh, prior generator fully drained)
+- [x] resume path: stored Pi session → spawn with `resumeSessionId = stored.sessionId`
+- [x] write tests (spawn path via `mock.module` stub of pi-rpc-protocol exports): `buildPiSpawnArgs` adds `--session` iff resume id; get_state SystemInit captured + persisted; single-consumer read terminates cleanly; claude path still bot-generates `--session-id` (regression)
+- [x] run tests — must pass before next task
 
 ### Task 4: Graceful resume-recovery (Pi-path, signal-matched, inline, at-most-once)
 

--- a/docs/plans/completed/2026-05-31-pi-rpc-plan-b-session-dispatch.md
+++ b/docs/plans/completed/2026-05-31-pi-rpc-plan-b-session-dispatch.md
@@ -160,9 +160,9 @@ First fix the independent translator bug (only `agent_end` terminates). Then `se
 **Files:**
 - Modify: `README.md` (repo ROOT — NOT bot/README.md)
 
-- [ ] short note: translator multi-turn fix + provider dispatch + get_state session-id capture + graceful resume-recovery + Pi steer; claude path unchanged
-- [ ] PR description: "Plan B — dispatch wiring; turn_end multi-turn truncation fix; get_state session-id capture + resume; graceful resume-recovery (replaces migration-only MF4); Pi mid-turn steer; claude path unchanged; coder PoC unblocked after merge"
-- [ ] move this plan to `docs/plans/completed/`
+- [x] short note: translator multi-turn fix + provider dispatch + get_state session-id capture + graceful resume-recovery + Pi steer; claude path unchanged (README.md "Provider backends" + "Monitoring" sections updated: dispatch-wired status, 4-bullet feature summary, `bot_pi_session_resume_discarded_total` metric)
+- [x] PR description: "Plan B — dispatch wiring; turn_end multi-turn truncation fix; get_state session-id capture + resume; graceful resume-recovery (replaces migration-only MF4); Pi mid-turn steer; claude path unchanged; coder PoC unblocked after merge"
+- [x] move this plan to `docs/plans/completed/`
 
 ## Post-Completion
 *Items requiring manual intervention — no checkboxes, informational only*


### PR DESCRIPTION
## Pi RPC — Plan B: session-manager dispatch + multi-turn fix

Second of the Pi-harness implementation PRs. Wires the Plan A protocol module into the live session lifecycle so `provider: "pi"` runs end-to-end, and fixes a multi-turn translation bug. The `claude` path is unchanged (every change gated on `agent.provider === "pi"`).

### What's in this PR
- **Translator multi-turn fix** (`pi-rpc-protocol.ts`): only `agent_end` is terminal; `turn_end` → null. Previously both mapped to the terminal result, truncating any tool-using (multi-turn) response at the first turn. (Verified live: `turn_end` fires per-turn, `agent_end` once.)
- **Provider dispatch** (`session-manager.ts`): 3 call sites route to the Pi protocol when `provider: "pi"`, else claude.
- **Session-id capture + resume**: Pi generates the id (no flag to force one), so the bot issues `get_state` after spawn, captures the id, persists it, and resumes via `--session <id>`.
- **Graceful resume-recovery**: a resume that fails with the unambiguous "session not found" signal → discard the stored id, one fresh start, log + metric (`pi_session_resume_discarded_total`). Other failures keep the existing backoff (no history discarded).
- **Mid-turn steer** (`message-queue.ts` + `telegram-bot.ts` + `discord-bot.ts`): a message arriving during a live Pi turn is delivered via RPC `steer`; the claude path keeps the inject-file hook.

### Verification
- `tsc --noEmit` clean; full suite **1156/1156 pass**.
- Forbidden files untouched: `cli-protocol.ts`, `cron-runner.ts` (cron = Plan C).
- New tests: `session-manager-pi-spawn.test.ts` (spawn/capture/recovery), plus additions to message-queue / pi-rpc-protocol / session-manager / metrics / provider-config suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
