### PR TITLE
feat: add Codex quota status pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,15 @@ Six hooks are wired in `.claude/settings.json`:
 - `session-end-commit.sh` — commits staged changes on session exit (SessionEnd)
 - `session-start-recovery.sh` — recovers orphaned staged changes (SessionStart)
 
+## Bot Architecture Notes
+
+- Telegram and Discord `/status` must use `bot/src/status-report.ts` for shared rendering.
+- `/status` is local-only: read quota data with `readQuotaStatus()` and never call Pi, Codex, the network, or Pi `get_state` from a status command.
+- Live Pi sessions stay on `transport: auto`; only `bot/scripts/codex-quota-sampler.ts` creates an isolated sampler cwd with `transport: "sse"`.
+- `bot/.claude/extensions/codex-usage.ts` is sampler-only and must not be added to the normal Pi RPC extension list.
+- Use `thinking` for `provider: pi`; use `effort` for Claude agents.
+- Sampler dry-run check: `cd bot && CODEX_QUOTA_TEXTFILE_DIR=/tmp/codex-quota-test CODEX_QUOTA_STATE_FILE=/tmp/codex-quota-test/state.json npx tsx scripts/codex-quota-sampler.ts --dry-run`.
+
 ## Skills
 
 Skills live in `.claude/skills/`. Each skill has a `SKILL.md` and optional helper scripts in `scripts/`.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ agents:
 
 A `pi` agent must set an explicit, Pi-appropriate `model` (e.g. `model: gpt-5.5`). Unlike a `claude` agent it does **not** inherit the top-level `defaultModel` — that value is Claude-oriented (e.g. `opus`) and the Pi spawn path would otherwise prefix it into a nonsensical `openai-codex/opus` string. The bot refuses to start if a `pi` agent omits `model`.
 
+Pi agents may also set `thinking`, which is passed as Pi `--thinking`. Allowed
+values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Claude agents
+continue to use `effort: low|medium|high`; `thinking` is only for `provider: pi`.
+
 Pi support is rolling out incrementally. The protocol layer is the typed Pi RPC module ([bot/src/pi-rpc-protocol.ts](bot/src/pi-rpc-protocol.ts)) — a newline-only JSONL splitter, spawn/send helpers, and a `parsePiEvent` translator that maps Pi RPC events into the bot's existing `StreamLine` shapes — plus the Pi Prometheus metrics listed under [Monitoring](#monitoring). **Session dispatch is now wired**: the [Session Manager](#architecture) branches on `agent.provider`, so a chat bound to a `pi` agent spawns via Pi RPC, streams to Telegram/Discord, persists and resumes its session across restarts, and is steerable mid-turn — while the `claude` path stays byte-identical. Specifically, this stage adds:
 
 - a multi-turn translator fix — only Pi's `agent_end` event terminates a turn (`turn_end` is a per-turn boundary), so a tool-using response delivers its final answer instead of truncating;
@@ -385,6 +389,175 @@ metricsPort: 9090
 See [bot/src/metrics.ts](bot/src/metrics.ts) for the full list of exported metrics.
 
 The Pi RPC provider (see [Provider backends](#provider-backends)) registers its own metrics: `bot_pi_turn_duration_seconds` (histogram, label `agent_id`, same buckets as the Claude turn histogram for direct comparison), the retry counters `bot_pi_retry_total`, `bot_pi_429_total`, `bot_pi_overload_total`, and `bot_pi_retry_unknown_total` (every retry increments `bot_pi_retry_total` plus exactly one signal-specific counter), and `bot_pi_session_resume_discarded_total` (label `agent_id`, incremented once per graceful resume-recovery — a stored Pi session id Pi could not find, discarded for one fresh start). They read zero until an agent runs with `provider: pi`.
+
+#### Codex quota sampler
+
+Telegram and Discord `/status` use the same compact local renderer. The normal
+healthy output shows session count, uptime, agent/provider, model,
+thinking/effort, processing-or-idle state, and session id. It omits noisy
+diagnostics such as RSS memory, PID, restart count, and last success unless those
+values are actionable: dead process, non-zero restarts, or missing/stale last
+success.
+
+Codex quota in `/status` is also local-only. The command never calls Pi, Codex,
+or the network; it only reads the sampler cache from `CODEX_QUOTA_STATE_FILE` (or
+the default cache path). If the cache is fresh, `/status` shows 5-hour and weekly
+used/left percentages, reset ETA, plan/active-limit metadata when present, sample
+age, and last probe attempt. If the cache is stale, missing, or malformed, it says
+so explicitly instead of probing live.
+
+A separate low-frequency sampler runs a tiny Pi SSE probe, loads only
+`bot/.claude/extensions/codex-usage.ts`, and writes:
+
+- JSON cache: `CODEX_QUOTA_STATE_FILE`, defaulting to
+  `bot/.tmp/codex-quota-state.json` when run from `bot/`.
+- Prometheus usage textfile: `codex_usage.prom` in `CODEX_QUOTA_TEXTFILE_DIR`,
+  `NODE_EXPORTER_TEXTFILE_DIR`, or `/opt/homebrew/var/node_exporter/textfile`
+  when that directory is writable.
+- Prometheus probe textfile: `codex_usage_probe.prom` in the same textfile dir.
+
+The sampler fails loudly if no configured or writable Prometheus textfile
+directory is available, rather than writing metrics to an unsupervised fallback
+directory.
+
+A sampler attempt is considered successful only when the Pi child exits cleanly
+and the JSON cache is refreshed by quota headers from that attempt. Missing
+headers, write warnings, timeouts, and non-zero exits record a failed attempt,
+preserve the last successful quota values, and leave `codex_usage.prom` unchanged.
+The JSON cache is still updated with `lastAttempt`, `lastAttemptTimestamp`, and
+`probeSuccess` when the existing cache is valid, so `/status` can report the
+latest failed probe without probing live.
+
+Normal Pi conversations must stay on `transport: auto`. Do not set global
+`~/.pi/agent/settings.json` or the bot workspace `.pi/settings.json` to
+`transport: "sse"` for live sessions. Codex quota headers are available on Pi's
+Codex SSE path, but live Codex SSE can fail before any response body with
+`Codex SSE response headers timed out after 10000ms`
+(`DEFAULT_SSE_HEADER_TIMEOUT_MS = 10_000`). Forcing that path globally would make
+interactive Telegram or Discord conversations less reliable. The sampler creates
+its own isolated project cwd and writes `{ "transport": "sse" }` only there, so a
+slow or failed SSE header probe cannot degrade live sessions.
+
+Sampler command:
+
+```bash
+cd ~/.minime/bot
+CODEX_QUOTA_TEXTFILE_DIR=/opt/homebrew/var/node_exporter/textfile \
+CODEX_QUOTA_STATE_FILE=$PWD/.tmp/codex-quota-state.json \
+npx tsx scripts/codex-quota-sampler.ts
+```
+
+Supported CLI flags:
+
+| Flag | Description |
+|---|---|
+| `--model <model>` | Probe model; same normalization as `CODEX_QUOTA_MODEL`. |
+| `--textfile-dir <dir>` | Prometheus textfile directory. |
+| `--state-file <file>` | Codex quota JSON state file. |
+| `--sampler-cwd <dir>` | Isolated cwd that receives `.pi/settings.json`. |
+| `--timeout-ms <ms>` / `--timeout <ms>` | Wall-clock timeout for the Pi child. |
+| `--pi-bin <path>` | Pi binary path/name. |
+| `--prompt <text>` | Minimal prompt sent to Pi. |
+| `--dry-run` | Print resolved command/settings without launching Pi or writing attempt metrics. |
+| `--help` / `-h` | Print sampler help. |
+
+Supported environment variables:
+
+| Variable | Description |
+|---|---|
+| `CODEX_QUOTA_MODEL` | Probe model. Defaults to `openai-codex/gpt-5.5`; unqualified names are prefixed with `openai-codex/`. |
+| `CODEX_QUOTA_TEXTFILE_DIR` | Directory for `codex_usage.prom` and `codex_usage_probe.prom`; takes precedence over `NODE_EXPORTER_TEXTFILE_DIR`. |
+| `NODE_EXPORTER_TEXTFILE_DIR` | Fallback textfile directory used when `CODEX_QUOTA_TEXTFILE_DIR` is unset. |
+| `CODEX_QUOTA_STATE_FILE` | JSON cache read by `/status`. The bot and sampler must agree on this path. |
+| `CODEX_QUOTA_SAMPLER_CWD` | Isolated sampler project cwd. Defaults to the system temp dir. |
+| `CODEX_QUOTA_TIMEOUT_MS` | Wall-clock timeout for the Pi child. Defaults to 20000. |
+| `CODEX_QUOTA_DRY_RUN` | Boolean-like dry-run switch; prints the resolved command without launching Pi. |
+| `CODEX_QUOTA_PI_BIN` | Pi binary path/name. Defaults to `pi`. |
+| `CODEX_QUOTA_STALE_MS` | `/status` stale threshold for cached quota data. Defaults to 1800000 (30 minutes). |
+
+JSON cache shape:
+
+```json
+{
+  "provider": "codex",
+  "sampledAt": "2026-06-05T12:00:01.000Z",
+  "lastSuccess": "2026-06-05T12:00:01.000Z",
+  "lastSuccessTimestamp": 1001,
+  "lastAttempt": "2026-06-05T12:00:00.000Z",
+  "lastAttemptTimestamp": 1000,
+  "probeSuccess": true,
+  "planType": "Pro",
+  "activeLimit": "primary",
+  "windows": {
+    "5h": { "usedPercent": 12.5, "remainingPercent": 87.5, "resetTimestamp": 2800 },
+    "week": { "usedPercent": 88, "remainingPercent": 12, "resetTimestamp": 7200 }
+  }
+}
+```
+
+Prometheus textfiles:
+
+| Metric | File | Description |
+|---|---|---|
+| `codex_usage_5h_percent` | `codex_usage.prom` | Last successful 5-hour usage percent. |
+| `codex_usage_weekly_percent` | `codex_usage.prom` | Last successful weekly usage percent. |
+| `codex_usage_5h_reset_timestamp` | `codex_usage.prom` | Unix reset timestamp for the 5-hour window. |
+| `codex_usage_weekly_reset_timestamp` | `codex_usage.prom` | Unix reset timestamp for the weekly window. |
+| `codex_usage_last_success_timestamp` | `codex_usage.prom` | Unix timestamp of the last successful quota sample. |
+| `codex_usage_info` | `codex_usage.prom` | Low-cardinality `provider`, `plan_type`, and `active_limit` labels. |
+| `codex_usage_last_attempt_timestamp` | `codex_usage_probe.prom` | Unix timestamp of the last sampler attempt. |
+| `codex_usage_probe_success` | `codex_usage_probe.prom` | `1` only when the attempt refreshed the quota cache. |
+
+Run the sampler every 15-30 minutes. Keep `CODEX_QUOTA_STALE_MS` at least as
+large as the scheduled interval plus normal launch jitter; the default 30-minute
+threshold fits a 15-minute schedule, while a 30-minute schedule should set a
+larger value such as 2700000.
+
+Example private `crons.local.yaml` entry. Redirect stdout/stderr so the bot's
+script cron runner skips success delivery and only notifies the delivery chat on
+failure:
+
+```yaml
+crons:
+  - name: codex-quota-sampler
+    type: script
+    schedule: "*/15 * * * *"
+    command: >
+      cd /absolute/path/to/minime/bot &&
+      CODEX_QUOTA_TEXTFILE_DIR=/opt/homebrew/var/node_exporter/textfile
+      CODEX_QUOTA_STATE_FILE=/absolute/path/to/minime/bot/.tmp/codex-quota-state.json
+      npx tsx scripts/codex-quota-sampler.ts
+      >> /absolute/path/to/minime/logs/codex-quota-sampler.log 2>&1
+    agentId: main
+    deliveryChatId: 123456789
+    timeout: 60000
+```
+
+Equivalent cron-style invocation:
+
+```cron
+*/15 * * * * cd /absolute/path/to/minime/bot && CODEX_QUOTA_TEXTFILE_DIR=/opt/homebrew/var/node_exporter/textfile CODEX_QUOTA_STATE_FILE=/absolute/path/to/minime/bot/.tmp/codex-quota-state.json npx tsx scripts/codex-quota-sampler.ts >> /absolute/path/to/minime/logs/codex-quota-sampler.log 2>&1
+```
+
+Prometheus alert expression:
+
+```promql
+codex_usage_5h_percent > 85 OR codex_usage_weekly_percent > 90
+```
+
+Post-merge private rollout: add a script cron or launchd entry for
+`scripts/codex-quota-sampler.ts`, confirm the bot and sampler use the same
+`CODEX_QUOTA_STATE_FILE`, and add the optional monitoring rule above to the
+private Prometheus configuration.
+
+Rollback: disable the sampler cron/launchd job first. If the bot was configured
+with custom quota env vars, unset `CODEX_QUOTA_STATE_FILE`,
+`CODEX_QUOTA_TEXTFILE_DIR`, `NODE_EXPORTER_TEXTFILE_DIR`, and
+`CODEX_QUOTA_STALE_MS` from the bot/sampler environment as applicable, then
+restart the bot only if its launchd environment changed. Existing live sessions
+remain on `transport: auto`; disabling quota visibility does not touch active Pi
+conversations. Remove or silence the private Prometheus alert separately if it
+was enabled.
 
 #### Telegram API metrics
 

--- a/bot/.claude/extensions/codex-usage.ts
+++ b/bot/.claude/extensions/codex-usage.ts
@@ -1,0 +1,28 @@
+/**
+ * Codex quota usage Pi extension wrapper.
+ *
+ * Loaded only by the out-of-band quota sampler. Normal bot-spawned Pi sessions
+ * keep their existing extension set and transport behavior; the sampler passes
+ * this wrapper explicitly for a tiny SSE probe so Codex response headers can be
+ * cached locally for `/status` and node_exporter.
+ */
+
+import {
+  captureCodexQuotaFromProviderResponse,
+  formatCodexQuotaWriteError,
+} from "../../src/pi-extensions/codex-usage.js";
+
+interface PiExtensionLike {
+  on: (eventName: string, handler: (...args: unknown[]) => unknown) => void;
+}
+
+export default function (pi: PiExtensionLike): void {
+  pi.on("after_provider_response", (...args: unknown[]) => {
+    const event = args.length === 1 ? args[0] : args;
+    const result = captureCodexQuotaFromProviderResponse(event);
+    if (result.status === "write_error") {
+      // eslint-disable-next-line no-console -- structured warning for the sampler process
+      console.warn(formatCodexQuotaWriteError(result.error));
+    }
+  });
+}

--- a/bot/scripts/codex-quota-sampler.ts
+++ b/bot/scripts/codex-quota-sampler.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env npx tsx
+
+import { runCodexQuotaSamplerFromCli } from "../src/codex-quota-sampler.js";
+
+runCodexQuotaSamplerFromCli().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[codex-quota-sampler] ${message}`);
+  process.exitCode = 1;
+});

--- a/bot/scripts/codex-quota-sampler.ts
+++ b/bot/scripts/codex-quota-sampler.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env npx tsx
-
 import { runCodexQuotaSamplerFromCli } from "../src/codex-quota-sampler.js";
 
 runCodexQuotaSamplerFromCli().catch((error: unknown) => {

--- a/bot/src/__tests__/codex-quota-sampler.test.ts
+++ b/bot/src/__tests__/codex-quota-sampler.test.ts
@@ -1,0 +1,580 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { PassThrough } from "node:stream";
+import {
+  CODEX_QUOTA_PROBE_TEXTFILE_NAME,
+  buildCodexQuotaSamplerArgs,
+  buildSamplerChildEnv,
+  ensureSamplerProjectSettings,
+  formatCodexQuotaSamplerHelp,
+  parseCodexQuotaSamplerArgs,
+  resolveCodexQuotaSamplerConfig,
+  runCodexQuotaSampler,
+  runPiProbe,
+  type SamplerChildLike,
+  type SamplerSpawn,
+} from "../codex-quota-sampler.js";
+import {
+  CODEX_QUOTA_ATTEMPT_FILE_ENV,
+  CODEX_USAGE_TEXTFILE_NAME,
+  captureCodexQuotaFromHeaders,
+} from "../pi-extensions/codex-usage.js";
+
+const fixtures: string[] = [];
+
+after(() => {
+  for (const dir of fixtures) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "codex-quota-sampler-test-"));
+  fixtures.push(dir);
+  return dir;
+}
+
+class FakeChild extends EventEmitter implements SamplerChildLike {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  kills: Array<NodeJS.Signals | number | undefined> = [];
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.kills.push(signal);
+    return true;
+  }
+
+  close(code: number | null): void {
+    this.emit("close", code);
+  }
+
+  fail(error: Error): void {
+    this.emit("error", error);
+  }
+}
+
+describe("codex quota sampler command setup", () => {
+  it("writes isolated project settings only in the sampler cwd", () => {
+    const workspace = tempDir();
+    const samplerCwd = join(workspace, "sampler");
+
+    const settingsFile = ensureSamplerProjectSettings(samplerCwd);
+
+    assert.equal(settingsFile, join(samplerCwd, ".pi", "settings.json"));
+    assert.deepEqual(JSON.parse(readFileSync(settingsFile, "utf8")), { transport: "sse" });
+    assert.equal(existsSync(join(workspace, ".pi", "settings.json")), false);
+    if (typeof process.getuid === "function") {
+      assert.equal(statSync(samplerCwd).mode & 0o077, 0);
+      assert.equal(statSync(join(samplerCwd, ".pi")).mode & 0o077, 0);
+      assert.equal(statSync(join(samplerCwd, ".tmp")).mode & 0o077, 0);
+    }
+  });
+
+  it("reuses sampler settings but refuses to overwrite other Pi project settings", () => {
+    const workspace = tempDir();
+    const samplerCwd = join(workspace, "sampler");
+    const settingsFile = join(samplerCwd, ".pi", "settings.json");
+    mkdirSync(dirname(settingsFile), { recursive: true });
+    writeFileSync(settingsFile, `${JSON.stringify({ transport: "sse" }, null, 2)}\n`);
+
+    assert.equal(ensureSamplerProjectSettings(samplerCwd), settingsFile);
+    assert.deepEqual(JSON.parse(readFileSync(settingsFile, "utf8")), { transport: "sse" });
+
+    const existingSettings = { transport: "auto", customSetting: true };
+    writeFileSync(settingsFile, `${JSON.stringify(existingSettings, null, 2)}\n`);
+
+    assert.throws(
+      () => ensureSamplerProjectSettings(samplerCwd),
+      /Refusing to overwrite existing Pi project settings/,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(settingsFile, "utf8")), existingSettings);
+  });
+
+  it("constructs a tiny explicit Pi SSE probe command", () => {
+    const args = buildCodexQuotaSamplerArgs({
+      model: "gpt-5.5",
+      extensionPath: "/abs/codex-usage.ts",
+      prompt: "OK?",
+    });
+
+    assert.deepEqual(args, [
+      "--provider",
+      "openai-codex",
+      "--model",
+      "openai-codex/gpt-5.5",
+      "--thinking",
+      "off",
+      "--no-context-files",
+      "--no-skills",
+      "--no-extensions",
+      "--extension",
+      "/abs/codex-usage.ts",
+      "--no-session",
+      "--no-tools",
+      "-p",
+      "OK?",
+    ]);
+  });
+
+  it("uses a private per-user sampler cwd by default", () => {
+    const cwd = tempDir();
+    const config = resolveCodexQuotaSamplerConfig({
+      cwd,
+      env: { CODEX_QUOTA_TEXTFILE_DIR: "metrics" },
+      extensionPath: "/abs/ext.ts",
+      forbiddenSamplerCwds: [],
+    });
+    const uid = typeof process.getuid === "function" ? String(process.getuid()) : "user";
+
+    assert.equal(config.samplerCwd, join(tmpdir(), `codex-quota-sampler-${uid}`));
+    assert.notEqual(config.samplerCwd, join(tmpdir(), "codex-quota-sampler"));
+  });
+
+  it("fails loudly when no Prometheus textfile directory is configured or writable", () => {
+    const cwd = tempDir();
+
+    assert.throws(
+      () => resolveCodexQuotaSamplerConfig({
+        cwd,
+        env: {},
+        extensionPath: "/abs/ext.ts",
+        forbiddenSamplerCwds: [],
+        isWritableDir: () => false,
+      }),
+      /requires a configured or writable Prometheus textfile directory/,
+    );
+  });
+
+  it("rejects sampler cwd values that target the bot dir or configured agent workspaces", () => {
+    const workspace = tempDir();
+    const botDir = join(workspace, "bot");
+    const agentWorkspace = join(workspace, "agent-workspace");
+    mkdirSync(botDir, { recursive: true });
+    writeFileSync(
+      join(workspace, "config.yaml"),
+      `
+defaultModel: opus
+agents:
+  main:
+    workspaceCwd: ${agentWorkspace}
+telegramTokenService: fake-token
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`,
+    );
+
+    assert.throws(
+      () => resolveCodexQuotaSamplerConfig({
+        cwd: workspace,
+        botDir,
+        env: {},
+        cli: { textfileDir: "metrics", samplerCwd: botDir },
+        extensionPath: "/abs/ext.ts",
+      }),
+      /Refusing to use sampler cwd/,
+    );
+    assert.throws(
+      () => resolveCodexQuotaSamplerConfig({
+        cwd: workspace,
+        botDir,
+        env: {},
+        cli: { textfileDir: "metrics", samplerCwd: agentWorkspace },
+        extensionPath: "/abs/ext.ts",
+      }),
+      /Refusing to use sampler cwd/,
+    );
+    assert.doesNotThrow(() => resolveCodexQuotaSamplerConfig({
+      cwd: workspace,
+      botDir,
+      env: {},
+      cli: { textfileDir: "metrics", samplerCwd: join(workspace, "isolated-sampler") },
+      extensionPath: "/abs/ext.ts",
+    }));
+  });
+
+  it("parses CLI flags and documents supported options", () => {
+    assert.deepEqual(
+      parseCodexQuotaSamplerArgs([
+        "--model",
+        "gpt-5.5",
+        "--textfile-dir",
+        "metrics",
+        "--state-file",
+        "quota.json",
+        "--sampler-cwd",
+        "sampler",
+        "--timeout",
+        "1234",
+        "--pi-bin",
+        "/opt/bin/pi",
+        "--prompt",
+        "OK?",
+        "--dry-run",
+      ]),
+      {
+        model: "gpt-5.5",
+        textfileDir: "metrics",
+        stateFile: "quota.json",
+        samplerCwd: "sampler",
+        timeoutMs: 1234,
+        piBin: "/opt/bin/pi",
+        prompt: "OK?",
+        dryRun: true,
+      },
+    );
+
+    assert.throws(() => parseCodexQuotaSamplerArgs(["--state-file"]), /requires a value/);
+    assert.throws(() => parseCodexQuotaSamplerArgs(["--timeout-ms", "0"]), /positive integer/);
+    assert.throws(() => parseCodexQuotaSamplerArgs(["--unknown"]), /Unknown argument/);
+
+    const help = formatCodexQuotaSamplerHelp();
+    for (const flag of ["--model", "--textfile-dir", "--state-file", "--sampler-cwd", "--timeout", "--timeout-ms", "--pi-bin", "--prompt", "--dry-run", "--help"]) {
+      assert.ok(help.includes(flag), `help should mention ${flag}`);
+    }
+  });
+
+  it("resolves CLI/env paths and passes only allowlisted values to the child env", () => {
+    const cwd = tempDir();
+    const config = resolveCodexQuotaSamplerConfig({
+      cwd,
+      env: {
+        CODEX_QUOTA_MODEL: "codex-mini",
+        CODEX_QUOTA_STATE_FILE: "quota/state.json",
+        CODEX_QUOTA_TEXTFILE_DIR: "metrics",
+        CODEX_QUOTA_SAMPLER_CWD: "sampler-cwd",
+        CODEX_QUOTA_TIMEOUT_MS: "1234",
+        CODEX_QUOTA_DRY_RUN: "off",
+        PATH: "/usr/bin",
+      },
+      extensionPath: "/abs/ext.ts",
+      forbiddenSamplerCwds: [],
+    });
+
+    assert.equal(config.model, "openai-codex/codex-mini");
+    assert.equal(config.stateFile, join(cwd, "quota", "state.json"));
+    assert.equal(config.textfileDir, join(cwd, "metrics"));
+    assert.equal(config.samplerCwd, join(cwd, "sampler-cwd"));
+    assert.equal(config.timeoutMs, 1234);
+    assert.equal(config.extensionPath, "/abs/ext.ts");
+
+    const attemptFile = join(cwd, "attempt.json");
+    const env = buildSamplerChildEnv({ ...config, attemptFile }, {
+      CLAUDE_CODE_OAUTH_TOKEN: "secret",
+      ANTHROPIC_API_KEY: "secret",
+      CLAUDECODE: "1",
+      TELEGRAM_BOT_TOKEN: "secret",
+      DISCORD_BOT_TOKEN: "secret",
+      TAVILY_API_KEY: "secret",
+      NODE_EXPORTER_TEXTFILE_DIR: "/ignored",
+      PATH: "/usr/bin",
+      HOME: "/Users/test",
+    });
+    assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, undefined);
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.CLAUDECODE, undefined);
+    assert.equal(env.TELEGRAM_BOT_TOKEN, undefined);
+    assert.equal(env.DISCORD_BOT_TOKEN, undefined);
+    assert.equal(env.TAVILY_API_KEY, undefined);
+    assert.equal(env.NODE_EXPORTER_TEXTFILE_DIR, undefined);
+    assert.equal(env.HOME, "/Users/test");
+    assert.equal(env.CODEX_QUOTA_STATE_FILE, config.stateFile);
+    assert.equal(env.CODEX_QUOTA_TEXTFILE_DIR, config.textfileDir);
+    assert.equal(env[CODEX_QUOTA_ATTEMPT_FILE_ENV], attemptFile);
+    assert.match(env.PATH ?? "", /^\/opt\/homebrew\/bin:/);
+  });
+
+  it("rejects invalid boolean environment values", () => {
+    assert.throws(
+      () => resolveCodexQuotaSamplerConfig({
+        env: {
+          CODEX_QUOTA_DRY_RUN: "maybe",
+          CODEX_QUOTA_TEXTFILE_DIR: "metrics",
+        },
+        forbiddenSamplerCwds: [],
+      }),
+      /CODEX_QUOTA_DRY_RUN must be boolean-like/,
+    );
+  });
+});
+
+describe("codex quota sampler probe execution", () => {
+  it("records a successful quota snapshot and probe attempt", async () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const textfileDir = join(dir, "metrics");
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const spawn: SamplerSpawn = (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      const child = new FakeChild();
+      setImmediate(() => {
+        const captured = captureCodexQuotaFromHeaders(
+          {
+            "x-codex-primary-used-percent": "12.5",
+            "x-codex-secondary-used-percent": "88",
+            "x-codex-primary-reset-at": "2026-06-05T17:00:00.000Z",
+            "x-codex-secondary-reset-at": "2026-06-12T00:00:00.000Z",
+          },
+          {
+            env: options.env,
+            now: new Date("2026-06-05T12:00:01.000Z"),
+          },
+        );
+        assert.equal(captured.status, "captured");
+        child.close(0);
+      });
+      return child;
+    };
+
+    const result = await runCodexQuotaSampler({
+      now: new Date("2026-06-05T12:00:00.000Z"),
+      spawn,
+      config: {
+        piBin: "pi",
+        model: "openai-codex/gpt-5.5",
+        prompt: "OK?",
+        stateFile,
+        textfileDir,
+        samplerCwd: join(dir, "sampler"),
+        extensionPath: "/abs/codex-usage.ts",
+        timeoutMs: 1_000,
+        killGraceMs: 10,
+        dryRun: false,
+      },
+    });
+
+    assert.equal(result.status, "success");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, "pi");
+    assert.equal(calls[0].cwd, join(dir, "sampler"));
+    assert.equal(calls[0].args.includes("--no-extensions"), true);
+    assert.equal(calls[0].args.includes("--extension"), true);
+    assert.ok(result.attemptFile?.startsWith(join(dir, "sampler", ".tmp")));
+    assert.equal(result.attemptMetricsFile, join(dir, "metrics", CODEX_QUOTA_PROBE_TEXTFILE_NAME));
+
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.windows["5h"].usedPercent, 12.5);
+    assert.equal(state.lastSuccessTimestamp, 1780660801);
+    assert.equal(state.lastAttemptTimestamp, 1780660800);
+    assert.equal(state.probeSuccess, true);
+
+    const usageMetrics = readFileSync(join(textfileDir, CODEX_USAGE_TEXTFILE_NAME), "utf8");
+    assert.match(usageMetrics, /codex_usage_5h_percent 12\.5/);
+
+    const metrics = readFileSync(result.attemptMetricsFile, "utf8");
+    assert.match(metrics, /codex_usage_last_attempt_timestamp 1780660800/);
+    assert.match(metrics, /codex_usage_probe_success 1/);
+    assert.equal(readdirSync(dirname(result.attemptMetricsFile)).some((name) => name.endsWith(".tmp")), false);
+  });
+
+  it("times out a hung child, kills it, and resolves as failure", async () => {
+    const child = new FakeChild();
+    const result = await runPiProbe({
+      command: "pi",
+      args: ["-p", "OK?"],
+      cwd: tempDir(),
+      env: {},
+      timeoutMs: 5,
+      killGraceMs: 5,
+      spawn: () => child,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.timedOut, true);
+    assert.equal(result.exitCode, null);
+    assert.deepEqual(child.kills, ["SIGTERM", "SIGKILL"]);
+  });
+
+  it("records failure attempts without overwriting prior successful state or usage metrics", async () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const textfileDir = join(dir, "metrics");
+    const successMetricsFile = join(textfileDir, "codex_usage.prom");
+    const priorState = {
+      provider: "codex",
+      sampledAt: "2026-06-05T12:00:00.000Z",
+      lastSuccess: "2026-06-05T12:00:00.000Z",
+      lastSuccessTimestamp: 1780660800,
+      windows: {
+        "5h": { usedPercent: 42 },
+        week: {},
+      },
+    };
+    const priorMetrics = "codex_usage_5h_percent 42\n";
+    mkdirSync(textfileDir, { recursive: true });
+    writeFileSync(stateFile, `${JSON.stringify(priorState, null, 2)}\n`);
+    writeFileSync(successMetricsFile, priorMetrics);
+
+    const spawn: SamplerSpawn = (_command, _args, options) => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        const captured = captureCodexQuotaFromHeaders(
+          { "x-codex-primary-used-percent": "99" },
+          {
+            env: options.env,
+            now: new Date("2026-06-05T12:30:01.000Z"),
+          },
+        );
+        assert.equal(captured.status, "captured");
+        child.stderr.write("provider failed\n");
+        child.close(1);
+      });
+      return child;
+    };
+
+    const result = await runCodexQuotaSampler({
+      now: new Date("2026-06-05T12:30:00.000Z"),
+      spawn,
+      config: {
+        piBin: "pi",
+        model: "openai-codex/gpt-5.5",
+        prompt: "OK?",
+        stateFile,
+        textfileDir,
+        samplerCwd: join(dir, "sampler"),
+        extensionPath: "/abs/codex-usage.ts",
+        timeoutMs: 1_000,
+        killGraceMs: 10,
+        dryRun: false,
+      },
+    });
+
+    assert.equal(result.status, "failure");
+    assert.equal(readFileSync(successMetricsFile, "utf8"), priorMetrics);
+
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.windows["5h"].usedPercent, 42);
+    assert.equal(state.lastSuccessTimestamp, 1780660800);
+    assert.equal(state.lastAttemptTimestamp, 1780662600);
+    assert.equal(state.probeSuccess, false);
+
+    const attemptMetrics = readFileSync(join(textfileDir, CODEX_QUOTA_PROBE_TEXTFILE_NAME), "utf8");
+    assert.match(attemptMetrics, /codex_usage_last_attempt_timestamp 1780662600/);
+    assert.match(attemptMetrics, /codex_usage_probe_success 0/);
+  });
+
+  it("writes failure attempt metrics even when attempt state cannot be updated", async () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state-as-dir");
+    const textfileDir = join(dir, "metrics");
+    mkdirSync(stateFile);
+
+    const spawn: SamplerSpawn = () => {
+      const child = new FakeChild();
+      setImmediate(() => child.close(0));
+      return child;
+    };
+
+    const result = await runCodexQuotaSampler({
+      now: new Date("2026-06-05T13:00:00.000Z"),
+      spawn,
+      config: {
+        piBin: "pi",
+        model: "openai-codex/gpt-5.5",
+        prompt: "OK?",
+        stateFile,
+        textfileDir,
+        samplerCwd: join(dir, "sampler"),
+        extensionPath: "/abs/codex-usage.ts",
+        timeoutMs: 1_000,
+        killGraceMs: 10,
+        dryRun: false,
+      },
+    });
+
+    assert.equal(result.status, "failure");
+    assert.match(result.failureReason ?? "", /probe attempt state write failed/);
+    const attemptMetricsFile = result.attemptMetricsFile;
+    assert.equal(attemptMetricsFile, join(textfileDir, CODEX_QUOTA_PROBE_TEXTFILE_NAME));
+    assert.ok(attemptMetricsFile);
+
+    const attemptMetrics = readFileSync(attemptMetricsFile, "utf8");
+    assert.match(attemptMetrics, /codex_usage_last_attempt_timestamp 1780664400/);
+    assert.match(attemptMetrics, /codex_usage_probe_success 0/);
+  });
+
+  it("treats child exit zero without a refreshed quota cache as failure", async () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const textfileDir = join(dir, "metrics");
+    const spawn: SamplerSpawn = () => {
+      const child = new FakeChild();
+      setImmediate(() => child.close(0));
+      return child;
+    };
+
+    const result = await runCodexQuotaSampler({
+      now: new Date("2026-06-05T12:45:00.000Z"),
+      spawn,
+      config: {
+        piBin: "pi",
+        model: "openai-codex/gpt-5.5",
+        prompt: "OK?",
+        stateFile,
+        textfileDir,
+        samplerCwd: join(dir, "sampler"),
+        extensionPath: "/abs/codex-usage.ts",
+        timeoutMs: 1_000,
+        killGraceMs: 10,
+        dryRun: false,
+      },
+    });
+
+    assert.equal(result.status, "failure");
+    assert.equal(result.failureReason, "quota cache was not refreshed");
+
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.provider, "codex");
+    assert.deepEqual(state.windows, { "5h": {}, week: {} });
+    assert.equal(state.lastAttemptTimestamp, 1780663500);
+    assert.equal(state.probeSuccess, false);
+
+    const attemptMetrics = readFileSync(join(textfileDir, CODEX_QUOTA_PROBE_TEXTFILE_NAME), "utf8");
+    assert.match(attemptMetrics, /codex_usage_probe_success 0/);
+  });
+
+  it("does not launch Pi or write files in dry-run mode", async () => {
+    const dir = tempDir();
+    let spawned = false;
+    const samplerCwd = join(dir, "sampler");
+
+    const result = await runCodexQuotaSampler({
+      spawn: () => {
+        spawned = true;
+        return new FakeChild();
+      },
+      config: {
+        piBin: "pi",
+        model: "openai-codex/gpt-5.5",
+        prompt: "OK?",
+        stateFile: join(dir, "state.json"),
+        textfileDir: join(dir, "metrics"),
+        samplerCwd,
+        extensionPath: "/abs/codex-usage.ts",
+        timeoutMs: 1_000,
+        killGraceMs: 10,
+        dryRun: true,
+      },
+    });
+
+    assert.equal(result.status, "dry_run");
+    assert.equal(spawned, false);
+    assert.equal(existsSync(samplerCwd), false);
+    assert.equal(existsSync(result.settingsFile), false);
+    assert.equal(existsSync(join(dir, "metrics", CODEX_QUOTA_PROBE_TEXTFILE_NAME)), false);
+  });
+});

--- a/bot/src/__tests__/codex-usage.test.ts
+++ b/bot/src/__tests__/codex-usage.test.ts
@@ -1,0 +1,335 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_USAGE_TEXTFILE_NAME,
+  captureCodexQuotaFromHeaders,
+  DEFAULT_NODE_EXPORTER_TEXTFILE_DIR,
+  extractCodexResponseHeaders,
+  formatCodexQuotaPrometheus,
+  formatCodexQuotaWriteError,
+  parseCodexQuotaHeaders,
+  recordCodexQuotaFromHeaders,
+  resolveCodexQuotaPaths,
+  writeCodexQuotaSnapshot,
+  type CodexQuotaSnapshot,
+} from "../pi-extensions/codex-usage.js";
+
+const fixtures: string[] = [];
+
+after(() => {
+  for (const dir of fixtures) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "codex-usage-test-"));
+  fixtures.push(dir);
+  return dir;
+}
+
+function sampleSnapshot(): CodexQuotaSnapshot {
+  const parsed = parseCodexQuotaHeaders(
+    {
+      "x-codex-primary-used-percent": "12.5",
+      "x-codex-secondary-used-percent": "88",
+      "x-codex-primary-reset-at": "2026-06-05T17:00:00.000Z",
+      "x-codex-secondary-reset-at": "2026-06-12T00:00:00.000Z",
+      "x-codex-plan-type": "Pro",
+      "x-codex-active-limit": "primary",
+    },
+    new Date("2026-06-05T12:00:00.000Z"),
+  );
+  assert.ok(parsed);
+  return parsed;
+}
+
+describe("codex usage header parsing", () => {
+  it("parses Codex quota headers into the 5h and weekly windows", () => {
+    const snapshot = sampleSnapshot();
+
+    assert.equal(snapshot.provider, "codex");
+    assert.equal(snapshot.sampledAt, "2026-06-05T12:00:00.000Z");
+    assert.equal(snapshot.lastSuccessTimestamp, 1780660800);
+    assert.deepEqual(snapshot.windows["5h"], {
+      usedPercent: 12.5,
+      remainingPercent: 87.5,
+      resetAt: "2026-06-05T17:00:00.000Z",
+      resetTimestamp: 1780678800,
+    });
+    assert.deepEqual(snapshot.windows.week, {
+      usedPercent: 88,
+      remainingPercent: 12,
+      resetAt: "2026-06-12T00:00:00.000Z",
+      resetTimestamp: 1781222400,
+    });
+    assert.equal(snapshot.planType, "Pro");
+    assert.equal(snapshot.activeLimit, "primary");
+  });
+
+  it("handles case-insensitive records, header arrays, and percent suffixes", () => {
+    const snapshot = parseCodexQuotaHeaders(
+      [
+        ["X-Codex-Primary-Used-Percent", "7.25%"],
+        ["X-Codex-Secondary-Reset-At", "1781222400000"],
+      ],
+      new Date("2026-06-05T12:00:00.000Z"),
+    );
+
+    assert.ok(snapshot);
+    assert.equal(snapshot.windows["5h"].usedPercent, 7.25);
+    assert.equal(snapshot.windows["5h"].remainingPercent, 92.75);
+    assert.equal(snapshot.windows.week.resetAt, "2026-06-12T00:00:00.000Z");
+  });
+
+  it("skips malformed numeric and timestamp headers without throwing", () => {
+    const snapshot = parseCodexQuotaHeaders(
+      {
+        "x-codex-primary-used-percent": "not-a-number",
+        "x-codex-secondary-used-percent": "35.5",
+        "x-codex-primary-reset-at": "not-a-date",
+        "x-codex-plan-type": "  Team   Plan  ",
+      },
+      new Date("2026-06-05T12:00:00.000Z"),
+    );
+
+    assert.ok(snapshot);
+    assert.equal(snapshot.windows["5h"].usedPercent, undefined);
+    assert.equal(snapshot.windows["5h"].resetTimestamp, undefined);
+    assert.equal(snapshot.windows.week.usedPercent, 35.5);
+    assert.equal(snapshot.windows.week.remainingPercent, 64.5);
+    assert.equal(snapshot.planType, "Team Plan");
+  });
+
+  it("returns null when no known quota headers are present", () => {
+    assert.equal(parseCodexQuotaHeaders({ "content-type": "application/json" }), null);
+    assert.equal(parseCodexQuotaHeaders(undefined), null);
+  });
+
+  it("returns null for metadata-only or all-malformed quota usage headers", () => {
+    assert.equal(
+      parseCodexQuotaHeaders({
+        "x-codex-plan-type": "Pro",
+        "x-codex-active-limit": "primary",
+      }),
+      null,
+    );
+    assert.equal(
+      parseCodexQuotaHeaders({
+        "x-codex-primary-used-percent": "not-a-number",
+        "x-codex-secondary-used-percent": "-1",
+        "x-codex-primary-reset-at": "2026-06-05T17:00:00.000Z",
+      }),
+      null,
+    );
+  });
+
+  it("finds nested provider response headers defensively", () => {
+    const headers = {
+      "x-codex-primary-used-percent": "41",
+    };
+
+    assert.equal(
+      extractCodexResponseHeaders({ providerResponse: { response: { headers } } }),
+      headers,
+    );
+  });
+});
+
+describe("codex usage paths and Prometheus formatting", () => {
+  it("uses env paths, then node_exporter env, then writable Homebrew textfile default", () => {
+    const cwd = "/tmp/codex-usage-cwd";
+    assert.deepEqual(
+      resolveCodexQuotaPaths({
+        cwd,
+        env: {
+          CODEX_QUOTA_STATE_FILE: "state/quota.json",
+          CODEX_QUOTA_TEXTFILE_DIR: "metrics",
+          NODE_EXPORTER_TEXTFILE_DIR: "ignored",
+        },
+        isWritableDir: () => false,
+      }),
+      {
+        stateFile: "/tmp/codex-usage-cwd/state/quota.json",
+        textfileDir: "/tmp/codex-usage-cwd/metrics",
+      },
+    );
+
+    assert.deepEqual(
+      resolveCodexQuotaPaths({
+        cwd,
+        env: { NODE_EXPORTER_TEXTFILE_DIR: "node-metrics" },
+        isWritableDir: () => false,
+      }),
+      {
+        stateFile: "/tmp/codex-usage-cwd/.tmp/codex-quota-state.json",
+        textfileDir: "/tmp/codex-usage-cwd/node-metrics",
+      },
+    );
+
+    assert.deepEqual(
+      resolveCodexQuotaPaths({
+        cwd,
+        env: {},
+        isWritableDir: (path) => path === DEFAULT_NODE_EXPORTER_TEXTFILE_DIR,
+      }),
+      {
+        stateFile: "/tmp/codex-usage-cwd/.tmp/codex-quota-state.json",
+        textfileDir: DEFAULT_NODE_EXPORTER_TEXTFILE_DIR,
+      },
+    );
+
+    assert.deepEqual(
+      resolveCodexQuotaPaths({
+        cwd,
+        env: {},
+        isWritableDir: () => false,
+      }),
+      {
+        stateFile: "/tmp/codex-usage-cwd/.tmp/codex-quota-state.json",
+      },
+    );
+  });
+
+  it("formats ADR-compatible gauges and low-cardinality metadata labels", () => {
+    const text = formatCodexQuotaPrometheus({
+      ...sampleSnapshot(),
+      planType: "ChatGPT Team",
+      activeLimit: "primary window",
+    });
+
+    assert.match(text, /# TYPE codex_usage_5h_percent gauge/);
+    assert.match(text, /codex_usage_5h_percent 12\.5/);
+    assert.match(text, /codex_usage_weekly_percent 88/);
+    assert.match(text, /codex_usage_5h_reset_timestamp 1780678800/);
+    assert.match(text, /codex_usage_weekly_reset_timestamp 1781222400/);
+    assert.match(text, /codex_usage_last_success_timestamp 1780660800/);
+    assert.match(
+      text,
+      /codex_usage_info\{provider="codex",plan_type="chatgpt_team",active_limit="primary_window"\} 1/,
+    );
+  });
+});
+
+describe("codex usage atomic writes", () => {
+  it("captures parsed quota headers to an attempt file without promoting canonical state", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const attemptFile = join(dir, "attempts", "quota-attempt.json");
+
+    const result = captureCodexQuotaFromHeaders(
+      { "x-codex-primary-used-percent": "12.5" },
+      {
+        env: { CODEX_QUOTA_ATTEMPT_FILE: attemptFile },
+        now: new Date("2026-06-05T12:00:00.000Z"),
+      },
+    );
+
+    assert.equal(result.status, "captured");
+    assert.equal(existsSync(attemptFile), true);
+    assert.equal(existsSync(stateFile), false);
+    assert.equal(JSON.parse(readFileSync(attemptFile, "utf8")).windows["5h"].usedPercent, 12.5);
+  });
+
+  it("writes JSON state and Prometheus textfiles atomically", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state", "quota.json");
+    const textfileDir = join(dir, "textfiles");
+    const result = writeCodexQuotaSnapshot(sampleSnapshot(), {
+      stateFile,
+      textfileDir,
+    });
+
+    assert.equal(result.stateFile, stateFile);
+    assert.equal(result.metricsFile, join(textfileDir, CODEX_USAGE_TEXTFILE_NAME));
+    assert.equal(existsSync(stateFile), true);
+    assert.equal(existsSync(result.metricsFile), true);
+
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.provider, "codex");
+    assert.equal(state.windows["5h"].usedPercent, 12.5);
+
+    const metrics = readFileSync(result.metricsFile, "utf8");
+    assert.match(metrics, /codex_usage_5h_percent 12\.5/);
+    assert.equal(readdirSync(join(dir, "state")).some((name) => name.endsWith(".tmp")), false);
+    assert.equal(readdirSync(textfileDir).some((name) => name.endsWith(".tmp")), false);
+  });
+
+  it("replaces existing files with the latest successful snapshot", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const textfileDir = join(dir, "metrics");
+    writeFileSync(stateFile, "old\n");
+
+    const first = sampleSnapshot();
+    writeCodexQuotaSnapshot(first, { stateFile, textfileDir });
+
+    const second = parseCodexQuotaHeaders(
+      {
+        "x-codex-primary-used-percent": "30",
+      },
+      new Date("2026-06-05T13:00:00.000Z"),
+    );
+    assert.ok(second);
+    writeCodexQuotaSnapshot(second, { stateFile, textfileDir });
+
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.windows["5h"].usedPercent, 30);
+    assert.equal(state.lastSuccessTimestamp, 1780664400);
+    assert.match(readFileSync(join(textfileDir, CODEX_USAGE_TEXTFILE_NAME), "utf8"), /codex_usage_5h_percent 30/);
+  });
+
+  it("leaves existing state untouched when metrics staging fails", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const blockedMetricsDir = join(dir, "blocked-metrics");
+    const priorState = "old-state\n";
+    writeFileSync(stateFile, priorState);
+    writeFileSync(blockedMetricsDir, "not a directory");
+
+    assert.throws(
+      () => writeCodexQuotaSnapshot(sampleSnapshot(), { stateFile, textfileDir: blockedMetricsDir }),
+      /ENOTDIR|EEXIST/,
+    );
+    assert.equal(readFileSync(stateFile, "utf8"), priorState);
+  });
+
+  it("treats absent quota headers as no-op before writing", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "state.json");
+    const result = recordCodexQuotaFromHeaders(
+      { "content-type": "application/json" },
+      { stateFile, textfileDir: join(dir, "metrics") },
+    );
+
+    assert.deepEqual(result, { status: "no_quota_headers" });
+    assert.equal(existsSync(stateFile), false);
+  });
+
+  it("returns write_error with a structured warning when the cache path cannot be written", () => {
+    const dir = tempDir();
+    const blocked = join(dir, "blocked");
+    writeFileSync(blocked, "not a directory");
+
+    const result = recordCodexQuotaFromHeaders(
+      { "x-codex-primary-used-percent": "12.5" },
+      { stateFile: join(blocked, "quota.json"), textfileDir: join(dir, "metrics") },
+    );
+
+    assert.equal(result.status, "write_error");
+    if (result.status !== "write_error") {
+      return;
+    }
+    assert.match(formatCodexQuotaWriteError(result.error), /^\[codex-usage\] failed to write quota cache:/);
+  });
+});

--- a/bot/src/__tests__/config-secrets.test.ts
+++ b/bot/src/__tests__/config-secrets.test.ts
@@ -71,6 +71,29 @@ bindings:
     assert.strictEqual(config.telegramToken, "env-wins");
   });
 
+  it("can validate configured Telegram secret references without resolving Keychain", () => {
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+telegramTokenService: this-keychain-service-would-fail-if-read
+bindings:
+  - chatId: 111
+    agentId: main
+    kind: dm
+`
+    );
+
+    assert.throws(
+      () => loadConfig(configPath),
+      /Failed to read Keychain service/,
+    );
+
+    const config = loadConfig(configPath, { resolveSecrets: false });
+    assert.equal(config.telegramToken, "[configured]");
+    assert.equal(config.bindings.length, 1);
+  });
+
   it("throws when telegramTokenEnv set but env var is empty string", () => {
     process.env.TEST_TELEGRAM_TOKEN_ENV = "";
     writeFileSync(
@@ -125,6 +148,30 @@ discord:
     const config = loadConfig(configPath);
     assert.ok(config.discord, "discord config should exist");
     assert.strictEqual(config.discord!.token, "dc-token-from-env");
+  });
+
+  it("can validate configured Discord secret references without resolving Keychain", () => {
+    writeFileSync(
+      configPath,
+      minimalAgentsYaml +
+        `
+discord:
+  tokenService: this-keychain-service-would-fail-if-read
+  bindings:
+    - guildId: "999"
+      agentId: main
+      kind: channel
+`
+    );
+
+    assert.throws(
+      () => loadConfig(configPath),
+      /Failed to read Keychain service/,
+    );
+
+    const config = loadConfig(configPath, { resolveSecrets: false });
+    assert.equal(config.discord!.token, "[configured]");
+    assert.equal(config.discord!.bindings.length, 1);
   });
 
   it("throws when discord.tokenService AND tokenEnv both missing", () => {

--- a/bot/src/__tests__/discord-bot.test.ts
+++ b/bot/src/__tests__/discord-bot.test.ts
@@ -7,11 +7,12 @@ import {
   resolveDiscordBinding,
   shouldRespondInDiscord,
   buildDiscordSourcePrefix,
+  handleDiscordChatInputCommand,
   installDiscordErrorHandlers,
   makeSteerFn,
 } from "../discord-bot.js";
 import { validateDiscordBinding } from "../config.js";
-import type { DiscordBinding } from "../types.js";
+import type { BotConfig, DiscordBinding, DiscordConfig } from "../types.js";
 import type { SessionManager } from "../session-manager.js";
 
 // --- discordSessionKey ---
@@ -166,6 +167,85 @@ describe("resolveDiscordBinding with guild-wide defaults", () => {
     const binding = resolveDiscordBinding("c999", guildBindings, "g1");
     assert.ok(binding);
     assert.strictEqual(binding.channels, undefined);
+  });
+});
+
+describe("Discord slash command status wiring", () => {
+  it("renders local status for a thread without opening or sending a session", async () => {
+    const calls: string[] = [];
+    const replies: Array<string | { content: string; ephemeral?: boolean }> = [];
+    const config: BotConfig = {
+      agents: {
+        main: { id: "main", workspaceCwd: "/tmp/test", model: "claude-opus-4-6" },
+      },
+      bindings: [],
+      sessionDefaults: {
+        idleTimeoutMs: 60_000,
+        maxConcurrentSessions: 2,
+        maxMessageAgeMs: 300_000,
+        requireMention: false,
+        maxMediaBytes: 209_715_200,
+      },
+    };
+    const discordConfig: DiscordConfig = {
+      token: "test-token",
+      bindings: [
+        { channelId: "parent-1", guildId: "guild-1", agentId: "main", kind: "channel" },
+      ],
+    };
+    const sessionManager = {
+      getActiveCount: () => 1,
+      getSessionHealth: (key: string) => {
+        calls.push(`getSessionHealth:${key}`);
+        return {
+          pid: 123,
+          alive: true,
+          agentId: "main",
+          sessionId: "session-123",
+          provider: "claude",
+          model: "claude-opus-4-6",
+          idleMs: 120_000,
+          processingMs: null,
+          lastSuccessAt: Date.now(),
+          restartCount: 0,
+        };
+      },
+      sendSessionMessage: () => { calls.push("sendSessionMessage"); throw new Error("unexpected"); },
+      getOrCreateSession: async () => { calls.push("getOrCreateSession"); throw new Error("unexpected"); },
+      closeSession: async () => { calls.push("closeSession"); },
+      destroySession: async () => { calls.push("destroySession"); },
+    } as unknown as SessionManager;
+
+    await handleDiscordChatInputCommand(
+      {
+        commandName: "status",
+        channelId: "thread-1",
+        guildId: "guild-1",
+        channel: {
+          isThread: () => true,
+          parentId: "parent-1",
+        },
+        reply: async (response) => {
+          replies.push(response);
+        },
+      },
+      {
+        config,
+        discordConfig,
+        sessionManager,
+        messageQueue: {
+          clear: (key: string) => { calls.push(`clear:${key}`); },
+        },
+      },
+    );
+
+    assert.equal(replies.length, 1);
+    assert.equal(typeof replies[0], "string");
+    assert.match(String(replies[0]), /Sessions: 1\/2/);
+    assert.match(String(replies[0]), /Session ID: session-123/);
+    assert.ok(calls.includes("getSessionHealth:discord:parent-1:thread-1"));
+    assert.ok(!calls.includes("sendSessionMessage"));
+    assert.ok(!calls.includes("getOrCreateSession"));
   });
 });
 

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -157,6 +157,27 @@ describe("buildPiSpawnArgs", () => {
     assert.strictEqual(args[args.indexOf("--model") + 1], "openai-codex/gpt-5.5");
   });
 
+  it("includes Pi thinking when configured on a Pi agent", () => {
+    const args = buildPiSpawnArgs({
+      ...testAgent,
+      provider: "pi",
+      thinking: "xhigh",
+    }, undefined, NO_EXTENSIONS);
+
+    const idx = args.indexOf("--thinking");
+    assert.notStrictEqual(idx, -1, "should include --thinking");
+    assert.strictEqual(args[idx + 1], "xhigh");
+  });
+
+  it("does not include thinking for a non-pi agent", () => {
+    const args = buildPiSpawnArgs({
+      ...testAgent,
+      thinking: "xhigh",
+    }, undefined, NO_EXTENSIONS);
+
+    assert.ok(!args.includes("--thinking"));
+  });
+
   it("does NOT invoke the context assembler for a non-pi agent (no context args)", () => {
     // testAgent carries no `provider` (semantically claude). The assembler is
     // gated on provider:"pi", so none of its CLI layers may appear — and the

--- a/bot/src/__tests__/provider-config.test.ts
+++ b/bot/src/__tests__/provider-config.test.ts
@@ -68,6 +68,31 @@ describe("validateAgent provider field", () => {
     assert.strictEqual(agent.provider, "pi");
   });
 
+  it("accepts Pi thinking levels", () => {
+    const agent = validateAgent(
+      { workspaceCwd: "/tmp/x", model: "gpt-5.5", provider: "pi", thinking: "xhigh" },
+      "coder",
+    );
+    assert.strictEqual(agent.thinking, "xhigh");
+  });
+
+  it("rejects invalid thinking values", () => {
+    assert.throws(
+      () => validateAgent(
+        { workspaceCwd: "/tmp/x", model: "gpt-5.5", provider: "pi", thinking: "ultra" },
+        "coder",
+      ),
+      /Agent "coder" has invalid thinking "ultra" \(must be one of: off, minimal, low, medium, high, xhigh\)/,
+    );
+    assert.throws(
+      () => validateAgent(
+        { workspaceCwd: "/tmp/x", model: "gpt-5.5", provider: "pi", thinking: 42 },
+        "coder",
+      ),
+      /Agent "coder" has invalid thinking "42"/,
+    );
+  });
+
   it("a claude agent still inherits the top-level defaultModel (regression)", () => {
     const agent = validateAgent(
       { workspaceCwd: "/tmp/x", provider: "claude" },
@@ -86,6 +111,7 @@ describe("validateAgent provider field", () => {
         systemPrompt: "be helpful",
         maxTurns: 5,
         effort: "high",
+        thinking: "medium",
         provider: "pi",
       },
       "main",
@@ -95,6 +121,7 @@ describe("validateAgent provider field", () => {
     assert.strictEqual(agent.systemPrompt, "be helpful");
     assert.strictEqual(agent.maxTurns, 5);
     assert.strictEqual(agent.effort, "high");
+    assert.strictEqual(agent.thinking, "medium");
     assert.strictEqual(agent.provider, "pi");
   });
 });

--- a/bot/src/__tests__/quota-status.test.ts
+++ b/bot/src/__tests__/quota-status.test.ts
@@ -1,0 +1,219 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_CODEX_QUOTA_STALE_MS,
+  formatCompactDuration,
+  formatResetEta,
+  formatSampleAge,
+  readQuotaStatus,
+  resolveQuotaStateFile,
+} from "../quota-status.js";
+
+const fixtures: string[] = [];
+
+after(() => {
+  for (const dir of fixtures) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "quota-status-test-"));
+  fixtures.push(dir);
+  return dir;
+}
+
+function writeQuotaState(path: string, overrides: Record<string, unknown> = {}): void {
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        provider: "codex",
+        sampledAt: "2026-06-05T12:00:00.000Z",
+        lastSuccess: "2026-06-05T12:00:00.000Z",
+        lastSuccessTimestamp: 1780660800,
+        planType: "Pro",
+        activeLimit: "primary",
+        windows: {
+          "5h": {
+            usedPercent: 12.5,
+            remainingPercent: 87.5,
+            resetAt: "2026-06-05T17:00:00.000Z",
+            resetTimestamp: 1780678800,
+          },
+          week: {
+            usedPercent: 88,
+            remainingPercent: 12,
+            resetAt: "2026-06-12T00:00:00.000Z",
+            resetTimestamp: 1781222400,
+          },
+        },
+        ...overrides,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+describe("quota status reader", () => {
+  it("reads fresh Codex quota data from the configured state file", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+    writeQuotaState(stateFile, {
+      lastAttempt: "2026-06-05T12:01:00.000Z",
+      lastAttemptTimestamp: 1780660860,
+      probeSuccess: true,
+    });
+
+    const status = readQuotaStatus({
+      stateFile,
+      now: new Date("2026-06-05T12:02:00.000Z"),
+    });
+
+    assert.equal(status.state, "available");
+    assert.equal(status.stateFile, stateFile);
+    assert.equal(status.staleMs, DEFAULT_CODEX_QUOTA_STALE_MS);
+    assert.equal(status.sampleAge, "2m ago");
+    assert.equal(status.snapshot.provider, "codex");
+    assert.equal(status.snapshot.windows["5h"].usedPercent, 12.5);
+    assert.equal(status.snapshot.windows["5h"].remainingPercent, 87.5);
+    assert.equal(status.snapshot.windows["5h"].resetTimestamp, 1780678800);
+    assert.equal(status.snapshot.windows.week.usedPercent, 88);
+    assert.equal(status.snapshot.lastAttemptTimestamp, 1780660860);
+    assert.equal(status.snapshot.probeSuccess, true);
+    assert.equal(status.snapshot.planType, "Pro");
+  });
+
+  it("marks quota data stale when the last successful sample is older than the threshold", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+    writeQuotaState(stateFile);
+
+    const status = readQuotaStatus({
+      stateFile,
+      now: new Date("2026-06-05T12:31:00.000Z"),
+      env: {
+        CODEX_QUOTA_STALE_MS: "1800000",
+      },
+    });
+
+    assert.equal(status.state, "stale");
+    assert.equal(status.sampleAge, "31m ago");
+    assert.equal(status.staleMs, 1_800_000);
+  });
+
+  it("returns unavailable when the state file is missing", () => {
+    const dir = tempDir();
+    const status = readQuotaStatus({
+      stateFile: join(dir, "missing.json"),
+      now: new Date("2026-06-05T12:00:00.000Z"),
+    });
+
+    assert.deepEqual(status, {
+      state: "unavailable",
+      stateFile: join(dir, "missing.json"),
+      reason: "missing_file",
+      staleMs: DEFAULT_CODEX_QUOTA_STALE_MS,
+    });
+  });
+
+  it("returns unavailable with last attempt when no successful sample exists yet", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+    writeQuotaState(stateFile, {
+      lastSuccess: undefined,
+      lastSuccessTimestamp: undefined,
+      sampledAt: undefined,
+      lastAttempt: "2026-06-05T12:01:00.000Z",
+      lastAttemptTimestamp: 1780660860,
+      probeSuccess: false,
+    });
+
+    const status = readQuotaStatus({
+      stateFile,
+      now: new Date("2026-06-05T12:02:00.000Z"),
+    });
+
+    assert.equal(status.state, "unavailable");
+    if (status.state !== "unavailable") {
+      throw new Error("expected unavailable quota status");
+    }
+    assert.equal(status.reason, "no_success");
+    assert.equal(status.snapshot?.lastAttemptTimestamp, 1780660860);
+    assert.equal(status.snapshot?.probeSuccess, false);
+  });
+
+  it("returns read_error for malformed state files", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+    writeFileSync(stateFile, "{not json\n");
+
+    const status = readQuotaStatus({
+      stateFile,
+      now: new Date("2026-06-05T12:00:00.000Z"),
+    });
+
+    assert.equal(status.state, "read_error");
+    assert.equal(status.stateFile, stateFile);
+    assert.match(status.error, /JSON|property name/i);
+  });
+
+  it("returns read_error for invalid stale threshold configuration", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+    writeQuotaState(stateFile);
+
+    const status = readQuotaStatus({
+      stateFile,
+      env: { CODEX_QUOTA_STALE_MS: "not-a-number" },
+      now: new Date("2026-06-05T12:00:00.000Z"),
+    });
+
+    assert.equal(status.state, "read_error");
+    assert.match(status.error, /CODEX_QUOTA_STALE_MS must be a positive number/);
+  });
+
+  it("returns read_error for unsupported providers and invalid windows", () => {
+    const dir = tempDir();
+    const stateFile = join(dir, "quota.json");
+
+    writeQuotaState(stateFile, { provider: "other" });
+    let status = readQuotaStatus({ stateFile });
+    assert.equal(status.state, "read_error");
+    assert.match(status.error, /provider is unsupported/);
+
+    writeQuotaState(stateFile, { windows: [] });
+    status = readQuotaStatus({ stateFile });
+    assert.equal(status.state, "read_error");
+    assert.match(status.error, /windows must be an object/);
+  });
+
+  it("resolves the state file from CODEX_QUOTA_STATE_FILE or the default path", () => {
+    const dir = tempDir();
+
+    assert.equal(
+      resolveQuotaStateFile({
+        cwd: dir,
+        env: { CODEX_QUOTA_STATE_FILE: "state/quota.json" },
+      }),
+      join(dir, "state", "quota.json"),
+    );
+    assert.equal(resolveQuotaStateFile({ cwd: dir, env: {} }), join(dir, ".tmp", "codex-quota-state.json"));
+  });
+});
+
+describe("quota status duration formatting", () => {
+  it("formats compact reset ETAs and sample ages", () => {
+    const now = new Date("2026-06-05T12:00:00.000Z");
+
+    assert.equal(formatResetEta("2026-06-05T16:52:00.000Z", now), "4h 52m");
+    assert.equal(formatResetEta(1781262000, now), "6d 23h");
+    assert.equal(formatResetEta("2026-06-05T11:59:00.000Z", now), "now");
+    assert.equal(formatSampleAge("2026-06-05T11:58:00.000Z", now), "2m ago");
+    assert.equal(formatCompactDuration(30_000), "0m");
+  });
+});

--- a/bot/src/__tests__/session-manager-pi-spawn.test.ts
+++ b/bot/src/__tests__/session-manager-pi-spawn.test.ts
@@ -13,7 +13,7 @@ import { ensureSessionMediaDir, sessionMediaDir, allocateMediaPath, releaseMedia
 // Real protocol helpers the spawn-path capture needs (parse get_state replies).
 // Resolved here BEFORE mock.module installs the stub, so these are the genuine
 // implementations; the stub below re-exports them so capture parses correctly.
-import { NewlineOnlyJsonlSplitter, parsePiRecord } from "../pi-rpc-protocol.js";
+import { NewlineOnlyJsonlSplitter, normalizePiModel, parsePiRecord } from "../pi-rpc-protocol.js";
 
 const TEST_DIR = "/tmp/minime-test-pi-spawn";
 const TEST_STORE_PATH = `${TEST_DIR}/sessions.json`;
@@ -227,6 +227,7 @@ mock.module("../pi-rpc-protocol.js", {
     },
     sendPiPrompt() {},
     sendPiSteer() {},
+    normalizePiModel,
     async *readPiStream(): AsyncGenerator<StreamLine> {
       // Message-path reader (unused by the spawn-path capture, which now reads
       // child.stdout directly). Present so session-manager's import resolves.
@@ -258,6 +259,7 @@ function makeConfig(): BotConfig {
         workspaceCwd: "/tmp/test-workspace-pi",
         model: "gpt-5.5",
         provider: "pi",
+        thinking: "xhigh",
       },
     },
     bindings: [
@@ -305,6 +307,17 @@ describe("SessionManager Pi session-id capture + resume", () => {
 
     // The in-memory session adopts the Pi-minted id (not the local UUID).
     assert.strictEqual(session.sessionId, "pi-generated-id", "session uses the captured Pi id");
+    assert.strictEqual(session.provider, "pi");
+    assert.strictEqual(session.model, "openai-codex/gpt-5.5");
+    assert.strictEqual(session.thinking, "xhigh");
+    assert.strictEqual(session.effort, undefined);
+
+    const health = manager.getSessionHealth("pi-chat");
+    assert.ok(health);
+    assert.strictEqual(health.provider, "pi");
+    assert.strictEqual(health.model, "openai-codex/gpt-5.5");
+    assert.strictEqual(health.thinking, "xhigh");
+    assert.strictEqual(health.effort, undefined);
 
     // ...and the captured id is persisted for resume across restarts.
     const store = new SessionStore(TEST_STORE_PATH);
@@ -404,6 +417,9 @@ describe("SessionManager Pi session-id capture + resume", () => {
       claudeSpawnCaptures[0].sessionId,
       "claude session keeps the bot-generated id (no Pi capture override)",
     );
+    assert.strictEqual(session.provider, "claude");
+    assert.strictEqual(session.model, "claude-opus-4-6");
+    assert.strictEqual(session.thinking, undefined);
     // The claude path must not have touched the Pi spawn path at all.
     assert.strictEqual(piSpawnCaptures.length, 0, "claude path must not spawn a Pi process");
 

--- a/bot/src/__tests__/session-manager.test.ts
+++ b/bot/src/__tests__/session-manager.test.ts
@@ -314,6 +314,8 @@ describe("SessionManager", () => {
       sessionId: "race-sid",
       agentId: "main",
       provider: "claude",
+      model: "claude-opus-4-6",
+      effort: "high",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 100000,
@@ -1181,6 +1183,9 @@ describe("SessionManager.getSessionHealth", () => {
       child,
       sessionId: "health-test",
       agentId: "main",
+      provider: "claude",
+      model: "claude-opus-4-6",
+      effort: "high",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1199,6 +1204,10 @@ describe("SessionManager.getSessionHealth", () => {
     assert.strictEqual(health.pid, 42000);
     assert.strictEqual(health.alive, true);
     assert.strictEqual(health.agentId, "main");
+    assert.strictEqual(health.provider, "claude");
+    assert.strictEqual(health.model, "claude-opus-4-6");
+    assert.strictEqual(health.effort, "high");
+    assert.strictEqual(health.thinking, undefined);
     assert.ok(health.idleMs >= 5000, "idle should be at least 5s");
     assert.strictEqual(health.processingMs, null);
     assert.strictEqual(health.lastSuccessAt, now - 10000);
@@ -1226,6 +1235,8 @@ describe("SessionManager.getSessionHealth", () => {
       child,
       sessionId: "proc-test",
       agentId: "main",
+      provider: "claude",
+      model: "claude-opus-4-6",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1263,6 +1274,8 @@ describe("SessionManager.getSessionHealth", () => {
       child,
       sessionId: "dead-health-test",
       agentId: "main",
+      provider: "claude",
+      model: "claude-opus-4-6",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1299,6 +1312,8 @@ describe("SessionManager.getSessionHealth", () => {
       child,
       sessionId: "killed-test",
       agentId: "main",
+      provider: "claude",
+      model: "claude-opus-4-6",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1335,6 +1350,8 @@ describe("SessionManager.getSessionHealth", () => {
       child,
       sessionId: "no-pid-test",
       agentId: "agent-b",
+      provider: "claude",
+      model: "claude-opus-4-6",
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1688,6 +1705,7 @@ describe("SessionManager gracefulShutdown", () => {
       sessionId: "test-session-" + chatId,
       agentId: "main",
       provider: "claude",
+      model: "claude-opus-4-6",
       queue,
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1865,6 +1883,8 @@ describe("SessionManager gracefulShutdown", () => {
       sessionId: "sid-pi-busy",
       agentId: "main",
       provider: "pi",
+      model: "openai-codex/gpt-5.5",
+      thinking: "xhigh",
       queue,
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -1968,6 +1988,8 @@ describe("SessionManager provider dispatch", () => {
       sessionId: `sid-${chatId}`,
       agentId,
       provider,
+      model: provider === "pi" ? "openai-codex/gpt-5.5" : "claude-opus-4-6",
+      thinking: provider === "pi" ? "xhigh" : undefined,
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: 60_000,
@@ -2295,4 +2317,3 @@ describe("SessionManager provider dispatch", () => {
     await manager.closeAll();
   });
 });
-

--- a/bot/src/__tests__/status-report.test.ts
+++ b/bot/src/__tests__/status-report.test.ts
@@ -1,0 +1,245 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildStatusReport } from "../status-report.js";
+import type { SessionHealth } from "../session-manager.js";
+import type { QuotaSnapshot, QuotaStatus } from "../quota-status.js";
+
+const NOW = new Date("2026-06-05T12:00:00.000Z");
+
+function ts(iso: string): number {
+  return Math.floor(Date.parse(iso) / 1000);
+}
+
+function baseHealth(overrides: Partial<SessionHealth> = {}): SessionHealth {
+  return {
+    pid: 12345,
+    alive: true,
+    agentId: "main",
+    sessionId: "session-123",
+    provider: "pi",
+    model: "openai-codex/gpt-5.5",
+    thinking: "xhigh",
+    idleMs: 125_000,
+    processingMs: null,
+    lastSuccessAt: NOW.getTime() - 2 * 60_000,
+    restartCount: 0,
+    ...overrides,
+  };
+}
+
+function quotaSnapshot(overrides: Partial<QuotaSnapshot> = {}): QuotaSnapshot {
+  return {
+    provider: "codex",
+    sampledAt: "2026-06-05T11:58:00.000Z",
+    lastSuccess: "2026-06-05T11:58:00.000Z",
+    lastSuccessTimestamp: ts("2026-06-05T11:58:00.000Z"),
+    planType: "Pro",
+    activeLimit: "primary",
+    windows: {
+      "5h": {
+        usedPercent: 12.5,
+        remainingPercent: 87.5,
+        resetAt: "2026-06-05T16:52:00.000Z",
+        resetTimestamp: ts("2026-06-05T16:52:00.000Z"),
+      },
+      week: {
+        usedPercent: 88,
+        remainingPercent: 12,
+        resetAt: "2026-06-12T11:00:00.000Z",
+        resetTimestamp: ts("2026-06-12T11:00:00.000Z"),
+      },
+    },
+    ...overrides,
+  };
+}
+
+function baseReport(overrides: Partial<Parameters<typeof buildStatusReport>[0]> = {}): string {
+  return buildStatusReport({
+    activeCount: 1,
+    maxSessions: 3,
+    uptimeSeconds: 7_500,
+    sessionHealth: baseHealth(),
+    now: NOW,
+    ...overrides,
+  });
+}
+
+describe("buildStatusReport", () => {
+  it("renders compact idle session health without healthy-path noise", () => {
+    const text = baseReport();
+
+    assert.match(text, /Sessions: 1\/3/);
+    assert.match(text, /Uptime: 2h 5m/);
+    assert.match(text, /Agent: main \(pi\)/);
+    assert.match(text, /Model: openai-codex\/gpt-5\.5/);
+    assert.match(text, /Thinking: xhigh/);
+    assert.match(text, /State: idle \(2m\)/);
+    assert.match(text, /Session ID: session-123/);
+    assert.match(text, /Codex quota: unavailable \(no cached state\)/);
+    assert.doesNotMatch(text, /Memory/i);
+    assert.doesNotMatch(text, /PID/);
+    assert.doesNotMatch(text, /Last success/);
+    assert.doesNotMatch(text, /Restarts/);
+  });
+
+  it("renders processing state and Claude effort", () => {
+    const text = baseReport({
+      sessionHealth: baseHealth({
+        provider: "claude",
+        model: "claude-opus-4-6",
+        thinking: undefined,
+        effort: "high",
+        processingMs: 42_500,
+      }),
+      quotaStatus: {
+        state: "unavailable",
+        stateFile: "/tmp/missing.json",
+        reason: "missing_file",
+        staleMs: 1_800_000,
+      },
+    });
+
+    assert.match(text, /Agent: main \(claude\)/);
+    assert.match(text, /Model: claude-opus-4-6/);
+    assert.match(text, /Effort: high/);
+    assert.match(text, /State: processing \(42s\)/);
+    assert.doesNotMatch(text, /Codex quota/);
+  });
+
+  it("includes PID diagnostics when the session process is dead", () => {
+    const text = baseReport({
+      sessionHealth: baseHealth({ alive: false, pid: 9876 }),
+    });
+
+    assert.match(text, /Diagnostics:/);
+    assert.match(text, /Process: dead \(PID 9876\)/);
+  });
+
+  it("includes restart diagnostics only when restarts are non-zero", () => {
+    const text = baseReport({
+      sessionHealth: baseHealth({ restartCount: 2 }),
+    });
+
+    assert.match(text, /Diagnostics:/);
+    assert.match(text, /Restarts: 2/);
+  });
+
+  it("includes last success diagnostics when missing or stale", () => {
+    const missing = baseReport({
+      sessionHealth: baseHealth({ lastSuccessAt: null }),
+    });
+    const stale = baseReport({
+      sessionHealth: baseHealth({ lastSuccessAt: NOW.getTime() - 31 * 60_000 }),
+    });
+
+    assert.match(missing, /Last success: none/);
+    assert.match(stale, /Last success: 31m ago \(stale\)/);
+  });
+
+  it("renders fresh Codex quota with used, left, reset ETA, and sample age", () => {
+    const quotaStatus: QuotaStatus = {
+      state: "available",
+      stateFile: "/tmp/quota.json",
+      snapshot: quotaSnapshot({
+        lastAttempt: "2026-06-05T11:59:00.000Z",
+        lastAttemptTimestamp: ts("2026-06-05T11:59:00.000Z"),
+        probeSuccess: true,
+      }),
+      ageMs: 120_000,
+      sampleAge: "2m ago",
+      staleMs: 1_800_000,
+    };
+
+    const text = baseReport({ quotaStatus });
+
+    assert.match(text, /Codex quota: fresh \(sample 2m ago\)/);
+    assert.match(text, /plan Pro, active primary/);
+    assert.match(text, /5h: 12\.5% used, 87\.5% left, resets in 4h 52m/);
+    assert.match(text, /week: 88% used, 12% left, resets in 6d 23h/);
+    assert.match(text, /Last attempt: 1m ago \(ok\)/);
+  });
+
+  it("renders stale Codex quota honestly with attempt and cached values", () => {
+    const quotaStatus: QuotaStatus = {
+      state: "stale",
+      stateFile: "/tmp/quota.json",
+      snapshot: quotaSnapshot({
+        lastSuccessTimestamp: ts("2026-06-05T11:29:00.000Z"),
+        lastAttemptTimestamp: ts("2026-06-05T11:59:00.000Z"),
+        probeSuccess: false,
+      }),
+      ageMs: 31 * 60_000,
+      sampleAge: "31m ago",
+      staleMs: 1_800_000,
+    };
+
+    const text = baseReport({ quotaStatus });
+
+    assert.match(text, /Codex quota: stale \(last success 31m ago\)/);
+    assert.match(text, /5h: 12\.5% used, 87\.5% left/);
+    assert.match(text, /Last attempt: 1m ago \(failed\)/);
+  });
+
+  it("renders unavailable Codex quota with a failed last attempt before any success", () => {
+    const quotaStatus: QuotaStatus = {
+      state: "unavailable",
+      stateFile: "/tmp/quota.json",
+      reason: "no_success",
+      staleMs: 1_800_000,
+      snapshot: quotaSnapshot({
+        sampledAt: undefined,
+        lastSuccess: undefined,
+        lastSuccessTimestamp: undefined,
+        lastAttemptTimestamp: ts("2026-06-05T11:59:00.000Z"),
+        probeSuccess: false,
+      }),
+    };
+
+    const text = baseReport({ quotaStatus });
+
+    assert.match(text, /Codex quota: unavailable \(no successful sample\)/);
+    assert.match(text, /Last attempt: 1m ago \(failed\)/);
+  });
+
+  it("renders missing and read-error quota states for Pi sessions", () => {
+    const missing = baseReport({
+      quotaStatus: {
+        state: "unavailable",
+        stateFile: "/tmp/missing.json",
+        reason: "missing_file",
+        staleMs: 1_800_000,
+      },
+    });
+    const readError = baseReport({
+      quotaStatus: {
+        state: "read_error",
+        stateFile: "/tmp/quota.json",
+        error: "bad json",
+        staleMs: 1_800_000,
+      },
+    });
+
+    assert.match(missing, /Codex quota: unavailable \(state file missing\)/);
+    assert.match(readError, /Codex quota: unavailable \(read error\)/);
+    assert.doesNotMatch(readError, /bad json/);
+  });
+
+  it("omits missing quota data for non-Pi sessions", () => {
+    const text = baseReport({
+      sessionHealth: baseHealth({
+        provider: "claude",
+        model: "claude-opus-4-6",
+        thinking: undefined,
+        effort: "medium",
+      }),
+      quotaStatus: {
+        state: "unavailable",
+        stateFile: "/tmp/missing.json",
+        reason: "missing_file",
+        staleMs: 1_800_000,
+      },
+    });
+
+    assert.doesNotMatch(text, /Codex quota/);
+  });
+});

--- a/bot/src/__tests__/telegram-bot.test.ts
+++ b/bot/src/__tests__/telegram-bot.test.ts
@@ -1331,10 +1331,26 @@ describe("command handler wiring", () => {
       calls,
       closeSession: async (_chatId: string) => { calls.push("closeSession"); },
       destroySession: async (_chatId: string) => { calls.push("destroySession"); },
-      sendSessionMessage: () => { throw new Error("unexpected"); },
-      getOrCreateSession: async () => { throw new Error("unexpected"); },
+      sendSessionMessage: () => { calls.push("sendSessionMessage"); throw new Error("unexpected"); },
+      getOrCreateSession: async () => { calls.push("getOrCreateSession"); throw new Error("unexpected"); },
       closeAll: async () => {},
       resolveStoredSession: () => ({ resume: false }),
+      getActiveCount: () => 1,
+      getSessionHealth: (key: string) => {
+        calls.push(`getSessionHealth:${key}`);
+        return {
+          pid: 123,
+          alive: true,
+          agentId: "main",
+          sessionId: "session-123",
+          provider: "claude",
+          model: "claude-opus-4-6",
+          idleMs: 120_000,
+          processingMs: null,
+          lastSuccessAt: Date.now(),
+          restartCount: 0,
+        };
+      },
       activeCount: () => 0,
       getActiveSession: () => undefined,
       isActive: () => false,
@@ -1356,10 +1372,13 @@ describe("command handler wiring", () => {
     };
   }
 
-  function initBot(mockSM: SessionManager) {
+  function initBot(mockSM: SessionManager, apiCalls: Array<{ method: string; payload: any }> = []) {
     const { bot } = createTelegramBot(handlerConfig, mockSM);
     // Intercept all API calls so nothing reaches Telegram
-    bot.api.config.use(async (_prev, _method, _payload) => ({ ok: true, result: true } as any));
+    bot.api.config.use(async (_prev, method, payload) => {
+      apiCalls.push({ method, payload });
+      return { ok: true, result: true } as any;
+    });
     // Provide bot info so handleUpdate works without calling getMe
     bot.botInfo = {
       id: 999,
@@ -1393,6 +1412,22 @@ describe("command handler wiring", () => {
     await bot.handleUpdate(makeCommandUpdate("clean", 2));
     assert.ok(mockSM.calls.includes("destroySession"), "/clean should call destroySession");
     assert.ok(!mockSM.calls.includes("closeSession"), "/clean handler calls destroySession, not closeSession directly");
+  });
+
+  it("/status replies from local health/cache without opening a session", async () => {
+    const mockSM = createMockSessionManager();
+    const apiCalls: Array<{ method: string; payload: any }> = [];
+    const bot = initBot(mockSM, apiCalls);
+
+    await bot.handleUpdate(makeCommandUpdate("status", 3));
+
+    const reply = apiCalls.find((call) => call.method === "sendMessage");
+    assert.ok(reply);
+    assert.match(String(reply.payload.text), /Sessions: 1\/2/);
+    assert.match(String(reply.payload.text), /Session ID: session-123/);
+    assert.ok(mockSM.calls.includes("getSessionHealth:111111111"));
+    assert.ok(!mockSM.calls.includes("sendSessionMessage"));
+    assert.ok(!mockSM.calls.includes("getOrCreateSession"));
   });
 });
 

--- a/bot/src/codex-quota-sampler.ts
+++ b/bot/src/codex-quota-sampler.ts
@@ -1,0 +1,814 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfig } from "./config.js";
+import {
+  CODEX_QUOTA_ATTEMPT_FILE_ENV,
+  CODEX_QUOTA_STATE_FILE_ENV,
+  CODEX_QUOTA_TEXTFILE_DIR_ENV,
+  NODE_EXPORTER_TEXTFILE_DIR_ENV,
+  resolveCodexQuotaPaths,
+  writeCodexQuotaSnapshot,
+  type CodexQuotaSnapshot,
+} from "./pi-extensions/codex-usage.js";
+
+export const CODEX_QUOTA_MODEL_ENV = "CODEX_QUOTA_MODEL";
+export const CODEX_QUOTA_SAMPLER_CWD_ENV = "CODEX_QUOTA_SAMPLER_CWD";
+export const CODEX_QUOTA_TIMEOUT_MS_ENV = "CODEX_QUOTA_TIMEOUT_MS";
+export const CODEX_QUOTA_DRY_RUN_ENV = "CODEX_QUOTA_DRY_RUN";
+export const CODEX_QUOTA_PI_BIN_ENV = "CODEX_QUOTA_PI_BIN";
+export const CODEX_QUOTA_PROBE_TEXTFILE_NAME = "codex_usage_probe.prom";
+
+const PI_PROVIDER = "openai-codex";
+const DEFAULT_PI_BIN = "pi";
+const DEFAULT_CODEX_QUOTA_MODEL = "openai-codex/gpt-5.5";
+const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_KILL_GRACE_MS = 1_000;
+const DEFAULT_PROMPT = "Reply with exactly: OK";
+const OUTPUT_BUFFER_LIMIT = 64 * 1024;
+const SAMPLER_PROJECT_SETTINGS = { transport: "sse" };
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BOT_DIR = resolve(__dirname, "..");
+
+export interface CodexQuotaSamplerCliOptions {
+  model?: string;
+  textfileDir?: string;
+  stateFile?: string;
+  samplerCwd?: string;
+  timeoutMs?: number;
+  dryRun?: boolean;
+  piBin?: string;
+  prompt?: string;
+  help?: boolean;
+}
+
+export interface ResolveCodexQuotaSamplerConfigOptions {
+  cli?: CodexQuotaSamplerCliOptions;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  botDir?: string;
+  extensionPath?: string;
+  forbiddenSamplerCwds?: readonly string[];
+  isWritableDir?: (path: string) => boolean;
+}
+
+export interface CodexQuotaSamplerConfig {
+  piBin: string;
+  model: string;
+  prompt: string;
+  stateFile: string;
+  textfileDir: string;
+  samplerCwd: string;
+  extensionPath: string;
+  timeoutMs: number;
+  killGraceMs: number;
+  dryRun: boolean;
+}
+
+export interface ProbeAttempt {
+  attemptedAt: Date;
+  probeSuccess: boolean;
+}
+
+export interface SamplerRunResult {
+  status: "success" | "failure" | "dry_run";
+  config: CodexQuotaSamplerConfig;
+  args: string[];
+  settingsFile: string;
+  attemptFile?: string;
+  attemptMetricsFile?: string;
+  failureReason?: string;
+  child?: PiProbeResult;
+}
+
+interface ReadableLike {
+  on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+}
+
+export interface SamplerChildLike {
+  stdout: ReadableLike | null;
+  stderr: ReadableLike | null;
+  on(event: "close", listener: (code: number | null) => void): unknown;
+  on(event: "error", listener: (err: Error) => void): unknown;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+export type SamplerSpawn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; stdio: ["ignore", "pipe", "pipe"] },
+) => SamplerChildLike;
+
+export interface RunPiProbeOptions {
+  spawn?: SamplerSpawn;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  killGraceMs?: number;
+}
+
+export interface PiProbeResult {
+  success: boolean;
+  exitCode: number | null;
+  timedOut: boolean;
+  killed: boolean;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+export interface RunCodexQuotaSamplerOptions {
+  config?: CodexQuotaSamplerConfig;
+  cli?: CodexQuotaSamplerCliOptions;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  botDir?: string;
+  extensionPath?: string;
+  spawn?: SamplerSpawn;
+  now?: Date;
+}
+
+export function parseCodexQuotaSamplerArgs(argv: readonly string[]): CodexQuotaSamplerCliOptions {
+  const parsed: CodexQuotaSamplerCliOptions = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      case "--model":
+        parsed.model = readFlagValue(argv, ++i, arg);
+        break;
+      case "--textfile-dir":
+        parsed.textfileDir = readFlagValue(argv, ++i, arg);
+        break;
+      case "--state-file":
+        parsed.stateFile = readFlagValue(argv, ++i, arg);
+        break;
+      case "--sampler-cwd":
+        parsed.samplerCwd = readFlagValue(argv, ++i, arg);
+        break;
+      case "--timeout":
+      case "--timeout-ms":
+        parsed.timeoutMs = parsePositiveInteger(readFlagValue(argv, ++i, arg), arg);
+        break;
+      case "--pi-bin":
+        parsed.piBin = readFlagValue(argv, ++i, arg);
+        break;
+      case "--prompt":
+        parsed.prompt = readFlagValue(argv, ++i, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+export function resolveCodexQuotaSamplerConfig(
+  options: ResolveCodexQuotaSamplerConfigOptions = {},
+): CodexQuotaSamplerConfig {
+  const cli = options.cli ?? {};
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const botDir = options.botDir ?? DEFAULT_BOT_DIR;
+
+  const paths = resolveCodexQuotaPaths({
+    cwd,
+    env,
+    stateFile: cli.stateFile,
+    textfileDir: cli.textfileDir,
+    isWritableDir: options.isWritableDir,
+  });
+  const stateFile = paths.stateFile;
+  const textfileDir = paths.textfileDir;
+  if (!textfileDir) {
+    throw new Error(
+      "Codex quota sampler requires a configured or writable Prometheus textfile directory; " +
+      `set ${CODEX_QUOTA_TEXTFILE_DIR_ENV} or ${NODE_EXPORTER_TEXTFILE_DIR_ENV}, or make the node_exporter textfile directory writable`,
+    );
+  }
+  const samplerCwd =
+    resolveConfiguredPath(cli.samplerCwd, cwd) ??
+    resolveConfiguredPath(env[CODEX_QUOTA_SAMPLER_CWD_ENV], cwd) ??
+    defaultSamplerCwd();
+  assertSamplerCwdIsolated(samplerCwd, botDir, options.forbiddenSamplerCwds ?? readConfiguredAgentWorkspaceCwds(botDir));
+
+  return {
+    piBin: nonEmpty(cli.piBin) ?? nonEmpty(env[CODEX_QUOTA_PI_BIN_ENV]) ?? DEFAULT_PI_BIN,
+    model: normalizeCodexModel(nonEmpty(cli.model) ?? nonEmpty(env[CODEX_QUOTA_MODEL_ENV])),
+    prompt: nonEmpty(cli.prompt) ?? DEFAULT_PROMPT,
+    stateFile,
+    textfileDir,
+    samplerCwd,
+    extensionPath: options.extensionPath ?? resolve(botDir, ".claude", "extensions", "codex-usage.ts"),
+    timeoutMs:
+      cli.timeoutMs ??
+      parseOptionalPositiveInteger(env[CODEX_QUOTA_TIMEOUT_MS_ENV], CODEX_QUOTA_TIMEOUT_MS_ENV) ??
+      DEFAULT_TIMEOUT_MS,
+    killGraceMs: DEFAULT_KILL_GRACE_MS,
+    dryRun: cli.dryRun ?? parseBooleanEnv(env[CODEX_QUOTA_DRY_RUN_ENV]) ?? false,
+  };
+}
+
+export function buildCodexQuotaSamplerArgs(config: Pick<CodexQuotaSamplerConfig, "model" | "extensionPath" | "prompt">): string[] {
+  return [
+    "--provider",
+    PI_PROVIDER,
+    "--model",
+    normalizeCodexModel(config.model),
+    "--thinking",
+    "off",
+    "--no-context-files",
+    "--no-skills",
+    "--no-extensions",
+    "--extension",
+    config.extensionPath,
+    "--no-session",
+    "--no-tools",
+    "-p",
+    config.prompt,
+  ];
+}
+
+export function ensureSamplerProjectSettings(samplerCwd: string): string {
+  ensurePrivateDirectory(samplerCwd, "Sampler cwd");
+  ensurePrivateDirectory(join(samplerCwd, ".pi"), "Sampler Pi settings directory");
+  ensurePrivateDirectory(join(samplerCwd, ".tmp"), "Sampler attempt directory");
+  const settingsFile = samplerProjectSettingsFile(samplerCwd);
+  const existing = readJsonObjectIfExists(settingsFile);
+  if (existing === "malformed" || (existing && !isSamplerProjectSettings(existing))) {
+    throw new Error(`Refusing to overwrite existing Pi project settings: ${settingsFile}`);
+  }
+  if (!existing) {
+    atomicWriteFile(settingsFile, `${JSON.stringify(SAMPLER_PROJECT_SETTINGS, null, 2)}\n`);
+  }
+  return settingsFile;
+}
+
+export function buildSamplerChildEnv(
+  config: Pick<CodexQuotaSamplerConfig, "stateFile" | "textfileDir"> & { attemptFile?: string },
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ["HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TEMP", "TMP", "XDG_CONFIG_HOME"] as const) {
+    const value = nonEmpty(baseEnv[key]);
+    if (value) {
+      env[key] = value;
+    }
+  }
+
+  env[CODEX_QUOTA_STATE_FILE_ENV] = config.stateFile;
+  env[CODEX_QUOTA_TEXTFILE_DIR_ENV] = config.textfileDir;
+  if (config.attemptFile) {
+    env[CODEX_QUOTA_ATTEMPT_FILE_ENV] = config.attemptFile;
+  }
+  env.PATH = prependHomebrewPath(baseEnv.PATH);
+
+  return env;
+}
+
+export function formatCodexQuotaProbePrometheus(attempt: ProbeAttempt): string {
+  const timestamp = Math.floor(attempt.attemptedAt.getTime() / 1000);
+  const success = attempt.probeSuccess ? 1 : 0;
+  return [
+    "# HELP codex_usage_last_attempt_timestamp Unix timestamp of the last Codex quota sampler attempt.",
+    "# TYPE codex_usage_last_attempt_timestamp gauge",
+    `codex_usage_last_attempt_timestamp ${timestamp}`,
+    "# HELP codex_usage_probe_success Whether the last Codex quota sampler attempt refreshed the quota cache.",
+    "# TYPE codex_usage_probe_success gauge",
+    `codex_usage_probe_success ${success}`,
+    "",
+  ].join("\n");
+}
+
+export function writeProbeAttemptMetrics(textfileDir: string, attempt: ProbeAttempt): string {
+  const metricsFile = join(textfileDir, CODEX_QUOTA_PROBE_TEXTFILE_NAME);
+  atomicWriteFile(metricsFile, formatCodexQuotaProbePrometheus(attempt));
+  return metricsFile;
+}
+
+export function runPiProbe(options: RunPiProbeOptions): Promise<PiProbeResult> {
+  const spawn = options.spawn ?? defaultSpawn;
+  const killGraceMs = options.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+
+  return new Promise<PiProbeResult>((resolveResult) => {
+    let child: SamplerChildLike;
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let killed = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (exitCode: number | null, error?: string) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+      }
+      if (killGraceTimer) {
+        clearTimeout(killGraceTimer);
+      }
+      resolveResult({
+        success: !timedOut && !error && exitCode === 0,
+        exitCode,
+        timedOut,
+        killed,
+        stdout,
+        stderr,
+        error,
+      });
+    };
+
+    try {
+      child = spawn(options.command, options.args, {
+        cwd: options.cwd,
+        env: options.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      finish(null, errorMessage(error));
+      return;
+    }
+
+    child.stdout?.on("data", (chunk) => {
+      stdout = appendCapped(stdout, chunk.toString());
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr = appendCapped(stderr, chunk.toString());
+    });
+    child.on("close", (code) => {
+      finish(code ?? null);
+    });
+    child.on("error", (error) => {
+      finish(null, errorMessage(error));
+    });
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      killed = tryKill(child, "SIGTERM") || killed;
+      killGraceTimer = setTimeout(() => {
+        killed = tryKill(child, "SIGKILL") || killed;
+        finish(null, `Pi probe timed out after ${options.timeoutMs}ms`);
+      }, killGraceMs);
+    }, options.timeoutMs);
+  });
+}
+
+export async function runCodexQuotaSampler(
+  options: RunCodexQuotaSamplerOptions = {},
+): Promise<SamplerRunResult> {
+  const config =
+    options.config ??
+    resolveCodexQuotaSamplerConfig({
+      cli: options.cli,
+      env: options.env,
+      cwd: options.cwd,
+      botDir: options.botDir,
+      extensionPath: options.extensionPath,
+    });
+  const settingsFile = samplerProjectSettingsFile(config.samplerCwd);
+  const args = buildCodexQuotaSamplerArgs(config);
+
+  if (config.dryRun) {
+    return {
+      status: "dry_run",
+      config,
+      args,
+      settingsFile,
+    };
+  }
+
+  ensureSamplerProjectSettings(config.samplerCwd);
+
+  const attemptedAt = options.now ?? new Date();
+  const attemptFile = buildAttemptFilePath(config.samplerCwd);
+  const child = await runPiProbe({
+    spawn: options.spawn,
+    command: config.piBin,
+    args,
+    cwd: config.samplerCwd,
+    env: buildSamplerChildEnv({ ...config, attemptFile }, options.env),
+    timeoutMs: config.timeoutMs,
+    killGraceMs: config.killGraceMs,
+  });
+  const extensionWriteError = child.stderr.includes("[codex-usage] failed to write quota cache");
+  const capturedSnapshot = child.success && !extensionWriteError
+    ? readCapturedSnapshot(attemptFile)
+    : undefined;
+  let cacheRefreshed = false;
+  let promotionError: unknown;
+  if (capturedSnapshot) {
+    try {
+      writeCodexQuotaSnapshot(capturedSnapshot, {
+        stateFile: config.stateFile,
+        textfileDir: config.textfileDir,
+      });
+      cacheRefreshed = true;
+    } catch (error) {
+      promotionError = error;
+    }
+  }
+  discardAttemptFile(attemptFile);
+  const attempt = {
+    attemptedAt,
+    probeSuccess: cacheRefreshed,
+  };
+  let attemptStateError: unknown;
+  try {
+    writeProbeAttemptState(config.stateFile, attempt);
+  } catch (error) {
+    attemptStateError = error;
+  }
+
+  let attemptMetricsFile: string | undefined;
+  let attemptMetricsError: unknown;
+  try {
+    attemptMetricsFile = writeProbeAttemptMetrics(config.textfileDir, attempt);
+  } catch (error) {
+    attemptMetricsError = error;
+  }
+
+  const samplerSucceeded = cacheRefreshed && !attemptStateError && !attemptMetricsError;
+
+  return {
+    status: samplerSucceeded ? "success" : "failure",
+    config,
+    args,
+    settingsFile,
+    attemptFile,
+    attemptMetricsFile,
+    failureReason: samplerSucceeded
+      ? undefined
+      : describeProbeFailure(child, extensionWriteError, promotionError, attemptStateError, attemptMetricsError),
+    child,
+  };
+}
+
+export async function runCodexQuotaSamplerFromCli(argv: readonly string[] = process.argv.slice(2)): Promise<void> {
+  const cli = parseCodexQuotaSamplerArgs(argv);
+  if (cli.help) {
+    console.log(formatCodexQuotaSamplerHelp());
+    return;
+  }
+
+  const result = await runCodexQuotaSampler({ cli });
+  if (result.status === "dry_run") {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          command: result.config.piBin,
+          args: result.args,
+          cwd: result.config.samplerCwd,
+          settingsFile: result.settingsFile,
+          stateFile: result.config.stateFile,
+          textfileDir: result.config.textfileDir,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (result.status === "success") {
+    console.log(`[codex-quota-sampler] probe succeeded; attempt metrics: ${result.attemptMetricsFile}`);
+    return;
+  }
+
+  const detail = result.failureReason ?? (result.child?.timedOut
+    ? `timed out after ${result.config.timeoutMs}ms`
+    : result.child?.error ?? result.child?.stderr.trim() ?? `exit ${result.child?.exitCode ?? "unknown"}`);
+  console.error(`[codex-quota-sampler] probe failed: ${detail}`);
+  process.exitCode = 1;
+}
+
+export function formatCodexQuotaSamplerHelp(): string {
+  return [
+    "Usage: npx tsx scripts/codex-quota-sampler.ts [options]",
+    "",
+    "Options:",
+    "  --model <model>          Codex model for the probe",
+    "  --textfile-dir <dir>     Prometheus textfile directory",
+    "  --state-file <file>      Codex quota JSON state file",
+    "  --sampler-cwd <dir>      Isolated cwd that receives .pi/settings.json",
+    "  --timeout <ms>           Alias for --timeout-ms",
+    "  --timeout-ms <ms>        Wall-clock timeout for the Pi child",
+    "  --pi-bin <path>          Pi binary path or command name",
+    "  --prompt <text>          Minimal prompt sent to Pi",
+    "  --dry-run                Print the resolved command without launching Pi",
+    "  --help, -h               Show this help",
+    "",
+    "Environment:",
+    `  ${CODEX_QUOTA_MODEL_ENV}, ${CODEX_QUOTA_TEXTFILE_DIR_ENV}, ${CODEX_QUOTA_STATE_FILE_ENV}`,
+    `  ${CODEX_QUOTA_SAMPLER_CWD_ENV}, ${CODEX_QUOTA_TIMEOUT_MS_ENV}, ${CODEX_QUOTA_DRY_RUN_ENV}`,
+    `  ${CODEX_QUOTA_PI_BIN_ENV}`,
+  ].join("\n");
+}
+
+function defaultSpawn(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; stdio: ["ignore", "pipe", "pipe"] },
+): SamplerChildLike {
+  return nodeSpawn(command, args, options) as ChildProcess;
+}
+
+function normalizeCodexModel(model: string | undefined): string {
+  const trimmed = nonEmpty(model);
+  if (!trimmed) {
+    return DEFAULT_CODEX_QUOTA_MODEL;
+  }
+  return trimmed.includes("/") ? trimmed : `${PI_PROVIDER}/${trimmed}`;
+}
+
+function readFlagValue(argv: readonly string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseOptionalPositiveInteger(raw: string | undefined, label: string): number | undefined {
+  const trimmed = nonEmpty(raw);
+  if (!trimmed) {
+    return undefined;
+  }
+  return parsePositiveInteger(trimmed, label);
+}
+
+function parsePositiveInteger(raw: string, label: string): number {
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw: string | undefined): boolean | undefined {
+  const trimmed = raw?.trim().toLowerCase();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (["1", "true", "yes", "on"].includes(trimmed)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(trimmed)) {
+    return false;
+  }
+  throw new Error(`${CODEX_QUOTA_DRY_RUN_ENV} must be boolean-like`);
+}
+
+function prependHomebrewPath(path: string | undefined): string {
+  const homebrewPath = "/opt/homebrew/bin";
+  if (!path) {
+    return homebrewPath;
+  }
+  return path.split(":").includes(homebrewPath) ? path : `${homebrewPath}:${path}`;
+}
+
+function defaultSamplerCwd(): string {
+  const uid = typeof process.getuid === "function" ? String(process.getuid()) : "user";
+  return join(tmpdir(), `codex-quota-sampler-${uid}`);
+}
+
+function readConfiguredAgentWorkspaceCwds(botDir: string): string[] {
+  const configPath = resolve(botDir, "..", "config.yaml");
+  const projectRoot = resolve(botDir, "..");
+  const config = loadConfig(configPath, { resolveSecrets: false });
+  return Object.values(config.agents).flatMap((agent) => {
+    const fromProjectRoot = resolveConfiguredPath(agent.workspaceCwd, projectRoot);
+    const fromProcessCwd = resolveConfiguredPath(agent.workspaceCwd, process.cwd());
+    return [fromProjectRoot, fromProcessCwd].filter((path, index, paths): path is string =>
+      path !== undefined && paths.indexOf(path) === index
+    );
+  });
+}
+
+function assertSamplerCwdIsolated(samplerCwd: string, botDir: string, forbiddenCwds: readonly string[]): void {
+  const normalizedSamplerCwd = normalizeComparablePath(samplerCwd);
+  const protectedCwds = [botDir, ...forbiddenCwds].map(normalizeComparablePath);
+  if (protectedCwds.includes(normalizedSamplerCwd)) {
+    throw new Error(
+      `Refusing to use sampler cwd that matches the bot directory or a configured agent workspace: ${samplerCwd}`,
+    );
+  }
+}
+
+function normalizeComparablePath(path: string): string {
+  return resolve(path).replace(/[\\/]+$/, "");
+}
+
+function samplerProjectSettingsFile(samplerCwd: string): string {
+  return join(samplerCwd, ".pi", "settings.json");
+}
+
+function isSamplerProjectSettings(settings: Record<string, unknown>): boolean {
+  const keys = Object.keys(settings);
+  return keys.length === 1 && settings.transport === SAMPLER_PROJECT_SETTINGS.transport;
+}
+
+function ensurePrivateDirectory(path: string, label: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  let stat = lstatSync(path);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must not be a symlink: ${path}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`${label} must be a directory: ${path}`);
+  }
+
+  if (typeof process.getuid !== "function") {
+    return;
+  }
+
+  const uid = process.getuid();
+  if (stat.uid !== uid) {
+    throw new Error(`${label} must be owned by the current user: ${path}`);
+  }
+
+  if ((stat.mode & 0o077) !== 0) {
+    chmodSync(path, 0o700);
+    stat = lstatSync(path);
+    if ((stat.mode & 0o077) !== 0) {
+      throw new Error(`${label} must not be accessible by group or others: ${path}`);
+    }
+  }
+}
+
+function buildAttemptFilePath(samplerCwd: string): string {
+  return join(
+    samplerCwd,
+    ".tmp",
+    `codex-quota-attempt-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+  );
+}
+
+function writeProbeAttemptState(stateFile: string, attempt: ProbeAttempt): void {
+  const existing = readJsonObjectIfExists(stateFile);
+  if (existing === "malformed") {
+    return;
+  }
+
+  const timestamp = Math.floor(attempt.attemptedAt.getTime() / 1000);
+  const state = existing ?? {
+    provider: "codex",
+    windows: {
+      "5h": {},
+      week: {},
+    },
+  };
+
+  state.lastAttempt = attempt.attemptedAt.toISOString();
+  state.lastAttemptTimestamp = timestamp;
+  state.probeSuccess = attempt.probeSuccess;
+  atomicWriteFile(stateFile, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function readCapturedSnapshot(attemptFile: string): CodexQuotaSnapshot | undefined {
+  const content = readFileIfExists(attemptFile);
+  if (!content) {
+    return undefined;
+  }
+  const parsed = parseJsonObject(content);
+  if (!parsed || parsed.provider !== "codex" || !parsed.windows || typeof parsed.windows !== "object") {
+    return undefined;
+  }
+  return parsed as unknown as CodexQuotaSnapshot;
+}
+
+function discardAttemptFile(attemptFile: string): void {
+  try {
+    unlinkSync(attemptFile);
+  } catch {
+    // Attempt files are best-effort scratch files under the isolated sampler cwd.
+  }
+}
+
+function describeProbeFailure(
+  child: PiProbeResult,
+  extensionWriteError: boolean,
+  promotionError: unknown,
+  attemptStateError: unknown,
+  attemptMetricsError: unknown,
+): string {
+  if (child.timedOut) {
+    return "Pi probe timed out";
+  }
+  if (child.error) {
+    return child.error;
+  }
+  if (extensionWriteError) {
+    return "quota cache write failed";
+  }
+  if (promotionError) {
+    return `quota cache write failed: ${errorMessage(promotionError)}`;
+  }
+  if (attemptStateError) {
+    return `probe attempt state write failed: ${errorMessage(attemptStateError)}`;
+  }
+  if (attemptMetricsError) {
+    return `probe attempt metrics write failed: ${errorMessage(attemptMetricsError)}`;
+  }
+  if (child.success) {
+    return "quota cache was not refreshed";
+  }
+  return child.stderr.trim() || `exit ${child.exitCode ?? "unknown"}`;
+}
+
+function readJsonObjectIfExists(path: string): Record<string, unknown> | "malformed" | undefined {
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  return parseJsonObject(readFileSync(path, "utf8")) ?? "malformed";
+}
+
+function readFileIfExists(path: string): string | undefined {
+  try {
+    return existsSync(path) ? readFileSync(path, "utf8") : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonObject(content: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(content);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveConfiguredPath(raw: string | undefined, cwd: string): string | undefined {
+  const trimmed = nonEmpty(raw);
+  return trimmed ? resolve(cwd, trimmed) : undefined;
+}
+
+function nonEmpty(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function appendCapped(existing: string, next: string): string {
+  const combined = existing + next;
+  return combined.length > OUTPUT_BUFFER_LIMIT ? combined.slice(-OUTPUT_BUFFER_LIMIT) : combined;
+}
+
+function tryKill(child: SamplerChildLike, signal: NodeJS.Signals): boolean {
+  try {
+    return child.kill(signal);
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function atomicWriteFile(path: string, content: string): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const tempPath = join(
+    dir,
+    `.${basename(path)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  try {
+    writeFileSync(tempPath, content, { encoding: "utf8" });
+    renameSync(tempPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best effort cleanup of a same-directory staging file.
+    }
+    throw error;
+  }
+}

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -9,6 +9,8 @@ import { DEFAULT_MAX_MEDIA_BYTES } from "./media-store.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CONFIG_PATH = resolve(__dirname, "..", "..", "config.yaml");
+const PI_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const CONFIGURED_SECRET_PLACEHOLDER = "[configured]";
 
 // Derive the .local counterpart path: config.yaml → config.local.yaml
 function deriveLocalConfigPath(configPath: string): string {
@@ -79,6 +81,10 @@ interface RawConfig {
   defaultDeliveryThreadId?: number;
   defaultModel?: unknown;
   defaultFallbackModel?: unknown;
+}
+
+interface LoadConfigOptions {
+  resolveSecrets?: boolean;
 }
 
 /**
@@ -162,6 +168,14 @@ export function validateAgent(
   if (obj.provider !== undefined && obj.provider !== "claude" && obj.provider !== "pi") {
     throw new Error(`Agent "${id}" has invalid provider "${String(obj.provider)}" (must be "claude" or "pi")`);
   }
+  if (
+    obj.thinking !== undefined &&
+    (typeof obj.thinking !== "string" || !PI_THINKING_LEVELS.includes(obj.thinking as typeof PI_THINKING_LEVELS[number]))
+  ) {
+    throw new Error(
+      `Agent "${id}" has invalid thinking "${String(obj.thinking)}" (must be one of: ${PI_THINKING_LEVELS.join(", ")})`,
+    );
+  }
   return {
     id: String(obj.id ?? id),
     workspaceCwd: obj.workspaceCwd,
@@ -173,6 +187,7 @@ export function validateAgent(
     effort: typeof obj.effort === "string" && ["low", "medium", "high"].includes(obj.effort)
       ? (obj.effort as AgentConfig["effort"])
       : undefined,
+    thinking: obj.thinking as AgentConfig["thinking"] | undefined,
     provider: obj.provider === "pi" ? "pi" : "claude",
   };
 }
@@ -290,7 +305,11 @@ export function validateDiscordBinding(raw: unknown, index: number): DiscordBind
   };
 }
 
-function validateDiscordConfig(raw: RawConfig["discord"], agents: Record<string, AgentConfig>): DiscordConfig | undefined {
+function validateDiscordConfig(
+  raw: RawConfig["discord"],
+  agents: Record<string, AgentConfig>,
+  options: LoadConfigOptions = {},
+): DiscordConfig | undefined {
   if (!raw) return undefined;
   // Accept either tokenService (Keychain — macOS) or tokenEnv (env var — Linux/NixOS).
   // At least one must be set.
@@ -303,11 +322,13 @@ function validateDiscordConfig(raw: RawConfig["discord"], agents: Record<string,
   if (!raw.tokenService && !raw.tokenEnv) {
     throw new Error("discord requires either tokenService (macOS Keychain) or tokenEnv (env var)");
   }
-  const token = resolveSecret({
-    service: raw.tokenService,
-    envVar: raw.tokenEnv,
-    fieldName: "discord.token",
-  });
+  const token = options.resolveSecrets === false
+    ? CONFIGURED_SECRET_PLACEHOLDER
+    : resolveSecret({
+      service: raw.tokenService,
+      envVar: raw.tokenEnv,
+      fieldName: "discord.token",
+    });
   if (!Array.isArray(raw.bindings) || raw.bindings.length === 0) {
     throw new Error("discord.bindings must be a non-empty array");
   }
@@ -377,8 +398,9 @@ export function validateSessionDefaults(raw: unknown): SessionDefaults {
   return { idleTimeoutMs, maxConcurrentSessions, maxMessageAgeMs, requireMention, maxMediaBytes };
 }
 
-export function loadConfig(configPath?: string): BotConfig {
+export function loadConfig(configPath?: string, options: LoadConfigOptions = {}): BotConfig {
   const raw: RawConfig = loadRawMergedConfig(configPath) as RawConfig;
+  const resolveSecrets = options.resolveSecrets !== false;
 
   if (!raw || typeof raw !== "object") {
     throw new Error("Config file is empty or invalid");
@@ -416,11 +438,13 @@ export function loadConfig(configPath?: string): BotConfig {
   }
   let telegramToken: string | undefined;
   if (raw.telegramTokenService || raw.telegramTokenEnv) {
-    telegramToken = resolveSecret({
-      service: raw.telegramTokenService,
-      envVar: raw.telegramTokenEnv,
-      fieldName: "telegramToken",
-    });
+    telegramToken = resolveSecrets
+      ? resolveSecret({
+        service: raw.telegramTokenService,
+        envVar: raw.telegramTokenEnv,
+        fieldName: "telegramToken",
+      })
+      : CONFIGURED_SECRET_PLACEHOLDER;
   }
 
   // Validate Telegram bindings (optional if Discord is configured)
@@ -446,7 +470,7 @@ export function loadConfig(configPath?: string): BotConfig {
   }
 
   // Validate Discord config (optional)
-  const discord = validateDiscordConfig(raw.discord, agents);
+  const discord = validateDiscordConfig(raw.discord, agents, { resolveSecrets });
 
   // At least one platform must be configured
   if (bindings.length === 0 && !discord) {
@@ -511,18 +535,19 @@ export function loadConfig(configPath?: string): BotConfig {
 }
 
 // CLI: validate config
-if (process.argv.includes("--validate")) {
+const validateWithoutSecrets = process.argv.includes("--validate-structure") || process.argv.includes("--no-resolve-secrets");
+if (process.argv.includes("--validate") || validateWithoutSecrets) {
   try {
-    const config = loadConfig();
+    const config = loadConfig(undefined, { resolveSecrets: !validateWithoutSecrets });
     log.info("config", "Config valid.");
     log.info("config", `  Agents: ${Object.keys(config.agents).join(", ")}`);
     log.info("config", `  Telegram bindings: ${config.bindings.length}`);
     if (config.telegramToken) {
-      log.info("config", `  Telegram token: ${config.telegramToken.slice(0, 4)}...`);
+      log.info("config", "  Telegram token: configured");
     }
     if (config.discord) {
       log.info("config", `  Discord bindings: ${config.discord.bindings.length}`);
-      log.info("config", `  Discord token: ${config.discord.token.slice(0, 4)}...`);
+      log.info("config", "  Discord token: configured");
     }
     log.info("config", `  Idle timeout: ${config.sessionDefaults.idleTimeoutMs}ms`);
     log.info("config", `  Max sessions: ${config.sessionDefaults.maxConcurrentSessions}`);

--- a/bot/src/discord-bot.ts
+++ b/bot/src/discord-bot.ts
@@ -10,6 +10,8 @@ import { tempFilePath, downloadFile, transcribeAudio, cleanupTempFile } from "./
 import { log } from "./logger.js";
 import { messagesReceived } from "./metrics.js";
 import { isImageMimeType } from "./mime.js";
+import { readQuotaStatus } from "./quota-status.js";
+import { buildStatusReport } from "./status-report.js";
 /** Check if a message is too old to process (same logic as telegram-bot.ts). */
 function isStaleMessage(messageTimestampMs: number, maxAgeMs: number): boolean {
   return Date.now() - messageTimestampMs > maxAgeMs;
@@ -121,6 +123,79 @@ export function buildDiscordSourcePrefix(
 export interface DiscordBotResult {
   client: Client;
   messageQueue: MessageQueue;
+}
+
+interface DiscordCommandInteractionLike {
+  commandName: string;
+  channelId: string;
+  guildId: string | null;
+  channel?: {
+    isThread: () => boolean;
+    parentId?: string | null;
+  } | null;
+  reply: (response: string | { content: string; ephemeral?: boolean }) => Promise<unknown>;
+}
+
+interface DiscordCommandHandlerOptions {
+  config: BotConfig;
+  discordConfig: DiscordConfig;
+  sessionManager: SessionManager;
+  messageQueue: Pick<MessageQueue, "clear">;
+}
+
+export async function handleDiscordChatInputCommand(
+  interaction: DiscordCommandInteractionLike,
+  options: DiscordCommandHandlerOptions,
+): Promise<void> {
+  const { config, discordConfig, sessionManager, messageQueue } = options;
+  const isThread = interaction.channel?.isThread() ?? false;
+  const channelId = isThread && interaction.channel && "parentId" in interaction.channel
+    ? (interaction.channel.parentId ?? interaction.channelId)
+    : interaction.channelId;
+  const threadId = isThread ? interaction.channelId : undefined;
+
+  const binding = resolveDiscordBinding(channelId, discordConfig.bindings, interaction.guildId ?? undefined);
+  if (!binding) {
+    await interaction.reply({ content: "This channel is not configured.", ephemeral: true });
+    return;
+  }
+
+  const key = discordSessionKey(channelId, threadId);
+
+  switch (interaction.commandName) {
+    case "start": {
+      const agent = config.agents[binding.agentId];
+      await interaction.reply(
+        `Connected to agent "${binding.agentId}" (${agent?.model ?? "unknown"}). Send a message to start.`,
+      );
+      break;
+    }
+    case "reconnect": {
+      messageQueue.clear(key);
+      await sessionManager.closeSession(key);
+      await interaction.reply("Session restarted. Prior context may be partially retained.");
+      break;
+    }
+    case "clean": {
+      messageQueue.clear(key);
+      await sessionManager.destroySession(key);
+      await interaction.reply("Session cleaned. Fresh start.");
+      break;
+    }
+    case "status": {
+      await interaction.reply(buildStatusReport({
+        activeCount: sessionManager.getActiveCount(),
+        maxSessions: config.sessionDefaults.maxConcurrentSessions,
+        uptimeSeconds: Math.floor(process.uptime()),
+        sessionHealth: sessionManager.getSessionHealth(key),
+        quotaStatus: readQuotaStatus(),
+      }));
+      break;
+    }
+    default:
+      await interaction.reply({ content: "Unknown command.", ephemeral: true });
+      break;
+  }
 }
 
 /**
@@ -355,93 +430,12 @@ export async function createDiscordBot(
   client.on(Events.InteractionCreate, async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
-
-      const isThread = interaction.channel?.isThread() ?? false;
-      const channelId = isThread && interaction.channel && "parentId" in interaction.channel
-        ? (interaction.channel.parentId ?? interaction.channelId)
-        : interaction.channelId;
-      const threadId = isThread ? interaction.channelId : undefined;
-
-      const binding = resolveDiscordBinding(channelId, discordConfig.bindings, interaction.guildId ?? undefined);
-      if (!binding) {
-        await interaction.reply({ content: "This channel is not configured.", ephemeral: true });
-        return;
-      }
-
-      const key = discordSessionKey(channelId, threadId);
-
-      switch (interaction.commandName) {
-        case "start": {
-          const agent = config.agents[binding.agentId];
-          await interaction.reply(
-            `Connected to agent "${binding.agentId}" (${agent?.model ?? "unknown"}). Send a message to start.`,
-          );
-          break;
-        }
-        // Session lifecycle: create → compact → reconnect → resume. Reconnect
-        // kills the Claude subprocess but the session file (with compacted
-        // conversation history) remains on disk. When the next message arrives,
-        // getOrCreateSession() finds the file and resumes with --resume, so
-        // prior context may be partially retained through the compaction summary.
-        case "reconnect": {
-          messageQueue.clear(key);
-          await sessionManager.closeSession(key);
-          await interaction.reply("Session restarted. Prior context may be partially retained.");
-          break;
-        }
-        // Clean destroys the session entirely — subprocess killed AND stored
-        // state deleted. Next message starts a brand new session with no history.
-        case "clean": {
-          messageQueue.clear(key);
-          await sessionManager.destroySession(key);
-          await interaction.reply("Session cleaned. Fresh start.");
-          break;
-        }
-        case "status": {
-          const activeCount = sessionManager.getActiveCount();
-          const memUsage = process.memoryUsage();
-          const uptimeSeconds = Math.floor(process.uptime());
-          const hours = Math.floor(uptimeSeconds / 3600);
-          const minutes = Math.floor((uptimeSeconds % 3600) / 60);
-
-          const lines = [
-            `Active sessions: ${activeCount}/${config.sessionDefaults.maxConcurrentSessions}`,
-            `Memory: ${Math.round(memUsage.rss / 1024 / 1024)}MB RSS`,
-            `Uptime: ${hours}h ${minutes}m`,
-          ];
-
-          const health = sessionManager.getSessionHealth(key);
-          if (health) {
-            const status = health.alive ? "alive" : "dead";
-            const pidStr = health.pid !== null ? String(health.pid) : "n/a";
-            const idleMins = Math.floor(health.idleMs / 60000);
-
-            lines.push(`This session: agent "${health.agentId}", PID ${pidStr} (${status})`);
-            lines.push(`  Session ID: ${health.sessionId}`);
-
-            if (health.processingMs !== null) {
-              lines.push(`  Processing: ${Math.floor(health.processingMs / 1000)}s`);
-            } else {
-              lines.push(`  Idle: ${idleMins}m`);
-            }
-
-            if (health.lastSuccessAt !== null) {
-              const agoMins = Math.floor((Date.now() - health.lastSuccessAt) / 60000);
-              lines.push(`  Last success: ${agoMins}m ago`);
-            } else {
-              lines.push(`  Last success: none`);
-            }
-
-            lines.push(`  Restarts: ${health.restartCount}`);
-          }
-
-          await interaction.reply(lines.join("\n"));
-          break;
-        }
-        default:
-          await interaction.reply({ content: "Unknown command.", ephemeral: true });
-          break;
-      }
+      await handleDiscordChatInputCommand(interaction, {
+        config,
+        discordConfig,
+        sessionManager,
+        messageQueue,
+      });
     } catch (err) {
       log.error("discord-bot", `Interaction handler error:`, err);
       if (interaction.isChatInputCommand() && !interaction.replied && !interaction.deferred) {

--- a/bot/src/pi-extensions/README.md
+++ b/bot/src/pi-extensions/README.md
@@ -1,7 +1,13 @@
 # pi-extensions
 
-Pure, testable helpers for the Pi extensions (A1 guard, A2 web-tools, A3 subagent)
-loaded into every `pi --mode rpc` spawn. See `docs/plans/completed/2026-06-01-pi-phase2-extensions.md`.
+Pure, testable helpers for Pi extension wrappers.
+
+Most helpers here back the live Pi RPC extensions (A1 guard, A2 web-tools, A3
+subagent) loaded into every `pi --mode rpc` spawn. `codex-usage.ts` is different:
+it is used only by the out-of-band Codex quota sampler via
+`bot/.claude/extensions/codex-usage.ts`, and must not be added to the normal
+`PI_EXTENSION_WRAPPER_RELPATHS` list. See
+`docs/plans/completed/2026-06-01-pi-phase2-extensions.md` for A1-A3.
 
 ## Location lock (Task 0)
 
@@ -9,7 +15,8 @@ There are TWO kinds of files in this feature, deliberately split:
 
 1. **Pure helpers — `bot/src/pi-extensions/*.ts`** (this directory).
    All real logic lives here: path classification (A1), Tavily request/parse
-   (A2), subagent spawn-arg/result helpers (A3). These files are:
+   (A2), subagent spawn-arg/result helpers (A3), and the sampler-only Codex
+   quota cache/export helper. These files are:
    - **Type-checked by `tsc --noEmit`** (the `npm run lint` command) because the
      bot `tsconfig.json` `include` is `["src/**/*.ts"]`, which matches this path.
    - **Exercised by `npm test`** because the test glob is `src/__tests__/*.test.ts`

--- a/bot/src/pi-extensions/codex-usage.ts
+++ b/bot/src/pi-extensions/codex-usage.ts
@@ -1,0 +1,622 @@
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+
+export const CODEX_QUOTA_STATE_FILE_ENV = "CODEX_QUOTA_STATE_FILE";
+export const CODEX_QUOTA_TEXTFILE_DIR_ENV = "CODEX_QUOTA_TEXTFILE_DIR";
+export const NODE_EXPORTER_TEXTFILE_DIR_ENV = "NODE_EXPORTER_TEXTFILE_DIR";
+export const CODEX_QUOTA_ATTEMPT_FILE_ENV = "CODEX_QUOTA_ATTEMPT_FILE";
+export const DEFAULT_NODE_EXPORTER_TEXTFILE_DIR = "/opt/homebrew/var/node_exporter/textfile";
+export const DEFAULT_CODEX_QUOTA_STATE_RELPATH = join(".tmp", "codex-quota-state.json");
+export const CODEX_USAGE_TEXTFILE_NAME = "codex_usage.prom";
+
+const HEADER_NAMES = {
+  primaryUsedPercent: "x-codex-primary-used-percent",
+  secondaryUsedPercent: "x-codex-secondary-used-percent",
+  primaryResetAt: "x-codex-primary-reset-at",
+  secondaryResetAt: "x-codex-secondary-reset-at",
+  planType: "x-codex-plan-type",
+  activeLimit: "x-codex-active-limit",
+} as const;
+
+const KNOWN_HEADER_NAMES = Object.values(HEADER_NAMES);
+
+export type CodexQuotaWindowName = "5h" | "week";
+
+export interface CodexQuotaWindow {
+  usedPercent?: number;
+  remainingPercent?: number;
+  resetAt?: string;
+  resetTimestamp?: number;
+}
+
+export interface CodexQuotaSnapshot {
+  provider: "codex";
+  sampledAt: string;
+  lastSuccess: string;
+  lastSuccessTimestamp: number;
+  lastAttempt?: string;
+  lastAttemptTimestamp?: number;
+  probeSuccess?: boolean;
+  planType?: string;
+  activeLimit?: string;
+  windows: Record<CodexQuotaWindowName, CodexQuotaWindow>;
+}
+
+export interface CodexQuotaPathOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  stateFile?: string;
+  textfileDir?: string;
+  isWritableDir?: (path: string) => boolean;
+}
+
+export interface CodexQuotaPaths {
+  stateFile: string;
+  textfileDir?: string;
+}
+
+export interface CodexQuotaWriteOptions extends CodexQuotaPathOptions {
+  textfileName?: string;
+}
+
+export interface CodexQuotaCaptureOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  attemptFile?: string;
+  now?: Date;
+}
+
+export interface CodexQuotaWriteResult {
+  stateFile: string;
+  metricsFile?: string;
+}
+
+export type CodexQuotaRecordResult =
+  | { status: "no_quota_headers" }
+  | ({ status: "written"; snapshot: CodexQuotaSnapshot } & CodexQuotaWriteResult)
+  | { status: "write_error"; snapshot: CodexQuotaSnapshot; error: unknown };
+
+export type CodexQuotaCaptureResult =
+  | { status: "no_quota_headers" }
+  | { status: "captured"; snapshot: CodexQuotaSnapshot; attemptFile: string }
+  | { status: "write_error"; snapshot: CodexQuotaSnapshot; error: unknown };
+
+interface HeaderGetter {
+  get: (name: string) => unknown;
+}
+
+export function resolveCodexQuotaPaths(options: CodexQuotaPathOptions = {}): CodexQuotaPaths {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const stateFile =
+    configuredPath(options.stateFile, cwd) ??
+    configuredPath(env[CODEX_QUOTA_STATE_FILE_ENV], cwd) ??
+    resolve(cwd, DEFAULT_CODEX_QUOTA_STATE_RELPATH);
+
+  const explicitTextfileDir =
+    configuredPath(options.textfileDir, cwd) ??
+    configuredPath(env[CODEX_QUOTA_TEXTFILE_DIR_ENV], cwd) ??
+    configuredPath(env[NODE_EXPORTER_TEXTFILE_DIR_ENV], cwd);
+  if (explicitTextfileDir) {
+    return { stateFile, textfileDir: explicitTextfileDir };
+  }
+
+  const isWritableDir = options.isWritableDir ?? isDirWritable;
+  if (isWritableDir(DEFAULT_NODE_EXPORTER_TEXTFILE_DIR)) {
+    return { stateFile, textfileDir: DEFAULT_NODE_EXPORTER_TEXTFILE_DIR };
+  }
+
+  return { stateFile };
+}
+
+export function parseCodexQuotaHeaders(headers: unknown, now = new Date()): CodexQuotaSnapshot | null {
+  if (!hasAnyKnownHeader(headers)) {
+    return null;
+  }
+
+  const sampledAt = now.toISOString();
+  const snapshot: CodexQuotaSnapshot = {
+    provider: "codex",
+    sampledAt,
+    lastSuccess: sampledAt,
+    lastSuccessTimestamp: Math.floor(now.getTime() / 1000),
+    windows: {
+      "5h": {},
+      week: {},
+    },
+  };
+
+  setUsedPercent(snapshot.windows["5h"], getHeaderValue(headers, HEADER_NAMES.primaryUsedPercent));
+  setUsedPercent(snapshot.windows.week, getHeaderValue(headers, HEADER_NAMES.secondaryUsedPercent));
+  setResetAt(snapshot.windows["5h"], getHeaderValue(headers, HEADER_NAMES.primaryResetAt));
+  setResetAt(snapshot.windows.week, getHeaderValue(headers, HEADER_NAMES.secondaryResetAt));
+
+  const planType = normalizeHeaderText(getHeaderValue(headers, HEADER_NAMES.planType));
+  if (planType) {
+    snapshot.planType = planType;
+  }
+
+  const activeLimit = normalizeHeaderText(getHeaderValue(headers, HEADER_NAMES.activeLimit));
+  if (activeLimit) {
+    snapshot.activeLimit = activeLimit;
+  }
+
+  return hasUsableQuotaUsage(snapshot) ? snapshot : null;
+}
+
+export function extractCodexResponseHeaders(input: unknown): unknown | undefined {
+  return findHeaderSource(input, 0, new Set<object>());
+}
+
+export function recordCodexQuotaFromProviderResponse(
+  input: unknown,
+  options: CodexQuotaWriteOptions & { now?: Date } = {},
+): CodexQuotaRecordResult {
+  const headers = extractCodexResponseHeaders(input);
+  if (!headers) {
+    return { status: "no_quota_headers" };
+  }
+  return recordCodexQuotaFromHeaders(headers, options);
+}
+
+export function recordCodexQuotaFromHeaders(
+  headers: unknown,
+  options: CodexQuotaWriteOptions & { now?: Date } = {},
+): CodexQuotaRecordResult {
+  const snapshot = parseCodexQuotaHeaders(headers, options.now ?? new Date());
+  if (!snapshot) {
+    return { status: "no_quota_headers" };
+  }
+
+  try {
+    return {
+      status: "written",
+      snapshot,
+      ...writeCodexQuotaSnapshot(snapshot, options),
+    };
+  } catch (error) {
+    return { status: "write_error", snapshot, error };
+  }
+}
+
+export function captureCodexQuotaFromProviderResponse(
+  input: unknown,
+  options: CodexQuotaCaptureOptions = {},
+): CodexQuotaCaptureResult {
+  const headers = extractCodexResponseHeaders(input);
+  if (!headers) {
+    return { status: "no_quota_headers" };
+  }
+  return captureCodexQuotaFromHeaders(headers, options);
+}
+
+export function captureCodexQuotaFromHeaders(
+  headers: unknown,
+  options: CodexQuotaCaptureOptions = {},
+): CodexQuotaCaptureResult {
+  const snapshot = parseCodexQuotaHeaders(headers, options.now ?? new Date());
+  if (!snapshot) {
+    return { status: "no_quota_headers" };
+  }
+
+  try {
+    const attemptFile = resolveCodexQuotaAttemptFile(options);
+    atomicWriteFile(attemptFile, `${JSON.stringify(snapshot, null, 2)}\n`);
+    return { status: "captured", snapshot, attemptFile };
+  } catch (error) {
+    return { status: "write_error", snapshot, error };
+  }
+}
+
+export function writeCodexQuotaSnapshot(
+  snapshot: CodexQuotaSnapshot,
+  options: CodexQuotaWriteOptions = {},
+): CodexQuotaWriteResult {
+  const paths = resolveCodexQuotaPaths(options);
+  const writes: Array<{ path: string; content: string }> = [
+    { path: paths.stateFile, content: `${JSON.stringify(snapshot, null, 2)}\n` },
+  ];
+
+  if (!paths.textfileDir) {
+    atomicWriteFiles(writes);
+    return { stateFile: paths.stateFile };
+  }
+
+  const metricsFile = join(paths.textfileDir, options.textfileName ?? CODEX_USAGE_TEXTFILE_NAME);
+  writes.push({ path: metricsFile, content: formatCodexQuotaPrometheus(snapshot) });
+  atomicWriteFiles(writes);
+  return { stateFile: paths.stateFile, metricsFile };
+}
+
+export function formatCodexQuotaPrometheus(snapshot: CodexQuotaSnapshot): string {
+  const lines: string[] = [];
+  pushGauge(
+    lines,
+    "codex_usage_5h_percent",
+    "Codex 5-hour usage percent from the last successful sampler probe.",
+    snapshot.windows["5h"].usedPercent,
+  );
+  pushGauge(
+    lines,
+    "codex_usage_weekly_percent",
+    "Codex weekly usage percent from the last successful sampler probe.",
+    snapshot.windows.week.usedPercent,
+  );
+  pushGauge(
+    lines,
+    "codex_usage_5h_reset_timestamp",
+    "Unix timestamp when the Codex 5-hour usage window resets.",
+    snapshot.windows["5h"].resetTimestamp,
+  );
+  pushGauge(
+    lines,
+    "codex_usage_weekly_reset_timestamp",
+    "Unix timestamp when the Codex weekly usage window resets.",
+    snapshot.windows.week.resetTimestamp,
+  );
+  pushGauge(
+    lines,
+    "codex_usage_last_success_timestamp",
+    "Unix timestamp of the last successful Codex quota sampler probe.",
+    snapshot.lastSuccessTimestamp,
+  );
+
+  const planType = prometheusLabelValue(lowCardinalityLabel(snapshot.planType));
+  const activeLimit = prometheusLabelValue(lowCardinalityLabel(snapshot.activeLimit));
+  lines.push(
+    "# HELP codex_usage_info Codex quota metadata from the last successful sampler probe.",
+    "# TYPE codex_usage_info gauge",
+    `codex_usage_info{provider="codex",plan_type="${planType}",active_limit="${activeLimit}"} 1`,
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatCodexQuotaWriteError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `[codex-usage] failed to write quota cache: ${message}`;
+}
+
+function configuredPath(raw: string | undefined, cwd: string): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? resolve(cwd, trimmed) : undefined;
+}
+
+function resolveCodexQuotaAttemptFile(options: CodexQuotaCaptureOptions): string {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const attemptFile =
+    configuredPath(options.attemptFile, cwd) ??
+    configuredPath(env[CODEX_QUOTA_ATTEMPT_FILE_ENV], cwd);
+  if (!attemptFile) {
+    throw new Error(`${CODEX_QUOTA_ATTEMPT_FILE_ENV} is required`);
+  }
+  return attemptFile;
+}
+
+function isDirWritable(path: string): boolean {
+  try {
+    accessSync(path, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function atomicWriteFile(path: string, content: string): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const tempPath = join(
+    dir,
+    `.${basename(path)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  try {
+    writeFileSync(tempPath, content, { encoding: "utf8" });
+    renameSync(tempPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best effort cleanup of a same-directory staging file.
+    }
+    throw error;
+  }
+}
+
+interface AtomicWritePlan {
+  path: string;
+  content: string;
+  tempPath: string;
+  previousContent?: string;
+  existed: boolean;
+  committed: boolean;
+}
+
+function atomicWriteFiles(writes: Array<{ path: string; content: string }>): void {
+  const plans: AtomicWritePlan[] = writes.map(({ path, content }) => ({
+    path,
+    content,
+    tempPath: tempPathFor(path),
+    ...readPreviousFile(path),
+    committed: false,
+  }));
+
+  try {
+    for (const plan of plans) {
+      mkdirSync(dirname(plan.path), { recursive: true });
+      writeFileSync(plan.tempPath, plan.content, { encoding: "utf8" });
+    }
+    for (const plan of plans) {
+      renameSync(plan.tempPath, plan.path);
+      plan.committed = true;
+    }
+  } catch (error) {
+    for (const plan of plans) {
+      if (!plan.committed) {
+        try {
+          unlinkSync(plan.tempPath);
+        } catch {
+          // Best effort cleanup of same-directory staging files.
+        }
+      }
+    }
+    rollbackCommittedWrites(plans);
+    throw error;
+  }
+}
+
+function tempPathFor(path: string): string {
+  return join(
+    dirname(path),
+    `.${basename(path)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+}
+
+function readPreviousFile(path: string): { existed: boolean; previousContent?: string } {
+  if (!existsSync(path)) {
+    return { existed: false };
+  }
+  return { existed: true, previousContent: readFileSync(path, "utf8") };
+}
+
+function rollbackCommittedWrites(plans: AtomicWritePlan[]): void {
+  for (const plan of plans.slice().reverse()) {
+    if (!plan.committed) {
+      continue;
+    }
+    try {
+      if (plan.existed) {
+        writeFileSync(plan.path, plan.previousContent ?? "", { encoding: "utf8" });
+      } else {
+        unlinkSync(plan.path);
+      }
+    } catch {
+      // Preserve the original write error; rollback is best effort.
+    }
+  }
+}
+
+function findHeaderSource(input: unknown, depth: number, seen: Set<object>): unknown | undefined {
+  if (!input || depth > 4) {
+    return undefined;
+  }
+  if (hasAnyKnownHeader(input)) {
+    return input;
+  }
+  if (typeof input !== "object") {
+    return undefined;
+  }
+  if (seen.has(input)) {
+    return undefined;
+  }
+  seen.add(input);
+
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const found = findHeaderSource(item, depth + 1, seen);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  const record = input as Record<string, unknown>;
+  const priorityKeys = [
+    "headers",
+    "responseHeaders",
+    "response",
+    "providerResponse",
+    "httpResponse",
+    "rawResponse",
+    "res",
+  ];
+  for (const key of priorityKeys) {
+    if (key in record) {
+      const found = findHeaderSource(record[key], depth + 1, seen);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  if (depth < 2) {
+    for (const value of Object.values(record)) {
+      const found = findHeaderSource(value, depth + 1, seen);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasAnyKnownHeader(headers: unknown): boolean {
+  return KNOWN_HEADER_NAMES.some((name) => getHeaderValue(headers, name) !== undefined);
+}
+
+function hasUsableQuotaUsage(snapshot: CodexQuotaSnapshot): boolean {
+  return Object.values(snapshot.windows).some((window) => typeof window.usedPercent === "number");
+}
+
+function getHeaderValue(headers: unknown, name: string): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (isHeaderGetter(headers)) {
+    return normalizeHeaderValue(headers.get(name));
+  }
+
+  if (Array.isArray(headers)) {
+    const lowerName = name.toLowerCase();
+    for (const entry of headers) {
+      if (!Array.isArray(entry) || entry.length < 2) {
+        continue;
+      }
+      const key = typeof entry[0] === "string" ? entry[0].toLowerCase() : "";
+      if (key === lowerName) {
+        return normalizeHeaderValue(entry[1]);
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof headers !== "object") {
+    return undefined;
+  }
+
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === lowerName) {
+      return normalizeHeaderValue(value);
+    }
+  }
+
+  return undefined;
+}
+
+function isHeaderGetter(value: unknown): value is HeaderGetter {
+  return Boolean(value) && typeof value === "object" && typeof (value as HeaderGetter).get === "function";
+}
+
+function normalizeHeaderValue(raw: unknown): string | undefined {
+  if (Array.isArray(raw)) {
+    for (const value of raw) {
+      const normalized = normalizeHeaderValue(value);
+      if (normalized !== undefined) {
+        return normalized;
+      }
+    }
+    return undefined;
+  }
+  if (typeof raw === "number") {
+    return Number.isFinite(raw) ? String(raw) : undefined;
+  }
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function setUsedPercent(window: CodexQuotaWindow, raw: string | undefined): void {
+  const usedPercent = parseNonNegativeNumber(raw);
+  if (usedPercent === undefined) {
+    return;
+  }
+  window.usedPercent = roundMetricValue(usedPercent);
+  window.remainingPercent = roundMetricValue(Math.max(0, 100 - usedPercent));
+}
+
+function setResetAt(window: CodexQuotaWindow, raw: string | undefined): void {
+  const resetTimestamp = parseTimestampSeconds(raw);
+  if (resetTimestamp === undefined) {
+    return;
+  }
+  window.resetTimestamp = resetTimestamp;
+  window.resetAt = new Date(resetTimestamp * 1000).toISOString();
+}
+
+function parseNonNegativeNumber(raw: string | undefined): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.endsWith("%") ? raw.slice(0, -1).trim() : raw;
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) {
+    return undefined;
+  }
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function parseTimestampSeconds(raw: string | undefined): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  if (/^\d+(?:\.\d+)?$/.test(raw)) {
+    const numeric = Number(raw);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      return undefined;
+    }
+    return Math.floor(numeric > 1_000_000_000_000 ? numeric / 1000 : numeric);
+  }
+
+  const millis = Date.parse(raw);
+  if (!Number.isFinite(millis)) {
+    return undefined;
+  }
+  return Math.floor(millis / 1000);
+}
+
+function normalizeHeaderText(raw: string | undefined): string | undefined {
+  const trimmed = raw?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.slice(0, 128);
+}
+
+function roundMetricValue(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function pushGauge(lines: string[], name: string, help: string, value: number | undefined): void {
+  lines.push(`# HELP ${name} ${help}`, `# TYPE ${name} gauge`);
+  if (value !== undefined && Number.isFinite(value)) {
+    lines.push(`${name} ${formatPrometheusNumber(value)}`);
+  }
+}
+
+function formatPrometheusNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(roundMetricValue(value));
+}
+
+function lowCardinalityLabel(raw: string | undefined): string {
+  const normalized = raw
+    ?.toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!normalized) {
+    return "unknown";
+  }
+  return normalized.length <= 64 ? normalized : "other";
+}
+
+function prometheusLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
+}

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -220,7 +220,7 @@ function stripTrailingCarriageReturn(record: string): string {
   return record.endsWith("\r") ? record.slice(0, -1) : record;
 }
 
-function normalizePiModel(model: string | undefined): string {
+export function normalizePiModel(model: string | undefined): string {
   const trimmed = model?.trim();
   if (!trimmed) {
     return DEFAULT_PI_MODEL;
@@ -238,6 +238,10 @@ export function buildPiSpawnArgs(
     "--provider", PI_PROVIDER,
     "--model", normalizePiModel(agent.model),
   ];
+
+  if (agent.provider === "pi" && agent.thinking) {
+    args.push("--thinking", agent.thinking);
+  }
 
   // Spawn-time context assembly — provider: "pi" ONLY (the claude path never
   // reaches here). The assembler (pi-context-assembler.ts) gives full Claude→Pi

--- a/bot/src/quota-status.ts
+++ b/bot/src/quota-status.ts
@@ -1,0 +1,286 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolveCodexQuotaPaths } from "./pi-extensions/codex-usage.js";
+
+export const CODEX_QUOTA_STALE_MS_ENV = "CODEX_QUOTA_STALE_MS";
+export const DEFAULT_CODEX_QUOTA_STALE_MS = 30 * 60 * 1000;
+
+export type QuotaProvider = "codex";
+export type QuotaWindowName = "5h" | "week";
+export type QuotaStatusState = "available" | "stale" | "unavailable" | "read_error";
+
+export interface QuotaWindowSnapshot {
+  usedPercent?: number;
+  remainingPercent?: number;
+  resetAt?: string;
+  resetTimestamp?: number;
+}
+
+export interface QuotaSnapshot {
+  provider: QuotaProvider;
+  windows: Record<QuotaWindowName, QuotaWindowSnapshot>;
+  sampledAt?: string;
+  lastSuccess?: string;
+  lastSuccessTimestamp?: number;
+  lastAttempt?: string;
+  lastAttemptTimestamp?: number;
+  probeSuccess?: boolean;
+  planType?: string;
+  activeLimit?: string;
+}
+
+export interface QuotaStatusOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  stateFile?: string;
+  now?: Date;
+  staleMs?: number;
+}
+
+export type QuotaStatus =
+  | {
+      state: "available" | "stale";
+      stateFile: string;
+      snapshot: QuotaSnapshot;
+      ageMs: number;
+      sampleAge: string;
+      staleMs: number;
+    }
+  | {
+      state: "unavailable";
+      stateFile: string;
+      reason: "missing_file" | "no_success";
+      staleMs: number;
+      snapshot?: QuotaSnapshot;
+    }
+  | {
+      state: "read_error";
+      stateFile: string;
+      error: string;
+      staleMs: number;
+    };
+
+export function readQuotaStatus(options: QuotaStatusOptions = {}): QuotaStatus {
+  const stateFile = resolveQuotaStateFile(options);
+  const now = options.now ?? new Date();
+  let staleMs = DEFAULT_CODEX_QUOTA_STALE_MS;
+  try {
+    staleMs = resolveQuotaStaleMs(options);
+  } catch (error) {
+    return {
+      state: "read_error",
+      stateFile,
+      error: errorMessage(error),
+      staleMs,
+    };
+  }
+
+  if (!existsSync(stateFile)) {
+    return {
+      state: "unavailable",
+      stateFile,
+      reason: "missing_file",
+      staleMs,
+    };
+  }
+
+  try {
+    const snapshot = parseQuotaSnapshot(JSON.parse(readFileSync(stateFile, "utf8")));
+    const lastSuccessMs = lastSuccessMillis(snapshot);
+    if (lastSuccessMs === undefined) {
+      return {
+        state: "unavailable",
+        stateFile,
+        reason: "no_success",
+        staleMs,
+        snapshot,
+      };
+    }
+
+    const ageMs = Math.max(0, now.getTime() - lastSuccessMs);
+    const sampleAge = formatSampleAge(lastSuccessMs, now) ?? "0m ago";
+    return {
+      state: ageMs > staleMs ? "stale" : "available",
+      stateFile,
+      snapshot,
+      ageMs,
+      sampleAge,
+      staleMs,
+    };
+  } catch (error) {
+    return {
+      state: "read_error",
+      stateFile,
+      error: errorMessage(error),
+      staleMs,
+    };
+  }
+}
+
+export function resolveQuotaStateFile(options: Pick<QuotaStatusOptions, "env" | "cwd" | "stateFile"> = {}): string {
+  return resolveCodexQuotaPaths({
+    env: options.env,
+    cwd: options.cwd,
+    stateFile: options.stateFile,
+    isWritableDir: () => false,
+  }).stateFile;
+}
+
+export function resolveQuotaStaleMs(options: Pick<QuotaStatusOptions, "env" | "staleMs"> = {}): number {
+  if (options.staleMs !== undefined) {
+    if (!isPositiveFiniteNumber(options.staleMs)) {
+      throw new Error(`${CODEX_QUOTA_STALE_MS_ENV} must be a positive number`);
+    }
+    return Math.floor(options.staleMs);
+  }
+
+  const env = options.env ?? process.env;
+  const raw = env[CODEX_QUOTA_STALE_MS_ENV];
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return DEFAULT_CODEX_QUOTA_STALE_MS;
+  }
+
+  const parsed = Number(trimmed);
+  if (!isPositiveFiniteNumber(parsed)) {
+    throw new Error(`${CODEX_QUOTA_STALE_MS_ENV} must be a positive number`);
+  }
+  return Math.floor(parsed);
+}
+
+export function parseQuotaSnapshot(raw: unknown): QuotaSnapshot {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("quota state must be an object");
+  }
+
+  const record = raw as Record<string, unknown>;
+  if (record.provider !== "codex") {
+    throw new Error("quota state provider is unsupported");
+  }
+
+  const windows = parseQuotaWindows(record.windows);
+  return {
+    provider: "codex",
+    windows,
+    ...optionalStringField(record, "sampledAt"),
+    ...optionalStringField(record, "lastSuccess"),
+    ...optionalNumberField(record, "lastSuccessTimestamp"),
+    ...optionalStringField(record, "lastAttempt"),
+    ...optionalNumberField(record, "lastAttemptTimestamp"),
+    ...optionalBooleanField(record, "probeSuccess"),
+    ...optionalStringField(record, "planType"),
+    ...optionalStringField(record, "activeLimit"),
+  };
+}
+
+export function formatResetEta(reset: string | number | undefined, now = new Date()): string | undefined {
+  const resetMs = timestampMillis(reset);
+  if (resetMs === undefined) {
+    return undefined;
+  }
+  const remainingMs = resetMs - now.getTime();
+  return remainingMs <= 0 ? "now" : formatCompactDuration(remainingMs);
+}
+
+export function formatSampleAge(sample: string | number | undefined, now = new Date()): string | undefined {
+  const sampleMs = timestampMillis(sample);
+  if (sampleMs === undefined) {
+    return undefined;
+  }
+  const ageMs = now.getTime() - sampleMs;
+  if (ageMs < 0) {
+    return `in ${formatCompactDuration(Math.abs(ageMs))}`;
+  }
+  return `${formatCompactDuration(ageMs)} ago`;
+}
+
+export function formatCompactDuration(durationMs: number): string {
+  const totalMinutes = Math.max(0, Math.floor(durationMs / 60_000));
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+function parseQuotaWindows(raw: unknown): Record<QuotaWindowName, QuotaWindowSnapshot> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("quota state windows must be an object");
+  }
+
+  const windows = raw as Record<string, unknown>;
+  return {
+    "5h": parseQuotaWindow(windows["5h"]),
+    week: parseQuotaWindow(windows.week),
+  };
+}
+
+function parseQuotaWindow(raw: unknown): QuotaWindowSnapshot {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+
+  const record = raw as Record<string, unknown>;
+  return {
+    ...optionalNumberField(record, "usedPercent"),
+    ...optionalNumberField(record, "remainingPercent"),
+    ...optionalStringField(record, "resetAt"),
+    ...optionalNumberField(record, "resetTimestamp"),
+  };
+}
+
+function optionalStringField<T extends string>(record: Record<string, unknown>, key: T): Partial<Record<T, string>> {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? ({ [key]: value } as Partial<Record<T, string>>) : {};
+}
+
+function optionalNumberField<T extends string>(record: Record<string, unknown>, key: T): Partial<Record<T, number>> {
+  const value = record[key];
+  return isFiniteNumber(value) ? ({ [key]: value } as Partial<Record<T, number>>) : {};
+}
+
+function optionalBooleanField<T extends string>(record: Record<string, unknown>, key: T): Partial<Record<T, boolean>> {
+  const value = record[key];
+  return typeof value === "boolean" ? ({ [key]: value } as Partial<Record<T, boolean>>) : {};
+}
+
+function lastSuccessMillis(snapshot: QuotaSnapshot): number | undefined {
+  return timestampMillis(snapshot.lastSuccessTimestamp ?? snapshot.lastSuccess ?? snapshot.sampledAt);
+}
+
+function timestampMillis(value: string | number | undefined): number | undefined {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) {
+      return undefined;
+    }
+    return value > 1_000_000_000_000 ? Math.floor(value) : Math.floor(value * 1000);
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric > 1_000_000_000_000 ? Math.floor(numeric) : Math.floor(numeric * 1000);
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value > 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/bot/src/session-manager.ts
+++ b/bot/src/session-manager.ts
@@ -7,7 +7,7 @@ import { on } from "node:events";
 import PQueue from "p-queue";
 import type { SessionState, StreamLine, BotConfig, AgentConfig } from "./types.js";
 import { spawnClaudeSession, sendMessage, readStream } from "./cli-protocol.js";
-import { spawnPiRpcSession, sendPiPrompt, sendPiSteer, sendPiGetState, readPiStream, parsePiRecord, NewlineOnlyJsonlSplitter, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
+import { spawnPiRpcSession, sendPiPrompt, sendPiSteer, sendPiGetState, readPiStream, parsePiRecord, NewlineOnlyJsonlSplitter, normalizePiModel, type PiStartupDiagnostics } from "./pi-rpc-protocol.js";
 import { SessionStore } from "./session-store.js";
 import { log } from "./logger.js";
 import { recordResultMetrics, recordPiRetry, recordPiTurnDuration, sessionsActive, sessionCrashes, piSessionResumeDiscarded } from "./metrics.js";
@@ -69,6 +69,12 @@ export interface ActiveSession {
    * fails to load must not break dispatch for a session that is still usable.
    */
   provider: "claude" | "pi";
+  /** Spawn-time model after provider-specific normalization. */
+  model: string;
+  /** Spawn-time Pi thinking level, when configured. */
+  thinking?: AgentConfig["thinking"];
+  /** Spawn-time Claude effort level, when configured. */
+  effort?: AgentConfig["effort"];
   queue: PQueue;
   idleTimer: ReturnType<typeof setTimeout> | null;
   /** Idle timeout baked at spawn time from config. */
@@ -91,12 +97,20 @@ export interface SessionHealth {
   alive: boolean;
   agentId: string;
   sessionId: string;
+  provider: "claude" | "pi";
+  model: string;
+  thinking?: AgentConfig["thinking"];
+  effort?: AgentConfig["effort"];
   idleMs: number;
   /** Milliseconds since current turn started, or null if not processing. */
   processingMs: number | null;
   /** Timestamp of last successful response, or null if none yet. */
   lastSuccessAt: number | null;
   restartCount: number;
+}
+
+function normalizedSessionModel(agent: AgentConfig, provider: "claude" | "pi"): string {
+  return provider === "pi" ? normalizePiModel(agent.model) : agent.model;
 }
 
 /**
@@ -469,12 +483,16 @@ export class SessionManager {
       this.restartCounts.set(chatId, 0);
     }
 
+    const provider = isPi ? "pi" : "claude";
     const session: ActiveSession = {
       child,
       sessionId: effectiveSessionId,
       agentId,
       // Pin the provider the child was actually spawned under (claude when absent).
-      provider: isPi ? "pi" : "claude",
+      provider,
+      model: normalizedSessionModel(agent, provider),
+      thinking: agent.thinking,
+      effort: agent.effort,
       queue: new PQueue({ concurrency: 1 }),
       idleTimer: null,
       idleTimeoutMs: freshConfig.sessionDefaults.idleTimeoutMs,
@@ -861,6 +879,10 @@ export class SessionManager {
       alive,
       agentId: session.agentId,
       sessionId: session.sessionId,
+      provider: session.provider,
+      model: session.model,
+      thinking: session.thinking,
+      effort: session.effort,
       idleMs: now - session.lastActivity,
       processingMs: session.processingStartedAt ? now - session.processingStartedAt : null,
       lastSuccessAt: session.lastSuccessAt,

--- a/bot/src/status-report.ts
+++ b/bot/src/status-report.ts
@@ -1,0 +1,256 @@
+import type { SessionHealth } from "./session-manager.js";
+import {
+  formatCompactDuration,
+  formatResetEta,
+  formatSampleAge,
+  type QuotaStatus,
+  type QuotaWindowName,
+  type QuotaWindowSnapshot,
+} from "./quota-status.js";
+
+export const DEFAULT_SESSION_LAST_SUCCESS_STALE_MS = 30 * 60 * 1000;
+
+type CachedQuotaStatus = Extract<QuotaStatus, { state: "available" | "stale" }>;
+
+export interface BuildStatusReportOptions {
+  activeCount: number;
+  maxSessions: number;
+  uptimeSeconds: number;
+  sessionHealth?: SessionHealth;
+  quotaStatus?: QuotaStatus;
+  now?: Date;
+  lastSuccessStaleMs?: number;
+}
+
+export function buildStatusReport(options: BuildStatusReportOptions): string {
+  const now = options.now ?? new Date();
+  const lines = [
+    `Sessions: ${options.activeCount}/${options.maxSessions}`,
+    `Uptime: ${formatCompactDuration(options.uptimeSeconds * 1000)}`,
+  ];
+
+  if (options.sessionHealth) {
+    lines.push("", ...formatSessionHealth(options.sessionHealth, now, options.lastSuccessStaleMs));
+  }
+
+  const quotaLines = formatQuotaBlock(options.quotaStatus, options.sessionHealth, now);
+  if (quotaLines.length > 0) {
+    lines.push("", ...quotaLines);
+  }
+
+  return lines.join("\n");
+}
+
+function formatSessionHealth(
+  health: SessionHealth,
+  now: Date,
+  lastSuccessStaleMs = DEFAULT_SESSION_LAST_SUCCESS_STALE_MS,
+): string[] {
+  const lines = [
+    `Agent: ${health.agentId} (${health.provider})`,
+    `Model: ${health.model}`,
+    formatReasoningLine(health),
+    `State: ${formatSessionState(health)}`,
+    `Session ID: ${health.sessionId}`,
+  ];
+
+  const diagnostics = formatSessionDiagnostics(health, now, lastSuccessStaleMs);
+  if (diagnostics.length > 0) {
+    lines.push("Diagnostics:", ...diagnostics.map((line) => `  ${line}`));
+  }
+
+  return lines;
+}
+
+function formatReasoningLine(health: SessionHealth): string {
+  if (health.provider === "pi") {
+    return `Thinking: ${health.thinking ?? "default"}`;
+  }
+  return `Effort: ${health.effort ?? "default"}`;
+}
+
+function formatSessionState(health: SessionHealth): string {
+  if (health.processingMs !== null) {
+    return `processing (${formatProcessingDuration(health.processingMs)})`;
+  }
+  return `idle (${formatCompactDuration(health.idleMs)})`;
+}
+
+function formatSessionDiagnostics(health: SessionHealth, now: Date, lastSuccessStaleMs: number): string[] {
+  const lines: string[] = [];
+
+  if (!health.alive) {
+    lines.push(`Process: dead (PID ${health.pid ?? "n/a"})`);
+  }
+  if (health.restartCount > 0) {
+    lines.push(`Restarts: ${health.restartCount}`);
+  }
+
+  const lastSuccessLine = formatLastSuccessDiagnostic(health.lastSuccessAt, now, lastSuccessStaleMs);
+  if (lastSuccessLine) {
+    lines.push(lastSuccessLine);
+  }
+
+  return lines;
+}
+
+function formatLastSuccessDiagnostic(lastSuccessAt: number | null, now: Date, staleMs: number): string | undefined {
+  if (lastSuccessAt === null) {
+    return "Last success: none";
+  }
+
+  const ageMs = now.getTime() - lastSuccessAt;
+  if (ageMs <= staleMs) {
+    return undefined;
+  }
+
+  return `Last success: ${formatSampleAge(lastSuccessAt, now) ?? "unknown"} (stale)`;
+}
+
+function formatQuotaBlock(
+  quotaStatus: QuotaStatus | undefined,
+  health: SessionHealth | undefined,
+  now: Date,
+): string[] {
+  if (!shouldRenderQuotaBlock(quotaStatus, health)) {
+    return [];
+  }
+  if (!quotaStatus) {
+    return ["Codex quota: unavailable (no cached state)"];
+  }
+
+  switch (quotaStatus.state) {
+    case "available":
+      return formatAvailableQuota(quotaStatus, now);
+    case "stale":
+      return formatStaleQuota(quotaStatus, now);
+    case "unavailable":
+      return formatUnavailableQuota(quotaStatus, now);
+    case "read_error":
+      return ["Codex quota: unavailable (read error)"];
+  }
+}
+
+function shouldRenderQuotaBlock(quotaStatus: QuotaStatus | undefined, health: SessionHealth | undefined): boolean {
+  if (!quotaStatus) {
+    return isPiCodexSession(health);
+  }
+  if (quotaStatus.state !== "unavailable") {
+    return true;
+  }
+  if (quotaStatus.reason !== "missing_file") {
+    return true;
+  }
+  return isPiCodexSession(health);
+}
+
+function isPiCodexSession(health: SessionHealth | undefined): boolean {
+  return health?.provider === "pi";
+}
+
+function formatAvailableQuota(quotaStatus: CachedQuotaStatus, now: Date): string[] {
+  const snapshot = quotaStatus.snapshot;
+  const lines = [`Codex quota: fresh (sample ${quotaStatus.sampleAge})`];
+  appendQuotaMetadata(lines, snapshot.planType, snapshot.activeLimit);
+  appendQuotaWindow(lines, "5h", snapshot.windows["5h"], now);
+  appendQuotaWindow(lines, "week", snapshot.windows.week, now);
+  appendAttemptLine(lines, snapshot.lastAttemptTimestamp ?? snapshot.lastAttempt, snapshot.probeSuccess, now);
+  return lines;
+}
+
+function formatStaleQuota(quotaStatus: CachedQuotaStatus, now: Date): string[] {
+  const snapshot = quotaStatus.snapshot;
+  const lines = [`Codex quota: stale (last success ${quotaStatus.sampleAge})`];
+  appendQuotaMetadata(lines, snapshot.planType, snapshot.activeLimit);
+  appendQuotaWindow(lines, "5h", snapshot.windows["5h"], now);
+  appendQuotaWindow(lines, "week", snapshot.windows.week, now);
+  appendAttemptLine(lines, snapshot.lastAttemptTimestamp ?? snapshot.lastAttempt, snapshot.probeSuccess, now);
+  return lines;
+}
+
+function formatUnavailableQuota(quotaStatus: Extract<QuotaStatus, { state: "unavailable" }>, now: Date): string[] {
+  const detail = quotaStatus.reason === "missing_file" ? "state file missing" : "no successful sample";
+  const lines = [`Codex quota: unavailable (${detail})`];
+  const snapshot = quotaStatus.snapshot;
+  if (snapshot) {
+    appendAttemptLine(lines, snapshot.lastAttemptTimestamp ?? snapshot.lastAttempt, snapshot.probeSuccess, now);
+  }
+  return lines;
+}
+
+function appendQuotaMetadata(lines: string[], planType: string | undefined, activeLimit: string | undefined): void {
+  const parts = [];
+  if (planType) {
+    parts.push(`plan ${planType}`);
+  }
+  if (activeLimit) {
+    parts.push(`active ${activeLimit}`);
+  }
+  if (parts.length > 0) {
+    lines.push(`  ${parts.join(", ")}`);
+  }
+}
+
+function appendQuotaWindow(
+  lines: string[],
+  name: QuotaWindowName,
+  window: QuotaWindowSnapshot,
+  now: Date,
+): void {
+  const resetEta = formatResetEta(window.resetTimestamp ?? window.resetAt, now);
+  const reset = resetEta ? `, resets in ${resetEta}` : "";
+  lines.push(
+    `  ${name}: ${formatPercent(window.usedPercent)} used, ${formatPercent(resolveRemainingPercent(window))} left${reset}`,
+  );
+}
+
+function appendAttemptLine(
+  lines: string[],
+  lastAttempt: string | number | undefined,
+  probeSuccess: boolean | undefined,
+  now: Date,
+): void {
+  const age = formatSampleAge(lastAttempt, now);
+  if (!age && probeSuccess === undefined) {
+    return;
+  }
+
+  const outcome = probeSuccess === undefined ? "unknown" : probeSuccess ? "ok" : "failed";
+  lines.push(`  Last attempt: ${age ?? "unknown"} (${outcome})`);
+}
+
+function resolveRemainingPercent(window: QuotaWindowSnapshot): number | undefined {
+  if (typeof window.remainingPercent === "number" && Number.isFinite(window.remainingPercent)) {
+    return window.remainingPercent;
+  }
+  if (typeof window.usedPercent === "number" && Number.isFinite(window.usedPercent)) {
+    return Math.max(0, 100 - window.usedPercent);
+  }
+  return undefined;
+}
+
+function formatPercent(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "unknown";
+  }
+
+  const rounded = Math.round(value * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+function formatProcessingDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}

--- a/bot/src/telegram-bot.ts
+++ b/bot/src/telegram-bot.ts
@@ -17,6 +17,8 @@ import type { MessageRecord } from "./message-content-index.js";
 import { logReaction } from "./reaction-log.js";
 import { EchoWatcher, ECHO_PREFIX } from "./echo-watcher.js";
 import { injectDirForChat, writeEchoInjectFile } from "./inject-file.js";
+import { readQuotaStatus } from "./quota-status.js";
+import { buildStatusReport } from "./status-report.js";
 
 
 // Re-export for backward compatibility (tests import from here)
@@ -763,7 +765,7 @@ export function createTelegramBot(
     await ctx.reply("Session cleaned. Fresh start.");
   });
 
-  // /status command — active sessions, memory, uptime, subprocess health
+  // /status command — compact local-only session and quota health.
   bot.command("status", async (ctx) => {
     const topicId = ctx.message?.message_thread_id;
     if (ctx.message) setThread(ctx.chat.id, ctx.message.message_id, topicId);
@@ -773,46 +775,14 @@ export function createTelegramBot(
       log.debug("telegram-bot", `Discarding stale /status for chat ${ctx.chat.id} (age: ${Math.round((Date.now() - ctx.message.date * 1000) / 1000)}s)`);
       return;
     }
-    const activeCount = sessionManager.getActiveCount();
-    const memUsage = process.memoryUsage();
-    const uptimeSeconds = Math.floor(process.uptime());
-    const hours = Math.floor(uptimeSeconds / 3600);
-    const minutes = Math.floor((uptimeSeconds % 3600) / 60);
-
-    const lines = [
-      `Active sessions: ${activeCount}/${config.sessionDefaults.maxConcurrentSessions}`,
-      `Memory: ${Math.round(memUsage.rss / 1024 / 1024)}MB RSS`,
-      `Uptime: ${hours}h ${minutes}m`,
-    ];
-
-    const health = sessionManager.getSessionHealth(sessionKey(ctx.chat.id, topicId));
-    if (health) {
-      const status = health.alive ? "alive" : "dead";
-      const pidStr = health.pid !== null ? String(health.pid) : "n/a";
-      const idleMins = Math.floor(health.idleMs / 60000);
-
-      lines.push(`This session: agent "${health.agentId}", PID ${pidStr} (${status})`);
-      lines.push(`  Session ID: ${health.sessionId}`);
-
-      if (health.processingMs !== null) {
-        const procSecs = Math.floor(health.processingMs / 1000);
-        lines.push(`  Processing: ${procSecs}s`);
-      } else {
-        lines.push(`  Idle: ${idleMins}m`);
-      }
-
-      if (health.lastSuccessAt !== null) {
-        const agoMs = Date.now() - health.lastSuccessAt;
-        const agoMins = Math.floor(agoMs / 60000);
-        lines.push(`  Last success: ${agoMins}m ago`);
-      } else {
-        lines.push(`  Last success: none`);
-      }
-
-      lines.push(`  Restarts: ${health.restartCount}`);
-    }
-
-    await ctx.reply(lines.join("\n"));
+    const key = sessionKey(ctx.chat.id, topicId);
+    await ctx.reply(buildStatusReport({
+      activeCount: sessionManager.getActiveCount(),
+      maxSessions: config.sessionDefaults.maxConcurrentSessions,
+      uptimeSeconds: Math.floor(process.uptime()),
+      sessionHealth: sessionManager.getSessionHealth(key),
+      quotaStatus: readQuotaStatus(),
+    }));
   });
 
   // Handle text messages

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -2,6 +2,8 @@
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
+export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
 export interface AgentConfig {
   id: string;
   workspaceCwd: string;
@@ -11,6 +13,7 @@ export interface AgentConfig {
   allowedTools?: string[];
   maxTurns?: number;
   effort?: "low" | "medium" | "high";
+  thinking?: PiThinkingLevel;
   /**
    * Which coding-agent backend dispatches this agent's sessions.
    * Optional; semantically defaults to "claude" (the existing `claude -p` path).

--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -23,6 +23,7 @@ agents:
     # model: opus[1m]
     # model: claude-haiku-4-5-20251001
     # provider: claude   # coding backend: "claude" (default, omit) or "pi" (Pi RPC + OpenAI Codex)
+    # thinking: xhigh    # optional for provider: pi; allowed: off, minimal, low, medium, high, xhigh
 
 bindings:
   - chatId: 123456789           # your Telegram user ID (get it from @userinfobot)

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ agents:
                         # "pi" routes the agent through the Pi coding agent; "claude" uses `claude -p`.
                         # A "pi" agent MUST set an explicit model (e.g. model: gpt-5.5) — it does
                         # not inherit defaultModel (which is Claude-oriented).
+                        # Optional for "pi": thinking: off|minimal|low|medium|high|xhigh.
 
   # Add more agents as needed:
   # coder:

--- a/docs/plans/completed/2026-06-05-codex-quota-status-pipeline.md
+++ b/docs/plans/completed/2026-06-05-codex-quota-status-pipeline.md
@@ -1,0 +1,219 @@
+# Plan: Codex quota sampler + compact /status
+
+## Goal
+
+Implement cached Codex quota visibility in Telegram/Discord `/status` without degrading live Pi sessions.
+
+Success criteria:
+- Live bot sessions keep Pi `transport: auto` / WebSocket; no forced SSE for user conversations.
+- A separate low-frequency sampler performs a tiny Codex SSE probe and exports cached quota data.
+- `/status` displays model, thinking/effort, processing/idle state, session id, active sessions, uptime, and Codex quota when available.
+- `/status` never calls Codex directly; it reads cached local state only.
+- If quota data is stale or sampler failed, `/status` says so honestly.
+- Existing Prometheus/node_exporter path can alert on high usage.
+
+Non-goals:
+- Do not add a separate `/quota` command in MVP.
+- Do not force SSE transport for normal Telegram/Discord Pi sessions.
+- Do not fetch or parse ChatGPT credentials directly; use Pi as the authenticated transport.
+- Do not implement quota sources for non-Codex providers yet; keep internal interfaces extensible.
+
+## Context
+
+Relevant files:
+- `bot/src/telegram-bot.ts` — current `/status` command.
+- `bot/src/discord-bot.ts` — duplicated `/status` command.
+- `bot/src/session-manager.ts` — `ActiveSession`, `SessionHealth`, spawn-time session metadata.
+- `bot/src/types.ts` — `AgentConfig` currently has `model`, Claude-only `effort`, no Pi `thinking` field.
+- `bot/src/pi-rpc-protocol.ts` — Pi spawn args and extension wrapper list.
+- `bot/.claude/extensions/` — Pi extension wrappers loaded into bot-spawned Pi sessions.
+- `bot/scripts/` — operational scripts; add sampler here.
+- `bot/src/__tests__/` — tests for config, Pi protocol, status commands, metrics.
+
+Evidence:
+- Pi `after_provider_response` gets HTTP response headers only on Codex SSE path.
+- Pi Codex default `transport` is `auto`, which tries WebSocket first.
+- WebSocket path does not call `options.onResponse`; SSE path does.
+- Forcing `transport: sse` on a live session can fail before headers with `Codex SSE response headers timed out after 10000ms` (`DEFAULT_SSE_HEADER_TIMEOUT_MS = 10_000`). This is a reliability regression for user conversations.
+- Observed useful headers under SSE:
+  - `x-codex-primary-used-percent`
+  - `x-codex-secondary-used-percent`
+  - `x-codex-primary-reset-at`
+  - `x-codex-secondary-reset-at`
+  - `x-codex-plan-type`
+  - `x-codex-active-limit`
+
+Existing desired `/status` content from user:
+- Keep `session id` — useful for terminal resume.
+- Keep `processing` / `idle` — used to detect stuck sessions.
+- Add model name.
+- Add thinking level / effort.
+- Remove normal-path noise where possible: RSS memory, PID, restart count when zero, last success when healthy.
+
+## Validation Commands
+
+```bash
+cd bot && npm test
+cd bot && npm run lint
+cd bot && npm run build
+cd bot && npm run validate-config
+
+# Sampler smoke test with temp outputs; must not touch production textfile dir.
+cd bot && CODEX_QUOTA_TEXTFILE_DIR=/tmp/codex-quota-test CODEX_QUOTA_STATE_FILE=/tmp/codex-quota-test/state.json npx tsx scripts/codex-quota-sampler.ts --dry-run
+```
+
+## Decisions
+
+1. **Normal sessions stay WebSocket/auto.**
+   - Value: do not set global/project `transport: "sse"` for bot workspaces.
+   - Reason: forcing SSE causes real 10s header-timeout failures before response start.
+
+2. **Quota collection is a separate sampler.**
+   - Value: a script runs a small isolated Pi SSE probe and writes cached state/metrics.
+   - Reason: quota observability must not affect interactive session reliability.
+
+3. **`/status` reads local cache, not Codex.**
+   - Value: command reads a JSON state file written by the sampler; Prometheus scrapes `.prom` files for alerting.
+   - Reason: status must be fast and must not consume quota or trigger network failures.
+
+4. **Prometheus metrics keep ADR-compatible names.**
+   - Value: export `codex_usage_5h_percent`, `codex_usage_weekly_percent`, reset timestamps, last success/attempt timestamps, and probe success.
+   - Reason: ADR-072 already names `codex_usage_5h_percent` / `codex_usage_weekly_percent` for `CodexUsageHigh`.
+
+5. **Provider extensibility lives in code structure, not metric over-generalization.**
+   - Value: implement `QuotaSnapshot` / `QuotaProvider` style internal types, but only Codex provider in MVP.
+   - Reason: avoids premature metric abstraction while keeping future providers straightforward.
+
+6. **Pi thinking uses a dedicated config field.**
+   - Value: add optional `AgentConfig.thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"` for Pi and pass `--thinking` on Pi spawn.
+   - Reason: current `effort` is Claude-only and only allows low/medium/high; Pi supports xhigh.
+
+## Tasks
+
+### Task 1: Add Codex quota cache/export extension [HIGH]
+
+**Goal:** Extract Codex quota headers on successful SSE probe and write cache + Prometheus metrics atomically.
+
+**Files:**
+- Create: `bot/.claude/extensions/codex-usage.ts`
+- Create/Modify tests under: `bot/src/__tests__/`
+
+- [x] Implement header parser for `x-codex-primary-used-percent`, `x-codex-secondary-used-percent`, reset timestamps, plan type, active limit.
+- [x] Write a JSON state file atomically; default path from `CODEX_QUOTA_STATE_FILE`, with a safe local default.
+- [x] Write Prometheus textfile atomically; textfile dir from `CODEX_QUOTA_TEXTFILE_DIR` or `NODE_EXPORTER_TEXTFILE_DIR`, defaulting to `/opt/homebrew/var/node_exporter/textfile` only when writable.
+- [x] Export ADR-compatible gauges: `codex_usage_5h_percent`, `codex_usage_weekly_percent`, `codex_usage_5h_reset_timestamp`, `codex_usage_weekly_reset_timestamp`, `codex_usage_last_success_timestamp`.
+- [x] Include info metric or labels for plan/active limit without high cardinality.
+- [x] Treat missing quota headers as no-op, not error.
+- [x] Treat malformed numeric headers as skipped fields, not process crash.
+- [x] Add unit tests for header parsing, malformed values, absent headers, and atomic file writes.
+- [x] Run `cd bot && npm test`.
+
+### Task 2: Add isolated Codex quota sampler script [HIGH]
+
+**Goal:** Run a tiny Pi SSE probe out-of-band and mark probe success/failure without breaking user sessions.
+
+**Files:**
+- Create: `bot/scripts/codex-quota-sampler.ts`
+- Modify tests under: `bot/src/__tests__/`
+
+- [x] Script creates or uses an isolated sampler cwd with project `.pi/settings.json` containing only `{ "transport": "sse" }`.
+- [x] Script invokes Pi with `--provider openai-codex`, configured model, `--thinking off`, `--no-context-files`, `--no-skills`, `--no-extensions`, explicit `--extension <codex-usage.ts>`, `--no-session`, and a minimal prompt.
+- [x] Script must never edit global `~/.pi/agent/settings.json` and must never set workspace `.pi/settings.json` for normal sessions.
+- [x] Add a bounded wall-clock timeout around the Pi child; on timeout/failure, kill child and continue failure recording.
+- [x] On every attempt, write `codex_usage_last_attempt_timestamp` and `codex_usage_probe_success` in a separate `.prom` file.
+- [x] On failure, preserve last successful usage values; do not delete or overwrite the success metrics/state with empty data.
+- [x] Add CLI flags/env for model, textfile dir, state file, sampler cwd, timeout, and dry-run.
+- [x] Add tests for command construction, success path, timeout/failure path, and preservation of prior successful state.
+- [x] Run `cd bot && npm test`.
+
+### Task 3: Add quota status reader/formatter [HIGH]
+
+**Goal:** Provide a small cached-data API used by `/status`.
+
+**Files:**
+- Create: `bot/src/quota-status.ts`
+- Create/Modify tests under: `bot/src/__tests__/`
+
+- [x] Define `QuotaSnapshot` with provider, windows (`5h`, `week`), used percent, remaining percent, reset timestamps, last success, last attempt, probe success, plan type.
+- [x] Read the sampler JSON state file from `CODEX_QUOTA_STATE_FILE` or default path.
+- [x] Compute freshness with default stale threshold, e.g. 30 minutes, overrideable by `CODEX_QUOTA_STALE_MS`.
+- [x] Format reset ETA and sample age compactly (`4h 52m`, `6d 23h`, `2m ago`).
+- [x] Return explicit states: `available`, `stale`, `unavailable`, `read_error`.
+- [x] Add tests for fresh data, stale data, missing file, malformed file, and reset ETA formatting.
+- [x] Run `cd bot && npm test`.
+
+### Task 4: Enrich session health with model and thinking/effort [HIGH]
+
+**Goal:** Make `/status` show spawn-time model and reasoning settings without probing Pi mid-turn.
+
+**Files:**
+- Modify: `bot/src/types.ts`
+- Modify: `bot/src/config.ts`
+- Modify: `bot/src/pi-rpc-protocol.ts`
+- Modify: `bot/src/session-manager.ts`
+- Modify tests under: `bot/src/__tests__/`
+
+- [x] Add `AgentConfig.thinking` with Pi levels: `off|minimal|low|medium|high|xhigh`.
+- [x] Validate `thinking` in config; keep existing Claude `effort` validation unchanged.
+- [x] Pass `--thinking <level>` from `buildPiSpawnArgs` when `agent.provider === "pi"` and `agent.thinking` is set.
+- [x] Store spawn-time `provider`, normalized model, `thinking`, and `effort` in `ActiveSession`.
+- [x] Include those fields in `SessionHealth` returned by `getSessionHealth`.
+- [x] Do not send `get_state` from `/status`; avoid stdout-reader races while a turn is processing.
+- [x] Add tests for config validation, Pi spawn args with `--thinking xhigh`, and health metadata.
+- [x] Run `cd bot && npm test`.
+
+### Task 5: Refactor and compact `/status` rendering [HIGH]
+
+**Goal:** Use one shared status renderer for Telegram and Discord and include quota block.
+
+**Files:**
+- Create: `bot/src/status-report.ts`
+- Modify: `bot/src/telegram-bot.ts`
+- Modify: `bot/src/discord-bot.ts`
+- Create/Modify tests under: `bot/src/__tests__/`
+
+- [x] Implement shared `buildStatusReport(...)` that receives active count, max sessions, uptime, optional session health, and optional quota status.
+- [x] Normal output includes agent/provider, model, thinking or effort, state (`processing` or `idle`), session id, sessions count, uptime.
+- [x] Normal output excludes memory RSS, PID, last success, and restarts when healthy.
+- [x] Diagnostic output includes PID when dead, restarts when `>0`, and last success when missing/stale.
+- [x] Add Codex quota block when quota state exists or when current session is Pi/Codex.
+- [x] Fresh quota format: used + left percent for 5h/week, reset ETA, sample age.
+- [x] Stale/unavailable quota format: clearly state stale/unavailable and last attempt/success if known.
+- [x] Wire Telegram `/status` to the shared renderer.
+- [x] Wire Discord `/status` to the same shared renderer.
+- [x] Add renderer tests for idle, processing, dead session, restarts, fresh quota, stale quota, and no quota data.
+- [x] Run `cd bot && npm test`.
+
+### Task 6: Add operational docs and private rollout notes [MED]
+
+**Goal:** Document how to run the sampler and how to wire it into existing monitoring without committing private config.
+
+**Files:**
+- Modify public docs as appropriate (`README.md` only if this is user-facing and safe; otherwise a bot docs file if available)
+- Do not modify private `crons.local.yaml` in the public PR.
+
+- [x] Document sampler env vars and example launchd/cron invocation.
+- [x] Document recommended sample interval (15-30 minutes) and stale threshold.
+- [x] Document that normal sessions must stay on `transport: auto`.
+- [x] Document Prometheus alert expression: `codex_usage_5h_percent > 85 OR codex_usage_weekly_percent > 90`.
+- [x] Add a post-merge note: private workspace needs a script cron/launchd entry for `codex-quota-sampler.ts` and optional monitoring rule update.
+- [x] Run `cd bot && npm run lint`.
+
+### Task 7: Verify acceptance criteria [HIGH]
+
+- [x] Verify normal Pi spawn args do not include any global/session-wide forced SSE setting.
+- [x] Verify sampler uses isolated project settings for `transport: sse` only in the sampler cwd.
+- [x] Verify `/status` does not call Pi/Codex/network; it only reads local cache.
+- [x] Verify stale/missing quota cache renders honestly.
+- [x] Verify model + thinking/effort appear in `/status`.
+- [x] Verify `session id` and `processing/idle` remain visible.
+- [x] Run `cd bot && npm test`.
+- [x] Run `cd bot && npm run lint`.
+- [x] Run `cd bot && npm run build`.
+- [x] Run `cd bot && npm run validate-config`.
+
+### Task 8: Update documentation [HIGH]
+
+- [x] Update relevant docs with the sampler/status behavior.
+- [x] Include the SSE timeout rationale so future maintainers do not force SSE on live sessions.
+- [x] Include rollback: disable sampler cron and/or unset quota status env vars; live sessions are unaffected.


### PR DESCRIPTION
## Summary
- add Codex quota sampler/cache and `/status` quota reporting
- add Pi Codex usage extension/exporter and quota Prometheus metrics
- document configuration, textfile outputs, and operational behavior

## Validation
- `npm test` passed in ralphex final validation
- `npm run lint` passed in ralphex final validation
- `npm run build` passed in ralphex final validation
- local gitleaks scan on the PR branch: no leaks found

Note: `npm run validate-config` needs local Keychain token access; ralphex verified the structural path with a dummy `security` shim.
