### PR TITLE
fix(subagent): make bundled agents + workflow prompts self-contained

### DIFF
--- a/bot/.claude/extensions/subagent/README.md
+++ b/bot/.claude/extensions/subagent/README.md
@@ -6,27 +6,43 @@ Delegate tasks to specialized subagents with isolated context windows.
 
 This is the upstream Pi `subagent` example, ADOPTED as a bot Pi extension and
 loaded into every `pi --mode rpc` spawn via `--extension` (see
-`resolvePiExtensionArgs` in `bot/src/pi-rpc-protocol.ts`). The ONLY behavioral
-change from upstream is the **provider wiring**: each spawned child runs on the
-bot's `openai-codex` provider/model (parity with the parent session) instead of
-the vendor's hardcoded Claude models. That wiring — plus the child-output (JSONL)
-parser, the result classifier, the dependency-injected child runner, and the
-structured child-error warn-log — lives in the unit-tested pure helper
-`bot/src/pi-extensions/subagent-args.ts` (single source of truth); `index.ts`
-is a thin orchestrator over it. The sample agents below have had their
-Claude-specific `model:` frontmatter REMOVED so each inherits the codex default
-(`buildSubagentSpawnArgs` injects `--provider openai-codex`).
+`resolvePiExtensionArgs` in `bot/src/pi-rpc-protocol.ts`). Two behavioral changes
+from upstream:
+
+1. **Provider wiring**: each spawned child runs on the bot's `openai-codex`
+   provider/model (parity with the parent session) instead of the vendor's
+   hardcoded Claude models. That wiring — plus the child-output (JSONL) parser,
+   the result classifier, the dependency-injected child runner, the agent
+   precedence-merge, and the structured child-error warn-log — lives in the
+   unit-tested pure helper `bot/src/pi-extensions/subagent-args.ts` (single
+   source of truth); `index.ts` is a thin orchestrator over it. The sample agents
+   below have had their Claude-specific `model:` frontmatter REMOVED so each
+   inherits the codex default (`buildSubagentSpawnArgs` injects `--provider
+   openai-codex`).
+2. **Self-contained discovery**: the bundled agents (`agents/*.md`) and workflow
+   prompts (`prompts/*.md`) are auto-discovered from the extension's OWN dir
+   (resolved from the module via `import.meta.url`, not cwd), so the extension
+   works on `--extension` load with no symlink setup. Bundled definitions are the
+   **lowest-precedence baseline** — user (`~/.pi/agent/agents`, `~/.pi/agent/prompts`)
+   and project (`.pi/agents`, `.pi/prompts`) definitions layer on top and
+   **override the bundled ones by name**. `discoverAgents` always loads the
+   bundled `agents/` dir first regardless of `agentScope`; the bundled `prompts/`
+   dir is registered via a `resources_discover` handler in `index.ts`.
 
 **Tool/param contract:** the registered tool is named `subagent`; modes are
 `single` (`{ agent, task }`), `parallel` (`{ tasks: [...] }`), and `chain`
 (`{ chain: [...] }` with a `{previous}` placeholder) — the same contract the
 workflow prompts in `prompts/` and the bot's delegation skills invoke.
 
-> **Note:** the sections below (Sample Agents, Agent Definitions, Installation)
-> are retained verbatim from upstream as reference. In this bot they do NOT
-> reflect the live deployment: the sample agents' Claude `model:` frontmatter is
-> removed (children inherit the `openai-codex` default), and loading is via
-> `--extension` (see above), not the symlink commands shown under Installation.
+> **Note:** the Installation section below is retained verbatim from upstream as
+> reference and does NOT reflect the live deployment. In this bot the extension
+> is loaded via `--extension` (see above), and the bundled agents + prompts are
+> auto-discovered from the extension's own dir (see "Self-contained discovery")
+> — the symlink commands under Installation are NOT needed. The sample agents'
+> Claude `model:` frontmatter is also removed (children inherit the
+> `openai-codex` default). Users MAY still add or override agents/prompts in the
+> user (`~/.pi/agent/...`) or project (`.pi/...`) dirs; those override the
+> bundled ones by name.
 
 ## Features
 
@@ -84,7 +100,7 @@ This tool executes a separate `pi` subprocess with a delegated system prompt and
 
 **Project-local agents** (`.pi/agents/*.md`) are repo-controlled prompts that can instruct the model to read files, run bash commands, etc.
 
-**Default behavior:** Only loads **user-level agents** from `~/.pi/agent/agents`.
+**Default behavior:** Loads the **bundled agents** (shipped with this extension, lowest precedence) plus **user-level agents** from `~/.pi/agent/agents` (which override bundled by name). Project-local agents are NOT loaded by default.
 
 To enable project-local agents, pass `agentScope: "both"` (or `"project"`). Only do this for repositories you trust.
 
@@ -163,11 +179,12 @@ model: claude-haiku-4-5
 System prompt for the agent goes here.
 ```
 
-**Locations:**
-- `~/.pi/agent/agents/*.md` - User-level (always loaded)
+**Locations (precedence, lowest → highest):**
+- `<extension>/agents/*.md` - Bundled (always loaded, the baseline)
+- `~/.pi/agent/agents/*.md` - User-level (loaded unless `agentScope: "project"`)
 - `.pi/agents/*.md` - Project-level (only with `agentScope: "project"` or `"both"`)
 
-Project agents override user agents with the same name when `agentScope: "both"`.
+Later sources override earlier ones with the same name: user overrides bundled; project overrides both (when `agentScope` includes project). The bundled agents always load regardless of `agentScope`, so the extension is self-contained.
 
 ## Sample Agents
 
@@ -185,6 +202,8 @@ Project agents override user agents with the same name when `agentScope: "both"`
 | `/implement <query>` | scout → planner → worker |
 | `/scout-and-plan <query>` | scout → planner |
 | `/implement-and-review <query>` | worker → reviewer → worker |
+
+These are auto-discovered from the bundled `prompts/` dir via the extension's `resources_discover` handler (lowest precedence). User (`~/.pi/agent/prompts`) and project (`.pi/prompts`) prompts of the same name override the bundled ones.
 
 ## Error Handling
 

--- a/bot/.claude/extensions/subagent/agents.ts
+++ b/bot/.claude/extensions/subagent/agents.ts
@@ -4,9 +4,13 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { mergeAgentsByPrecedence } from "../../../src/pi-extensions/subagent-args.js";
 
 export type AgentScope = "user" | "project" | "both";
+
+export type AgentSource = "bundled" | "user" | "project";
 
 export interface AgentConfig {
 	name: string;
@@ -14,7 +18,7 @@ export interface AgentConfig {
 	tools?: string[];
 	model?: string;
 	systemPrompt: string;
-	source: "user" | "project";
+	source: AgentSource;
 	filePath: string;
 }
 
@@ -23,7 +27,7 @@ export interface AgentDiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
-function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
+function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
 	if (!fs.existsSync(dir)) {
@@ -94,25 +98,28 @@ function findNearestProjectAgentsDir(cwd: string): string | null {
 	}
 }
 
+/**
+ * Resolve the extension's OWN bundled `agents/` dir from this module's location
+ * (NOT cwd), so the bundled agents load wherever the extension is loaded from.
+ */
+function bundledAgentsDir(): string {
+	return path.join(path.dirname(fileURLToPath(import.meta.url)), "agents");
+}
+
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
 	const userDir = path.join(getAgentDir(), "agents");
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 
+	// Bundled agents are the always-loaded baseline (lowest precedence), so the
+	// extension is self-contained on `--extension` load regardless of `scope`.
+	const bundledAgents = loadAgentsFromDir(bundledAgentsDir(), "bundled");
 	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");
 	const projectAgents = scope === "user" || !projectAgentsDir ? [] : loadAgentsFromDir(projectAgentsDir, "project");
 
-	const agentMap = new Map<string, AgentConfig>();
+	// Layer low→high: bundled, then user, then project override by name.
+	const agents = mergeAgentsByPrecedence<AgentConfig>([bundledAgents, userAgents, projectAgents]);
 
-	if (scope === "both") {
-		for (const agent of userAgents) agentMap.set(agent.name, agent);
-		for (const agent of projectAgents) agentMap.set(agent.name, agent);
-	} else if (scope === "user") {
-		for (const agent of userAgents) agentMap.set(agent.name, agent);
-	} else {
-		for (const agent of projectAgents) agentMap.set(agent.name, agent);
-	}
-
-	return { agents: Array.from(agentMap.values()), projectAgentsDir };
+	return { agents, projectAgentsDir };
 }
 
 export function formatAgentList(agents: AgentConfig[], maxItems: number): { text: string; remaining: number } {

--- a/bot/.claude/extensions/subagent/index.ts
+++ b/bot/.claude/extensions/subagent/index.ts
@@ -16,13 +16,14 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { type ExtensionAPI, getMarkdownTheme, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.ts";
+import { type AgentConfig, type AgentScope, type AgentSource, discoverAgents } from "./agents.ts";
 // Provider wiring (openai-codex), child JSONL parse, result classification, and
 // the child-error warn-log all live in the unit-tested pure helper (single
 // source of truth — see bot/src/pi-extensions/README.md). This wrapper stays a
@@ -164,7 +165,7 @@ interface UsageStats {
 
 interface SingleResult {
 	agent: string;
-	agentSource: "user" | "project" | "unknown";
+	agentSource: AgentSource | "unknown";
 	task: string;
 	exitCode: number;
 	messages: Message[];
@@ -403,6 +404,16 @@ const SubagentParams = Type.Object({
 });
 
 export default function (pi: ExtensionAPI) {
+	// Make the bundled workflow prompts (prompts/*.md: /implement, /scout-and-plan,
+	// /implement-and-review) self-contained: register the extension's OWN prompts
+	// dir (resolved from this module, NOT cwd) as an additional prompt source on
+	// load. Pi appends these AFTER the global/project defaults and dedupes by name
+	// keeping the first occurrence, so user (~/.pi/agent/prompts) and project
+	// (.pi/prompts) prompts override the bundled ones by name (lowest precedence).
+	pi.on("resources_discover", () => ({
+		promptPaths: [path.join(path.dirname(fileURLToPath(import.meta.url)), "prompts")],
+	}));
+
 	pi.registerTool({
 		name: "subagent",
 		label: "Subagent",

--- a/bot/src/__tests__/subagent.test.ts
+++ b/bot/src/__tests__/subagent.test.ts
@@ -9,6 +9,7 @@ import {
   getFinalOutput,
   getResultOutput,
   isFailedResult,
+  mergeAgentsByPrecedence,
   normalizeSubagentModel,
   parseSubagentEventLine,
   runSubagentChild,
@@ -417,5 +418,57 @@ describe("subagent: runSubagentChild (mock spawn)", () => {
     child.emitClose(0);
     await promise;
     assert.deepEqual(snapshots, ["step 1", "step 2"]);
+  });
+});
+
+// ---- agent discovery precedence ---------------------------------------------
+//
+// `discoverAgents` (bot/.claude/extensions/subagent/agents.ts) reads the real
+// dirs via the pi runtime (a jiti-only dep that does NOT resolve under the node
+// test runner), so the load-bearing precedence logic is extracted here as a pure
+// helper and tested directly. The full runtime path (bundled-dir resolution from
+// import.meta.url + actual frontmatter parsing) is verified live by the main
+// agent, not in CI.
+
+describe("subagent: mergeAgentsByPrecedence", () => {
+  type Agent = { name: string; source: "bundled" | "user" | "project" };
+  const agent = (name: string, source: Agent["source"]): Agent => ({ name, source });
+
+  it("resolves the bundled agents when user and project layers are empty", () => {
+    const bundled = [agent("scout", "bundled"), agent("planner", "bundled")];
+    const merged = mergeAgentsByPrecedence<Agent>([bundled, [], []]);
+    assert.deepEqual(
+      merged.map((a) => a.name),
+      ["scout", "planner"],
+    );
+    assert.ok(merged.every((a) => a.source === "bundled"));
+  });
+
+  it("lets a user agent OVERRIDE a bundled agent of the same name", () => {
+    const bundled = [agent("scout", "bundled")];
+    const user = [agent("scout", "user")];
+    const merged = mergeAgentsByPrecedence<Agent>([bundled, user, []]);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].source, "user");
+  });
+
+  it("lets a project agent OVERRIDE both bundled and user (highest precedence)", () => {
+    const merged = mergeAgentsByPrecedence<Agent>([
+      [agent("scout", "bundled")],
+      [agent("scout", "user")],
+      [agent("scout", "project")],
+    ]);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].source, "project");
+  });
+
+  it("keeps a custom user agent additive alongside the bundled baseline", () => {
+    const bundled = [agent("scout", "bundled"), agent("worker", "bundled")];
+    const user = [agent("custom", "user")];
+    const merged = mergeAgentsByPrecedence<Agent>([bundled, user, []]);
+    assert.deepEqual(
+      merged.map((a) => `${a.name}:${a.source}`),
+      ["scout:bundled", "worker:bundled", "custom:user"],
+    );
   });
 });

--- a/bot/src/pi-extensions/subagent-args.ts
+++ b/bot/src/pi-extensions/subagent-args.ts
@@ -453,3 +453,34 @@ export function runSubagentChild(deps: RunSubagentChildDeps): Promise<SubagentRu
     }
   });
 }
+
+// ---- agent discovery precedence (pure) --------------------------------------
+
+/** Any discovered agent — keyed by `name` for precedence merging. */
+export interface NamedAgent {
+  name: string;
+}
+
+/**
+ * Merge ordered agent layers by `name`, lowest precedence FIRST.
+ *
+ * Backs `discoverAgents` in the wrapper (`bot/.claude/extensions/subagent/
+ * agents.ts`), which reads the real dirs (pi-runtime dep) and passes the parsed
+ * layers here. Pass layers low→high: `[bundled, user, project]`. Each later
+ * layer OVERRIDES an earlier one with the same `name`; novel names are additive.
+ * Insertion order of the result follows first-seen order across layers (a later
+ * override keeps the earlier slot), so the bundled baseline stays stable.
+ *
+ * The bundled layer is always included by the caller regardless of scope, so the
+ * extension is self-contained; user/project layers the caller omits per scope
+ * simply arrive empty here.
+ */
+export function mergeAgentsByPrecedence<T extends NamedAgent>(layers: T[][]): T[] {
+  const byName = new Map<string, T>();
+  for (const layer of layers) {
+    for (const agent of layer) {
+      byName.set(agent.name, agent);
+    }
+  }
+  return Array.from(byName.values());
+}


### PR DESCRIPTION
## Problem

The `subagent` extension ships 4 agent definitions (`agents/*.md`) and 3 workflow prompts (`prompts/*.md`), but **never loaded them at runtime**:

- `discoverAgents()` read only the user dir (`~/.pi/agent/agents`) and the nearest project dir (`.pi/agents`). The extension's own bundled `agents/` dir was not a discovery source.
- The 3 workflow prompts were similarly never surfaced (no `resources_discover` handler).

Net effect with the default scope: the tool resolved **zero** agents → every subagent call failed with `Unknown agent ... Available agents: none`. The extension was non-functional on a plain `--extension` load.

## Fix (self-contained)

- **Agents:** `discoverAgents` now adds the extension's own bundled `agents/` dir (resolved from the module via `import.meta.url`, not cwd) as an **always-loaded, lowest-precedence** source. User (`~/.pi/agent/agents`) and project (`.pi/agents`) dirs still load and **override bundled agents by name** — so the 4 defaults work out of the box, and users can add or override their own. New `"bundled"` value on the `source` union.
- **Prompts:** added a `resources_discover` handler returning the bundled `prompts/` dir via `import.meta.url`. Confirmed against the runtime's resource-loader: extension `promptPaths` are appended after defaults and deduped first-wins → bundled = lowest precedence, user/project override by name.
- The precedence merge was extracted into a pure helper (`mergeAgentsByPrecedence`) so it is unit-testable (the discovery module itself depends on the runtime package and can't be imported by the test runner).
- README corrected: the prior "only loads user-level agents / symlink install required" notes were misleading; it now states the extension is self-contained and how precedence works.

## Verification

- **Unit:** 4 new tests on `mergeAgentsByPrecedence` (bundled-only resolves; user overrides bundled by name; project overrides both; custom user is additive). Full suite: **1304 pass / 0 fail**, `tsc --noEmit` clean.
- **Live (runtime path CI can't reach):** loaded the real extension under `pi --extension` and invoked the tool with a bogus agent name. The runtime now reports:
  `Unknown agent: "__nope__". Available agents: "planner", "reviewer", "scout", "worker".`
  (previously `none`) — confirms the `import.meta.url` bundled-dir resolution + frontmatter loading work end-to-end at the default scope.

Follow-up to the Phase-2 extensions PR; addresses the bundled-agents-never-loaded finding left for maintainer decision.