### PR TITLE
feat: add Pi cron runner engine

### DIFF
--- a/.claude/rules/platform/runtime-context.md
+++ b/.claude/rules/platform/runtime-context.md
@@ -1,21 +1,22 @@
 # Runtime Context
 
-You are running as a **Claude Code CLI subprocess**, spawned by the grammY Telegram bot.
+You are running as a **coding-agent backend** spawned by the Telegram/Discord bot. Interactive sessions may use Claude Code CLI or Pi RPC, depending on the bound agent config. Scheduled LLM crons may use Claude print mode or Pi print mode, depending on the cron `engine`.
 
 ## How you were started
 
-- The Telegram bot spawned your process via `claude -p` with stream-json protocol
+- The Telegram/Discord bot spawned your process through the configured backend (`claude -p` stream-json for Claude sessions, Pi RPC for Pi sessions)
 - Messages arrive from Telegram, routed through bot bindings to your session
-- Each Telegram chat gets its own Claude Code subprocess with separate conversation context
-- The bot runs under a Max subscription (no API keys, fixed monthly cost) — applies to all agents spawned by this bot
+- Each chat gets its own backend process with separate conversation context
+- Claude-backed sessions run under a Max subscription (no API keys, fixed monthly cost). Pi-backed sessions use Pi's own auth in `~/.pi/agent/auth.json`.
 
 ## What this means
 
-- You are a Claude Code CLI process. You have full Claude Code capabilities (Read, Edit, Write, Bash, Agent, etc.)
+- Your exact tools depend on the backend. Claude sessions have Claude Code capabilities (Read, Edit, Write, Bash, Agent, etc.). Pi RPC sessions load the bot's Pi extensions. Pi print-mode crons load only the A1 guard extension and do not have A2/A3/browser/MCP/subagent parity.
 - You are NOT running in a terminal. Messages come from Telegram users, not a keyboard
 - Your responses are sent back to Telegram via the bot's stream relay
 - Your workspace is your current working directory. Other agents live in sibling directories alongside it; check the bot's `config.yaml` (in the main workspace) for the full agent roster and which Telegram chats route to which agent
 - Bot tools are available: `bot/scripts/deliver.sh` for Telegram messaging, `launchctl` for cron management
+- Pi print-mode crons do not have automatic memory recall. Use `MEMORY.md` as the index and read specific memory files on demand.
 
 ## Session transcripts
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Both platforms share one Session Manager and use the same stream-relay logic via
 
 **Context injection:** Each message includes metadata — current time, chat type (DM/group/topic), topic name, sender username, and emoji reactions. The agent knows where it is, when it is, and who it's talking to. Reactions are delivered as messages so the agent can respond to a thumbs-up or a ❤️ without the user typing anything.
 
-**Cron jobs** run separately via launchd plists. Each plist calls `run-cron.sh <task-name>`, which invokes `cron-runner.ts` to spawn a one-shot `claude -p` session with the cron's prompt.
+**Cron jobs** run separately via launchd plists. Each plist calls `run-cron.sh <task-name>`, which invokes `cron-runner.ts` to spawn a one-shot coding-agent session with the cron's prompt. LLM crons use Claude by default and can opt into Pi print mode per cron.
 
 **Config:** `config.yaml` defines agents (workspace + model) and bindings (chatId/channelId -> agentId). User-specific overrides live in `config.local.yaml` (gitignored, deep-merged over `config.yaml`). At least one platform (Telegram or Discord) must be configured. Tokens are read from macOS Keychain at runtime.
 
@@ -75,6 +75,7 @@ Both platforms share one Session Manager and use the same stream-relay logic via
 - Node.js 20+ and npm
 - `jq` — required by hook scripts (`brew install jq`)
 - [Claude Code CLI](https://claude.ai/code) with Max subscription
+- Optional for `engine: pi` crons or Pi-backed agents: the `pi` binary on launchd `PATH` and Pi auth initialized for the launchd user with `pi /login`
 - A Telegram bot token from [@BotFather](https://t.me/BotFather) (or Discord bot token)
 
 ### Steps
@@ -126,7 +127,7 @@ claude setup-token
 security add-generic-password -s 'claude-code-oauth-token' -a 'minime' -w 'YOUR_OAUTH_TOKEN'
 ```
 
-The bot reads this token at startup via `start-bot.sh` and `run-cron.sh` — it does not use `claude auth login`.
+The bot reads this token at startup via `start-bot.sh` and Claude-engine crons read it via `run-cron.sh` when available — it does not use `claude auth login`. Pi-engine crons can run without `CLAUDE_CODE_OAUTH_TOKEN`; Pi uses its own `~/.pi/agent/auth.json`.
 
 **5. Create launchd service**
 
@@ -208,14 +209,43 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.minime.telegram-bot.p
    |-------|------|----------|-------------|
    | `name` | string | yes | Unique identifier for the cron job |
    | `schedule` | string | yes | 5-field cron expression, local timezone |
-   | `type` | `"llm"` or `"script"` | no | `"llm"` (default) runs `claude -p`; `"script"` runs a shell command |
-   | `prompt` | string | for llm | Prompt sent to Claude |
+   | `type` | `"llm"` or `"script"` | no | `"llm"` (default) runs a one-shot coding-agent backend; `"script"` runs a shell command |
+   | `engine` | `"claude"` or `"pi"` | no | LLM backend for one-shot crons. Omit for `"claude"`; set `"pi"` to use Pi print mode. Ignored for script crons |
+   | `prompt` | string | for llm | Prompt sent to the selected LLM cron engine |
    | `command` | string | for script | Shell command to execute |
    | `agentId` | string | yes | Must match an agent in `config.yaml` or `config.local.yaml` |
    | `deliveryChatId` | number | no | Telegram chat ID for delivery (falls back to config default) |
    | `deliveryThreadId` | number | no | Telegram forum topic ID for delivery |
-   | `timeout` | number | no | Per-cron timeout in ms (default: 300000 = 5 min) |
+   | `timeout` | number | no | Per-cron timeout in ms (default: 900000 = 15 min) |
    | `enabled` | boolean | no | Set `false` to disable without deleting (default: `true`) |
+
+   Minimal Pi LLM example:
+   ```yaml
+   crons:
+     - name: read-only-example
+       schedule: "0 9 * * *"
+       type: llm
+       engine: pi
+       agentId: main
+       prompt: "Summarize read-only status and include NO_REPLY if there is nothing notable."
+   ```
+
+   Pi cron rollout guidance:
+
+   - `engine: pi` is opt-in per LLM cron. It is independent of the agent's `provider`, `model`, `fallbackModel`, `maxTurns`, and `allowedTools`: Pi crons always spawn `pi -p` with `--no-session --no-extensions`, the fixed model `openai-codex/gpt-5.5`, the agent `systemPrompt`/workspace context, and only the explicit A1 guard extension. Agent `effort` maps to `--thinking`; unsupported or absent effort defaults to `medium`.
+   - `engine: pi` requires the `pi` binary on the launchd cron `PATH` and Pi auth at `~/.pi/agent/auth.json` for the launchd user. Run `pi /login` as that user before enabling Pi crons.
+   - Keep browser/MCP/tool-dependent crons on Claude until Pi has equivalent browser/MCP/tool coverage for the cron path.
+   - Keep dangerous state-mutating crons on Claude until Pi has had enough soak coverage for that class of work.
+   - The safest first Pi subset is selected by criteria, not by private cron names: read-only, non-browser, non-secret, non-mutating, low blast-radius, and either visibly delivered or covered by cron-health metrics.
+   - Per-cron rollback: remove `engine: pi` or set `engine: claude`, then regenerate and reload that cron's plist.
+   - Global rollback: set `CRON_PI_DISABLED=1` in the launchd cron environment to force all LLM crons back to Claude. Put it in generated cron plists or export it from `bot/scripts/run-cron.sh`, then unload/reload the affected cron plists because launchd caches plist environment variables.
+   - Production flips are post-merge operator work after restart and observation; they are not part of the public PR.
+
+   Cron result handling:
+
+   - Empty stdout with empty stderr is a successful no-delivery run.
+   - `NO_REPLY` is a successful no-delivery LLM run.
+   - Pi stderr-only success, non-zero exit, signal exit, spawn timeout, missing A1 guard, or disabled A1 guard are failures and trigger the existing `⚠️ Cron FAIL` notification plus the failure metric.
 
 2. Generate launchd plists:
    ```bash
@@ -362,11 +392,12 @@ Every `pi --mode rpc` spawn loads three first-party extensions so Pi sessions re
 security add-generic-password -s 'tavily-api-key' -a 'minime' -w 'YOUR_TAVILY_KEY'
 ```
 
-**Kill-switch:** set `PI_EXTENSIONS_DISABLED=1` in the bot's environment to spawn Pi with **no** extensions — a bare, claude-parity command. This is the fast rollback path (no code change, no merge). With extensions enabled, a configured wrapper missing on disk makes the spawn **fail loudly** rather than silently dropping the guard (A1 is the write guard — a silent skip would spawn an unguarded session).
+**Kill-switch:** set `PI_EXTENSIONS_DISABLED=1` in the bot's environment to spawn Pi RPC chat sessions with **no** extensions — a bare, claude-parity command. This is the fast rollback path for Pi RPC sessions (no code change, no merge). With extensions enabled, a configured wrapper missing on disk makes the spawn **fail loudly** rather than silently dropping the guard (A1 is the write guard — a silent skip would spawn an unguarded session). Pi crons are stricter: `engine: pi` crons require A1 and fail closed if `PI_EXTENSIONS_DISABLED=1`; use `CRON_PI_DISABLED=1` or set the cron back to `engine: claude` for cron rollback.
 
 **Rollback:**
 
-- **Fast (no deploy):** set `PI_EXTENSIONS_DISABLED=1` in the bot's launchd environment, then `bot/scripts/restart-bot.sh --plist` (env-var changes are plist-level — see [Start / Stop](#start--stop)). Pi spawns drop all three extensions immediately.
+- **Fast RPC rollback (no deploy):** set `PI_EXTENSIONS_DISABLED=1` in the bot's launchd environment, then `bot/scripts/restart-bot.sh --plist` (env-var changes are plist-level — see [Start / Stop](#start--stop)). Pi RPC chat spawns drop all three extensions immediately.
+- **Fast cron rollback:** set `CRON_PI_DISABLED=1` in the cron launchd environment, or change individual crons from `engine: pi` to `engine: claude` and reload the cron plists.
 - **Code:** `git revert <merge-commit>` in this repo → `git fetch upstream && git merge upstream/main` in the workspace → `bot/scripts/restart-bot.sh`.
 
 ### Logging
@@ -387,6 +418,11 @@ metricsPort: 9090
 ```
 
 See [bot/src/metrics.ts](bot/src/metrics.ts) for the full list of exported metrics.
+
+Cron runs also write best-effort Prometheus textfile metrics for node_exporter. These do not appear on the bot's `metricsPort` endpoint. Configure node_exporter with `--collector.textfile.directory=/opt/homebrew/var/node_exporter/textfile`, or override the directory with `CRON_HEALTH_TEXTFILE_DIR` for tests or alternate installs. Ensure the launchd cron user can create and write the directory. Each cron gets collision-resistant textfiles with the raw cron name escaped as the `cron` label:
+
+- `minime_cron_last_success_timestamp{cron="<name>"}` is updated only after successful runs and remains present after later failures.
+- `minime_cron_last_exit_code{cron="<name>"}` is updated on every run.
 
 The Pi RPC provider (see [Provider backends](#provider-backends)) registers its own metrics: `bot_pi_turn_duration_seconds` (histogram, label `agent_id`, same buckets as the Claude turn histogram for direct comparison), the retry counters `bot_pi_retry_total`, `bot_pi_429_total`, `bot_pi_overload_total`, and `bot_pi_retry_unknown_total` (every retry increments `bot_pi_retry_total` plus exactly one signal-specific counter), and `bot_pi_session_resume_discarded_total` (label `agent_id`, incremented once per graceful resume-recovery — a stored Pi session id Pi could not find, discarded for one fresh start). They read zero until an agent runs with `provider: pi`.
 

--- a/bot/scripts/generate-plists.ts
+++ b/bot/scripts/generate-plists.ts
@@ -8,6 +8,7 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { loadMergedCrons } from "../src/cron-runner.js";
+import { validateCronForPlist, type CronPlistDef } from "../src/cron-plist.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BOT_DIR = resolve(__dirname, "..");
@@ -19,17 +20,7 @@ const RUN_CRON_SCRIPT = resolve(BOT_DIR, "scripts", "run-cron.sh");
 
 const dryRun = process.argv.includes("--dry-run");
 
-interface CronDef {
-  name: string;
-  schedule: string;
-  type?: "llm" | "script";
-  prompt?: string;
-  command?: string;
-  agentId: string;
-  deliveryChatId?: number;
-  timeout?: number;
-  enabled?: boolean;
-}
+type CronDef = CronPlistDef;
 
 // Parse cron expression to launchd StartCalendarInterval entries
 // launchd doesn't support */N — we expand to individual entries
@@ -241,19 +232,9 @@ function main(): void {
       console.log(`[SKIP] ${cron.name} (enabled: false)`);
       continue;
     }
-    const cronType = cron.type ?? "llm";
-    if (cronType !== "llm" && cronType !== "script") {
-      console.error(`ERROR: ${cron.name} has invalid type "${cron.type}" (must be "llm" or "script")`);
-      errors++;
-      continue;
-    }
-    if (cronType === "script" && (!cron.command || !cron.command.trim())) {
-      console.error(`ERROR: ${cron.name} is type "script" but missing required "command" field`);
-      errors++;
-      continue;
-    }
-    if (cronType === "llm" && (!cron.prompt || !cron.prompt.trim())) {
-      console.error(`ERROR: ${cron.name} is type "llm" but missing required "prompt" field`);
+    const validationError = validateCronForPlist(cron);
+    if (validationError) {
+      console.error(`ERROR: ${validationError}`);
       errors++;
       continue;
     }
@@ -291,4 +272,9 @@ function main(): void {
   }
 }
 
-main();
+const isMain =
+  process.argv[1]?.endsWith("generate-plists.ts") ||
+  process.argv[1]?.endsWith("generate-plists.js");
+if (isMain) {
+  main();
+}

--- a/bot/scripts/run-cron.sh
+++ b/bot/scripts/run-cron.sh
@@ -7,13 +7,19 @@ set -euo pipefail
 
 # Ensure HOME and PATH are set (launchd context may not have them)
 export HOME="${HOME:-$(dscl . -read /Users/$(whoami) NFSHomeDirectory | awk '{print $2}')}"
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+PATH_PREFIX="${MINIME_PATH_PREFIX:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
+export PATH="${PATH_PREFIX}:${PATH:-}"
 
 # Claude Code subprocess must NOT inherit CLAUDECODE
 unset CLAUDECODE
 
-# Read OAuth token from Keychain for Claude CLI subprocess
-export CLAUDE_CODE_OAUTH_TOKEN=$(security find-generic-password -s claude-code-oauth-token -w)
+# Read OAuth token from Keychain for Claude CLI subprocess when available. This
+# must be best-effort so Pi-engine crons can run without a Claude credential.
+if CLAUDE_CODE_OAUTH_TOKEN="$(security find-generic-password -s claude-code-oauth-token -w 2>/dev/null)"; then
+  export CLAUDE_CODE_OAUTH_TOKEN
+else
+  unset CLAUDE_CODE_OAUTH_TOKEN
+fi
 unset ANTHROPIC_API_KEY
 
 # Claude Code subprocess environment

--- a/bot/scripts/run-cron.sh
+++ b/bot/scripts/run-cron.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Ensure HOME and PATH are set (launchd context may not have them)
 export HOME="${HOME:-$(dscl . -read /Users/$(whoami) NFSHomeDirectory | awk '{print $2}')}"
 PATH_PREFIX="${MINIME_PATH_PREFIX:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
-export PATH="${PATH_PREFIX}:${PATH:-}"
+export PATH="${PATH_PREFIX}${PATH:+:${PATH}}"
 
 # Claude Code subprocess must NOT inherit CLAUDECODE
 unset CLAUDECODE

--- a/bot/src/__tests__/context-assembler.test.ts
+++ b/bot/src/__tests__/context-assembler.test.ts
@@ -342,6 +342,16 @@ describe("writeTempArtifact", () => {
     assert.strictEqual(readFileSync(path, "utf8"), "BUNDLE_CONTENT");
     assert.throws(() => statSync(`${path}.tmp.${process.pid}`), "staging file is renamed away");
   });
+
+  it("keeps unsafe agent IDs inside .tmp artifact paths", () => {
+    const ws = makeWorkspace({ claudeMd: "# x" });
+    const path = writeTempArtifact(ws, "../outside/agent", "bundle", "SAFE_CONTENT");
+
+    assert.ok(path.startsWith(join(ws, ".tmp") + "/"), path);
+    assert.match(path, /pi-context-outside_agent-[a-f0-9]{12}\.bundle\.md$/);
+    assert.strictEqual(readFileSync(path, "utf8"), "SAFE_CONTENT");
+    assert.throws(() => statSync(join(ws, "outside", "agent.bundle.md")));
+  });
 });
 
 describe("assemblePiContext", () => {

--- a/bot/src/__tests__/cron-fields.test.ts
+++ b/bot/src/__tests__/cron-fields.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validateCronForPlist, type CronPlistDef } from "../cron-plist.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
@@ -16,6 +17,7 @@ describe("cron field documentation", () => {
 
   const cronFields = [
     "type",
+    "engine",
     "timeout",
     "deliveryThreadId",
     "enabled",
@@ -51,6 +53,56 @@ describe("cron field documentation", () => {
       example.includes("enabled"),
       "crons.yaml does not demonstrate enabled field"
     );
+  });
+
+  it("crons.yaml documents engine and the 15-minute timeout default", () => {
+    const example = readRepoFile("crons.yaml");
+    assert.ok(example.includes("engine"), "crons.yaml does not document engine");
+    assert.ok(example.includes("900000 = 15 min"), "crons.yaml does not document the 15-minute cron timeout default");
+  });
+
+  it("README documents Pi engine rollback and cron health metrics", () => {
+    assert.ok(readme.includes("engine: pi"), "README.md does not document engine: pi");
+    assert.ok(readme.includes("CRON_PI_DISABLED=1"), "README.md does not document CRON_PI_DISABLED=1");
+    assert.ok(readme.includes("CRON_HEALTH_TEXTFILE_DIR"), "README.md does not document CRON_HEALTH_TEXTFILE_DIR");
+    assert.ok(readme.includes("minime_cron_last_success_timestamp"), "README.md does not document cron success metric");
+    assert.ok(readme.includes("900000 = 15 min"), "README.md does not document the 15-minute cron timeout default");
+  });
+
+  it("crons.local.yaml.example shows the engine override", () => {
+    const example = readRepoFile("crons.local.yaml.example");
+    assert.ok(example.includes("engine: pi"), "crons.local.yaml.example does not show engine: pi");
+  });
+
+  it("plist generator validates LLM engine values", () => {
+    const validPiCron: CronPlistDef = {
+      name: "valid-pi",
+      schedule: "0 * * * *",
+      type: "llm",
+      engine: "pi",
+      prompt: "Summarize status",
+      agentId: "main",
+    };
+    const invalidPiCron: CronPlistDef = {
+      ...validPiCron,
+      name: "invalid-pi",
+      engine: "bad" as unknown as CronPlistDef["engine"],
+    };
+    const scriptCron: CronPlistDef = {
+      name: "script-bad-engine",
+      schedule: "0 * * * *",
+      type: "script",
+      engine: "bad" as unknown as CronPlistDef["engine"],
+      command: "echo ok",
+      agentId: "main",
+    };
+
+    assert.strictEqual(validateCronForPlist(validPiCron), undefined);
+    assert.match(
+      validateCronForPlist(invalidPiCron) ?? "",
+      /invalid-pi has invalid engine "bad"/,
+    );
+    assert.strictEqual(validateCronForPlist(scriptCron), undefined);
   });
 
 });

--- a/bot/src/__tests__/cron-runner-pi.test.ts
+++ b/bot/src/__tests__/cron-runner-pi.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import type {
+  SpawnSyncOptionsWithStringEncoding,
+  SpawnSyncReturns,
+} from "node:child_process";
+import { runPi, type PiRunDeps } from "../cron-runner.js";
+import { assemblePiContext } from "../pi-context-assembler.js";
+import {
+  buildPiSpawnEnv,
+  PI_EXTENSIONS_DISABLED_ENV,
+  PI_SUBAGENT_CHILD_WRAPPER_RELPATHS,
+} from "../pi-rpc-protocol.js";
+import type { AgentConfig, CronJob } from "../types.js";
+
+interface SpawnCapture {
+  command: string;
+  args: string[];
+  options: SpawnSyncOptionsWithStringEncoding;
+}
+
+const fixtures: string[] = [];
+const GUARD_EXTENSION_ARGS = ["--extension", "/fake/guardian-protect-files.ts"];
+
+after(() => {
+  for (const dir of fixtures) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspace(): string {
+  const ws = mkdtempSync(join(tmpdir(), "cron-runner-pi-"));
+  fixtures.push(ws);
+  return ws;
+}
+
+function makeCron(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    name: "pi-cron-test",
+    schedule: "0 * * * *",
+    type: "llm",
+    prompt: "Summarize the workspace",
+    agentId: "main",
+    deliveryChatId: 111111111,
+    engine: "pi",
+    ...overrides,
+  };
+}
+
+function makeAgent(workspaceCwd: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: "main",
+    workspaceCwd,
+    provider: "pi",
+    model: "openai-codex/gpt-5.5",
+    ...overrides,
+  };
+}
+
+function spawnResult(overrides: Partial<SpawnSyncReturns<string>> = {}): SpawnSyncReturns<string> {
+  return {
+    pid: 12345,
+    output: [null, " pi output\n", ""],
+    stdout: " pi output\n",
+    stderr: "",
+    status: 0,
+    signal: null,
+    ...overrides,
+  } as SpawnSyncReturns<string>;
+}
+
+function capturingSpawn(
+  captures: SpawnCapture[],
+  result: SpawnSyncReturns<string> = spawnResult(),
+): PiRunDeps["spawnSync"] {
+  return (command, args, options) => {
+    captures.push({ command, args: [...args], options });
+    return result;
+  };
+}
+
+function makeDeps(
+  captures: SpawnCapture[],
+  overrides: Partial<PiRunDeps> = {},
+): PiRunDeps {
+  return {
+    spawnSync: capturingSpawn(captures),
+    buildAgentConfig: (_cron, cwd) => makeAgent(cwd),
+    buildEnv: buildPiSpawnEnv,
+    assembleContext: () => null,
+    resolveExtensionArgs: () => [...GUARD_EXTENSION_ARGS],
+    ...overrides,
+  };
+}
+
+function flagValue(args: string[], flag: string): string {
+  const idx = args.indexOf(flag);
+  assert.notStrictEqual(idx, -1, `missing ${flag}`);
+  return args[idx + 1];
+}
+
+function flagValues(args: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let idx = args.indexOf(flag); idx !== -1; idx = args.indexOf(flag, idx + 2)) {
+    values.push(args[idx + 1]);
+  }
+  return values;
+}
+
+function assertCronSystemInstruction(value: string): void {
+  assert.match(value, /^Today is \d{4}-\d{2}-\d{2}\. Respond concisely\.$/);
+}
+
+describe("cron-runner runPi", () => {
+  it("spawns Pi in print one-shot mode with the required argv and spawn options", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    let relpathsSeen: readonly string[] | undefined;
+    const deps = makeDeps(captures, {
+      buildAgentConfig: (_cron, cwd) => makeAgent(cwd, { effort: "high" }),
+      resolveExtensionArgs: (options) => {
+        relpathsSeen = options?.relpaths;
+        return ["--extension", "/fake/guardian-protect-files.ts"];
+      },
+    });
+
+    const output = runPi(makeCron({ timeout: 1234 }), ws, deps);
+
+    assert.strictEqual(output, "pi output");
+    assert.strictEqual(captures.length, 1);
+    const capture = captures[0];
+    assert.strictEqual(capture.command, "pi");
+    assert.deepStrictEqual(capture.args.slice(0, 8), [
+      "-p",
+      "Summarize the workspace",
+      "--no-session",
+      "--no-extensions",
+      "--model",
+      "openai-codex/gpt-5.5",
+      "--thinking",
+      "high",
+    ]);
+    assertCronSystemInstruction(flagValue(capture.args, "--append-system-prompt"));
+    assert.deepStrictEqual(capture.args.slice(-2), [
+      "--extension",
+      "/fake/guardian-protect-files.ts",
+    ]);
+    assert.strictEqual(capture.options.input, undefined);
+    assert.deepStrictEqual([...(relpathsSeen ?? [])], [...PI_SUBAGENT_CHILD_WRAPPER_RELPATHS]);
+    assert.strictEqual(capture.options.cwd, ws);
+    assert.strictEqual(capture.options.timeout, 1234);
+    assert.strictEqual(capture.options.encoding, "utf8");
+    assert.strictEqual(capture.options.maxBuffer, 10 * 1024 * 1024);
+
+    for (const forbidden of [
+      "--mode",
+      "--output-format",
+      "--fallback-model",
+      "--max-turns",
+      "--dangerously-skip-permissions",
+      "--add-dir",
+      "--session",
+    ]) {
+      assert.ok(!capture.args.includes(forbidden), `forbidden Pi cron flag present: ${forbidden}`);
+    }
+  });
+
+  it("passes option-like cron prompts as safe positional argv", () => {
+    for (const prompt of [
+      "- start with a single dash",
+      "--model malicious-model",
+      "@prompt-file.md should be literal text",
+    ]) {
+      const ws = makeWorkspace();
+      const captures: SpawnCapture[] = [];
+      const deps = makeDeps(captures);
+
+      runPi(makeCron({ prompt }), ws, deps);
+
+      assert.strictEqual(captures[0].options.input, undefined);
+      assert.strictEqual(captures[0].args[0], "-p");
+      assert.strictEqual(captures[0].args[1], ` ${prompt}`);
+      assert.strictEqual(captures[0].args[2], "--no-session");
+    }
+  });
+
+  it("defaults --thinking to medium when effort is absent or unsupported", () => {
+    for (const effort of [undefined, "xhigh" as unknown as AgentConfig["effort"]]) {
+      const ws = makeWorkspace();
+      const captures: SpawnCapture[] = [];
+      const deps = makeDeps(captures, {
+        buildAgentConfig: (_cron, cwd) => makeAgent(cwd, { effort }),
+      });
+
+      runPi(makeCron(), ws, deps);
+
+      assert.strictEqual(flagValue(captures[0].args, "--thinking"), "medium");
+    }
+  });
+
+  it("passes context artifact args before A1 extension args", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    const deps = makeDeps(captures, {
+      assembleContext: () => ({
+        systemPromptPath: "/tmp/pi-persona.md",
+        appendSystemPromptPath: "/tmp/pi-bundle.md",
+      }),
+      resolveExtensionArgs: () => [...GUARD_EXTENSION_ARGS],
+    });
+
+    runPi(makeCron(), ws, deps);
+
+    const args = captures[0].args;
+    assert.strictEqual(flagValue(args, "--system-prompt"), "/tmp/pi-persona.md");
+    const appendPrompts = flagValues(args, "--append-system-prompt");
+    assert.strictEqual(appendPrompts[0], "/tmp/pi-bundle.md");
+    assertCronSystemInstruction(appendPrompts[1]);
+    assert.ok(args.includes("--no-context-files"));
+
+    const thinkingIdx = args.indexOf("--thinking");
+    const systemIdx = args.indexOf("--system-prompt");
+    const appendIdx = args.indexOf("--append-system-prompt");
+    const noContextIdx = args.indexOf("--no-context-files");
+    const cronInstructionIdx = args.indexOf("--append-system-prompt", appendIdx + 2);
+    const extensionIdx = args.indexOf("--extension");
+    assert.ok(thinkingIdx < systemIdx);
+    assert.ok(systemIdx < appendIdx);
+    assert.ok(appendIdx < noContextIdx);
+    assert.ok(noContextIdx < cronInstructionIdx);
+    assert.ok(cronInstructionIdx < extensionIdx);
+  });
+
+  it("passes pre-resolved cron agent data into the Pi agent builder", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    const agentData = {
+      id: "main",
+      workspaceCwd: ws,
+      systemPrompt: "PERSONA_TOKEN",
+      effort: "low" as const,
+    };
+    let seenAgentData: typeof agentData | undefined;
+    const deps = makeDeps(captures, {
+      buildAgentConfig: (_cron, cwd, data) => {
+        seenAgentData = data as typeof agentData;
+        return makeAgent(cwd, { systemPrompt: data?.systemPrompt, effort: data?.effort });
+      },
+    });
+
+    runPi(makeCron(), ws, deps, agentData);
+
+    assert.deepStrictEqual(seenAgentData, agentData);
+    assert.strictEqual(flagValue(captures[0].args, "--thinking"), "low");
+  });
+
+  it("uses the real context assembler output when the default context dependency is in place", () => {
+    const ws = makeWorkspace();
+    mkdirSync(join(ws, ".claude", "rules", "platform"), { recursive: true });
+    writeFileSync(join(ws, "CLAUDE.md"), "# Cron Agent\n\nBODY_TOKEN", "utf8");
+    writeFileSync(join(ws, ".claude", "rules", "platform", "cron.md"), "RULE_TOKEN", "utf8");
+    const captures: SpawnCapture[] = [];
+    const deps = makeDeps(captures, {
+      buildAgentConfig: (_cron, cwd) => makeAgent(cwd, { systemPrompt: "PERSONA_TOKEN" }),
+      assembleContext: assemblePiContext,
+      resolveExtensionArgs: () => [...GUARD_EXTENSION_ARGS],
+    });
+
+    runPi(makeCron(), ws, deps);
+
+    const args = captures[0].args;
+    const personaPath = flagValue(args, "--system-prompt");
+    const bundlePath = flagValue(args, "--append-system-prompt");
+    assert.ok(personaPath.endsWith(join(".tmp", "pi-context-main.persona.md")));
+    assert.ok(bundlePath.endsWith(join(".tmp", "pi-context-main.bundle.md")));
+    assert.ok(args.includes("--no-context-files"));
+  });
+
+  it("uses a scrubbed Pi env and sets HOME when the parent environment lacks it", () => {
+    const oldHome = process.env.HOME;
+    const oldClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    const oldAnthropicKey = process.env.ANTHROPIC_API_KEY;
+    const oldClaudeCode = process.env.CLAUDECODE;
+    const openAiKeyEnv = ["OPENAI", "API", "KEY"].join("_");
+    const piSessionDirEnv = ["PI", "CODING", "AGENT", "SESSION", "DIR"].join("_");
+    const telegramTokenEnv = ["TELEGRAM", "BOT", "TOKEN"].join("_");
+    const tavilyKeyEnv = ["TAVILY", "API", "KEY"].join("_");
+    const sessionSecretEnv = ["MINIME", "SESSION", "SECRET"].join("_");
+    const githubTokenEnv = ["GITHUB", "TOKEN"].join("_");
+    const awsSecretEnv = ["AWS", "SECRET", "ACCESS", "KEY"].join("_");
+    const oldOpenAiKey = process.env[openAiKeyEnv];
+    const oldPiSessionDir = process.env[piSessionDirEnv];
+    const oldTelegramToken = process.env[telegramTokenEnv];
+    const oldTavilyKey = process.env[tavilyKeyEnv];
+    const oldSessionSecret = process.env[sessionSecretEnv];
+    const oldGithubToken = process.env[githubTokenEnv];
+    const oldAwsSecret = process.env[awsSecretEnv];
+
+    try {
+      delete process.env.HOME;
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "value-one";
+      process.env.ANTHROPIC_API_KEY = "value-two";
+      process.env[openAiKeyEnv] = "secret-openai";
+      process.env[piSessionDirEnv] = "/tmp/pi-sessions";
+      process.env.CLAUDECODE = "session-marker";
+      process.env[telegramTokenEnv] = "fixture";
+      process.env[tavilyKeyEnv] = "fixture";
+      process.env[sessionSecretEnv] = "fixture";
+      process.env[githubTokenEnv] = "fixture";
+      process.env[awsSecretEnv] = "fixture";
+
+      const ws = makeWorkspace();
+      const captures: SpawnCapture[] = [];
+      const deps = makeDeps(captures);
+
+      runPi(makeCron(), ws, deps);
+
+      const env = captures[0].options.env ?? {};
+      assert.strictEqual(env.HOME, homedir());
+      assert.strictEqual(env.CLAUDE_CODE_OAUTH_TOKEN, undefined);
+      assert.strictEqual(env.ANTHROPIC_API_KEY, undefined);
+      assert.strictEqual(env[openAiKeyEnv], undefined);
+      assert.strictEqual(env[piSessionDirEnv], "/tmp/pi-sessions");
+      assert.strictEqual(env.CLAUDECODE, undefined);
+      assert.strictEqual(env[telegramTokenEnv], undefined);
+      assert.strictEqual(env[tavilyKeyEnv], undefined);
+      assert.strictEqual(env[sessionSecretEnv], undefined);
+      assert.strictEqual(env[githubTokenEnv], undefined);
+      assert.strictEqual(env[awsSecretEnv], undefined);
+      assert.ok(env.PATH?.includes("/opt/homebrew/bin"));
+      assert.strictEqual(captures[0].options.timeout, 900000);
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      if (oldClaudeToken === undefined) {
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      } else {
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = oldClaudeToken;
+      }
+      if (oldAnthropicKey === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env["ANTHROPIC_API_KEY"] = oldAnthropicKey;
+      }
+      if (oldOpenAiKey === undefined) {
+        delete process.env[openAiKeyEnv];
+      } else {
+        process.env[openAiKeyEnv] = oldOpenAiKey;
+      }
+      if (oldPiSessionDir === undefined) {
+        delete process.env[piSessionDirEnv];
+      } else {
+        process.env[piSessionDirEnv] = oldPiSessionDir;
+      }
+      if (oldClaudeCode === undefined) {
+        delete process.env.CLAUDECODE;
+      } else {
+        process.env.CLAUDECODE = oldClaudeCode;
+      }
+      if (oldTelegramToken === undefined) {
+        delete process.env[telegramTokenEnv];
+      } else {
+        process.env[telegramTokenEnv] = oldTelegramToken;
+      }
+      if (oldTavilyKey === undefined) {
+        delete process.env[tavilyKeyEnv];
+      } else {
+        process.env[tavilyKeyEnv] = oldTavilyKey;
+      }
+      if (oldSessionSecret === undefined) {
+        delete process.env[sessionSecretEnv];
+      } else {
+        process.env[sessionSecretEnv] = oldSessionSecret;
+      }
+      if (oldGithubToken === undefined) {
+        delete process.env[githubTokenEnv];
+      } else {
+        process.env[githubTokenEnv] = oldGithubToken;
+      }
+      if (oldAwsSecret === undefined) {
+        delete process.env[awsSecretEnv];
+      } else {
+        process.env[awsSecretEnv] = oldAwsSecret;
+      }
+    }
+  });
+
+  it("fails closed before spawn when the ambient Pi extension kill-switch would remove A1", () => {
+    const oldDisabled = process.env[PI_EXTENSIONS_DISABLED_ENV];
+
+    try {
+      process.env[PI_EXTENSIONS_DISABLED_ENV] = "1";
+      const ws = makeWorkspace();
+      const captures: SpawnCapture[] = [];
+      const deps = makeDeps(captures, {
+        resolveExtensionArgs: () => [],
+      });
+
+      assert.throws(
+        () => runPi(makeCron(), ws, deps),
+        /PI_EXTENSIONS_DISABLED=1 cannot disable the required Pi cron guard extension/,
+      );
+      assert.strictEqual(captures.length, 0);
+    } finally {
+      if (oldDisabled === undefined) {
+        delete process.env[PI_EXTENSIONS_DISABLED_ENV];
+      } else {
+        process.env[PI_EXTENSIONS_DISABLED_ENV] = oldDisabled;
+      }
+    }
+  });
+
+  it("throws classified Pi errors with bounded private diagnostics so main can use the FAIL path", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    const deps = makeDeps(captures, {
+      spawnSync: capturingSpawn(captures, spawnResult({ stdout: "", stderr: "auth expired" })),
+    });
+
+    assert.throws(() => runPi(makeCron(), ws, deps), (err: unknown) => {
+      assert.match((err as Error).message, /Pi cron produced stderr without stdout/);
+      assert.doesNotMatch((err as Error).message, /auth expired/);
+      assert.match((err as { diagnostics?: string }).diagnostics ?? "", /stderr: auth expired/);
+      return true;
+    });
+  });
+
+  it("throws spawn errors before result classification", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    const deps = makeDeps(captures, {
+      spawnSync: capturingSpawn(captures, spawnResult({ error: new Error("ENOENT pi") })),
+    });
+
+    assert.throws(() => runPi(makeCron(), ws, deps), /Pi cron spawn failed: ENOENT pi/);
+  });
+
+  it("keeps timeout spawn diagnostics separate from the public spawn error", () => {
+    const ws = makeWorkspace();
+    const captures: SpawnCapture[] = [];
+    const timeoutError = Object.assign(new Error("spawnSync pi ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const deps = makeDeps(captures, {
+      spawnSync: capturingSpawn(captures, spawnResult({
+        error: timeoutError,
+        stdout: "partial timeout stdout",
+        stderr: "timeout stderr details",
+        status: null,
+        signal: "SIGTERM",
+      })),
+    });
+
+    assert.throws(() => runPi(makeCron(), ws, deps), (err: unknown) => {
+      assert.match((err as Error).message, /Pi cron spawn failed: spawnSync pi ETIMEDOUT/);
+      assert.doesNotMatch((err as Error).message, /timeout stderr details/);
+      assert.match((err as { diagnostics?: string }).diagnostics ?? "", /stderr: timeout stderr details/);
+      assert.match((err as { diagnostics?: string }).diagnostics ?? "", /stdout: partial timeout stdout/);
+      return true;
+    });
+  });
+});

--- a/bot/src/__tests__/cron-runner.test.ts
+++ b/bot/src/__tests__/cron-runner.test.ts
@@ -1,14 +1,29 @@
 import { describe, it, before, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdirSync, rmSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { loadCronTask, getAgentWorkspace, buildDeliverCommand, shellEscape, loadAdminChatId, handleDeliveryFailure, loadDefaultDelivery, runScript } from "../cron-runner.js";
-import type { DeliveryDefaults } from "../cron-runner.js";
+import { loadCronTask, getAgentWorkspace, resolveCronAgentData, buildPiCronAgentConfig, buildDeliverCommand, shellEscape, loadAdminChatId, handleDeliveryFailure, loadDefaultDelivery, resolveCronEngine, runOneShot, classifyPiResult, writeCronHealthMetric, runScript, main } from "../cron-runner.js";
+import type { CronAgentData, CronRunnerMainDeps, DeliveryDefaults } from "../cron-runner.js";
 import type { CronJob } from "../types.js";
 
 // We test the pure functions. runClaude and deliver require real claude/Telegram.
 
 const TEST_DIR = join("/tmp", "cron-runner-test-" + Date.now());
+
+function makeLlmCron(engine?: CronJob["engine"]): CronJob {
+  const cron: CronJob = {
+    name: engine ? `${engine}-engine-task` : "default-engine-task",
+    schedule: "0 * * * *",
+    type: "llm",
+    prompt: "test",
+    agentId: "main",
+    deliveryChatId: 111111111,
+  };
+  if (engine !== undefined) {
+    cron.engine = engine;
+  }
+  return cron;
+}
 
 describe("cron-runner", () => {
   describe("shellEscape", () => {
@@ -557,6 +572,864 @@ describe("cron-runner", () => {
 `);
       const cron = loadCronTask("enabled-task", CRONS_FILE);
       assert.strictEqual(cron.enabled, undefined);
+    });
+  });
+
+  describe("loadCronTask — engine field", () => {
+    const CRONS_DIR = join(TEST_DIR, "cron-engine");
+    const CRONS_FILE = join(CRONS_DIR, "crons.yaml");
+
+    beforeEach(() => {
+      mkdirSync(CRONS_DIR, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(CRONS_DIR, { recursive: true, force: true });
+    });
+
+    it("returns undefined engine when omitted", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: default-engine-task
+    schedule: "0 * * * *"
+    prompt: "test"
+    agentId: main
+    deliveryChatId: 111111111
+`);
+      const cron = loadCronTask("default-engine-task", CRONS_FILE);
+      assert.strictEqual(cron.engine, undefined);
+    });
+
+    it("parses engine: claude", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: claude-engine-task
+    schedule: "0 * * * *"
+    prompt: "test"
+    agentId: main
+    deliveryChatId: 111111111
+    engine: claude
+`);
+      const cron = loadCronTask("claude-engine-task", CRONS_FILE);
+      assert.strictEqual(cron.engine, "claude");
+    });
+
+    it("parses engine: pi", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: pi-engine-task
+    schedule: "0 * * * *"
+    prompt: "test"
+    agentId: main
+    deliveryChatId: 111111111
+    engine: pi
+`);
+      const cron = loadCronTask("pi-engine-task", CRONS_FILE);
+      assert.strictEqual(cron.engine, "pi");
+    });
+
+    it("rejects invalid engine values", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: bad-engine-task
+    schedule: "0 * * * *"
+    prompt: "test"
+    agentId: main
+    deliveryChatId: 111111111
+    engine: codex
+`);
+      assert.throws(() => loadCronTask("bad-engine-task", CRONS_FILE), /invalid 'engine' "codex"/);
+    });
+
+    it("ignores engine on script crons without changing script validation", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: script-engine-task
+    schedule: "0 * * * *"
+    type: script
+    command: "echo script"
+    agentId: main
+    deliveryChatId: 111111111
+    engine: pi
+`);
+      const cron = loadCronTask("script-engine-task", CRONS_FILE);
+      assert.strictEqual(cron.type, "script");
+      assert.strictEqual(cron.command, "echo script");
+      assert.strictEqual(cron.prompt, undefined);
+      assert.strictEqual(cron.engine, undefined);
+    });
+
+    it("ignores invalid engine values on script crons", () => {
+      writeFileSync(CRONS_FILE, `crons:
+  - name: script-bad-engine-task
+    schedule: "0 * * * *"
+    type: script
+    command: "echo script"
+    agentId: main
+    deliveryChatId: 111111111
+    engine: codex
+`);
+      const cron = loadCronTask("script-bad-engine-task", CRONS_FILE);
+      assert.strictEqual(cron.type, "script");
+      assert.strictEqual(cron.command, "echo script");
+      assert.strictEqual(cron.engine, undefined);
+    });
+  });
+
+  describe("cron engine dispatch", () => {
+    let oldCronPiDisabled: string | undefined;
+
+    beforeEach(() => {
+      oldCronPiDisabled = process.env.CRON_PI_DISABLED;
+      delete process.env.CRON_PI_DISABLED;
+    });
+
+    afterEach(() => {
+      if (oldCronPiDisabled === undefined) {
+        delete process.env.CRON_PI_DISABLED;
+      } else {
+        process.env.CRON_PI_DISABLED = oldCronPiDisabled;
+      }
+    });
+
+    function makeDispatchDeps(calls: string[]) {
+      return {
+        runClaude: (cron: CronJob, workspaceCwd: string): string => {
+          calls.push(`claude:${cron.name}:${workspaceCwd}`);
+          return "claude-output";
+        },
+        runPi: (cron: CronJob, workspaceCwd: string): string => {
+          calls.push(`pi:${cron.name}:${workspaceCwd}`);
+          return "pi-output";
+        },
+      };
+    }
+
+    it("defaults omitted engine to Claude", () => {
+      const cron = makeLlmCron();
+      const calls: string[] = [];
+
+      assert.strictEqual(resolveCronEngine(cron), "claude");
+      assert.strictEqual(runOneShot(cron, "/tmp/workspace", makeDispatchDeps(calls)), "claude-output");
+      assert.deepStrictEqual(calls, ["claude:default-engine-task:/tmp/workspace"]);
+    });
+
+    it("dispatches explicit Claude engine to Claude", () => {
+      const cron = makeLlmCron("claude");
+      const calls: string[] = [];
+
+      assert.strictEqual(resolveCronEngine(cron), "claude");
+      assert.strictEqual(runOneShot(cron, "/tmp/workspace", makeDispatchDeps(calls)), "claude-output");
+      assert.deepStrictEqual(calls, ["claude:claude-engine-task:/tmp/workspace"]);
+    });
+
+    it("dispatches explicit Pi engine to Pi", () => {
+      const cron = makeLlmCron("pi");
+      const calls: string[] = [];
+
+      assert.strictEqual(resolveCronEngine(cron), "pi");
+      assert.strictEqual(runOneShot(cron, "/tmp/workspace", makeDispatchDeps(calls)), "pi-output");
+      assert.deepStrictEqual(calls, ["pi:pi-engine-task:/tmp/workspace"]);
+    });
+
+    it("falls back to Claude when CRON_PI_DISABLED=1", () => {
+      const cron = makeLlmCron("pi");
+      const calls: string[] = [];
+      process.env.CRON_PI_DISABLED = "1";
+
+      assert.strictEqual(resolveCronEngine(cron), "claude");
+      assert.strictEqual(runOneShot(cron, "/tmp/workspace", makeDispatchDeps(calls)), "claude-output");
+      assert.deepStrictEqual(calls, ["claude:pi-engine-task:/tmp/workspace"]);
+    });
+  });
+
+  describe("Pi result classification", () => {
+    const cases = [
+      {
+        name: "returns trimmed stdout for a zero exit with output",
+        args: [0, null, "  hello from pi\n", ""] as const,
+        expected: { status: "ok" as const, output: "hello from pi" },
+      },
+      {
+        name: "treats a zero exit with empty stdout and empty stderr as intentional empty success",
+        args: [0, null, " \n\t", ""] as const,
+        expected: { status: "ok" as const, output: "" },
+      },
+      {
+        name: "preserves NO_REPLY output for the existing post-run suppression logic",
+        args: [0, null, "\nNO_REPLY\n", "diagnostic warning"] as const,
+        expected: { status: "ok" as const, output: "NO_REPLY" },
+      },
+      {
+        name: "treats a zero exit with empty stdout and non-empty stderr as an error",
+        args: [0, null, "", "auth expired"] as const,
+        messageMatches: [/stderr without stdout/],
+        diagnosticMatches: [/stderr: auth expired/],
+      },
+      {
+        name: "treats a non-zero exit as an error with bounded stderr and stdout diagnostics",
+        args: [2, null, "partial output", "failure details"] as const,
+        messageMatches: [/code 2/],
+        diagnosticMatches: [/stderr: failure details/, /stdout: partial output/],
+      },
+      {
+        name: "treats a signal as an error with bounded output diagnostics",
+        args: [null, "SIGTERM", "partial output", "terminated"] as const,
+        messageMatches: [/signal SIGTERM/],
+        diagnosticMatches: [/stderr: terminated/, /stdout: partial output/],
+      },
+    ];
+
+    for (const testCase of cases) {
+      it(testCase.name, () => {
+        const [exitCode, signal, stdout, stderr] = testCase.args;
+        const result = classifyPiResult(exitCode, signal, stdout, stderr);
+        if ("expected" in testCase) {
+          assert.deepStrictEqual(result, testCase.expected);
+          return;
+        }
+        assert.strictEqual(result.status, "error");
+        for (const pattern of testCase.messageMatches) {
+          assert.match(result.message, pattern);
+        }
+        for (const pattern of testCase.diagnosticMatches) {
+          assert.match(result.diagnostics ?? "", pattern);
+        }
+      });
+    }
+
+    it("treats a missing exit code without signal as an error", () => {
+      const result = classifyPiResult(undefined, null, "", "");
+
+      assert.strictEqual(result.status, "error");
+      assert.match(result.message, /without an exit code/);
+    });
+
+    it("bounds long stderr/stdout excerpts in diagnostics", () => {
+      const longStdout = `stdout-${"o".repeat(2100)}-tail`;
+      const longStderr = `stderr-${"e".repeat(2100)}-tail`;
+      const result = classifyPiResult(1, null, longStdout, longStderr);
+
+      assert.strictEqual(result.status, "error");
+      assert.match(result.message, /code 1/);
+      assert.match(result.diagnostics ?? "", /stderr \(first 1000 chars\): stderr-eeee/);
+      assert.match(result.diagnostics ?? "", /stdout \(first 1000 chars\): stdout-oooo/);
+      assert.match(result.diagnostics ?? "", /truncated \d+ chars/);
+      assert.doesNotMatch(result.diagnostics ?? "", /-tail/);
+      assert.ok((result.diagnostics ?? "").length < 2400, `diagnostics were not bounded: ${result.diagnostics?.length}`);
+    });
+  });
+
+  describe("cron agent data resolution", () => {
+    const CONFIG_DIR = join(TEST_DIR, "cron-agent-config");
+    const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
+    const CRONS_FILE = join(CONFIG_DIR, "crons.yaml");
+
+    beforeEach(() => {
+      mkdirSync(CONFIG_DIR, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(CONFIG_DIR, { recursive: true, force: true });
+    });
+
+    it("resolves the default main agent for cron Pi context assembly", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  main:
+    id: ignored-raw-id
+    workspaceCwd: /tmp/main-workspace
+    model: claude-opus-4-6
+    systemPrompt: "Use the main persona"
+    effort: high
+bindings: []
+`);
+      writeFileSync(CRONS_FILE, `crons:
+  - name: default-main-cron
+    schedule: "0 * * * *"
+    prompt: "test"
+    deliveryChatId: 111111111
+`);
+
+      const cron = loadCronTask("default-main-cron", CRONS_FILE);
+      const agent = buildPiCronAgentConfig(cron.agentId, CONFIG_FILE);
+
+      assert.strictEqual(cron.agentId, "main");
+      assert.deepStrictEqual(agent, {
+        id: "main",
+        workspaceCwd: "/tmp/main-workspace",
+        provider: "pi",
+        model: "openai-codex/gpt-5.5",
+        systemPrompt: "Use the main persona",
+        effort: "high",
+      });
+    });
+
+    it("ignores non-string systemPrompt and unsupported effort values", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  main:
+    workspaceCwd: /tmp/main-workspace
+    model: claude-opus-4-6
+    systemPrompt: 42
+    effort: xhigh
+bindings: []
+`);
+
+      const agent = buildPiCronAgentConfig("main", CONFIG_FILE);
+      assert.strictEqual(agent.systemPrompt, undefined);
+      assert.strictEqual(agent.effort, undefined);
+    });
+
+    it("getAgentWorkspace uses the same raw config resolution", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  worker:
+    workspaceCwd: /tmp/worker-workspace
+    model: claude-opus-4-6
+bindings: []
+`);
+
+      assert.strictEqual(getAgentWorkspace("worker", CONFIG_FILE), "/tmp/worker-workspace");
+      assert.deepStrictEqual(resolveCronAgentData("worker", CONFIG_FILE), {
+        id: "worker",
+        workspaceCwd: "/tmp/worker-workspace",
+      });
+    });
+
+    it("throws before spawn when the cron agent is missing", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  main:
+    workspaceCwd: /tmp/main-workspace
+    model: claude-opus-4-6
+bindings: []
+`);
+
+      assert.throws(
+        () => buildPiCronAgentConfig("missing", CONFIG_FILE),
+        /Agent "missing" not found in config.yaml \/ config.local.yaml/,
+      );
+    });
+
+    it("throws before spawn when workspaceCwd is missing", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  main:
+    model: claude-opus-4-6
+bindings: []
+`);
+
+      assert.throws(
+        () => buildPiCronAgentConfig("main", CONFIG_FILE),
+        /Agent "main" missing workspaceCwd/,
+      );
+    });
+
+    it("throws before spawn when workspaceCwd is invalid", () => {
+      writeFileSync(CONFIG_FILE, `agents:
+  main:
+    workspaceCwd: 42
+    model: claude-opus-4-6
+bindings: []
+`);
+
+      assert.throws(
+        () => buildPiCronAgentConfig("main", CONFIG_FILE),
+        /Agent "main" missing workspaceCwd/,
+      );
+    });
+  });
+
+  describe("cron health metrics", () => {
+    const METRIC_DIR = join(TEST_DIR, "cron-health-metrics");
+    let oldTextfileDir: string | undefined;
+
+    beforeEach(() => {
+      oldTextfileDir = process.env.CRON_HEALTH_TEXTFILE_DIR;
+      mkdirSync(METRIC_DIR, { recursive: true });
+      process.env.CRON_HEALTH_TEXTFILE_DIR = METRIC_DIR;
+    });
+
+    afterEach(() => {
+      if (oldTextfileDir === undefined) {
+        delete process.env.CRON_HEALTH_TEXTFILE_DIR;
+      } else {
+        process.env.CRON_HEALTH_TEXTFILE_DIR = oldTextfileDir;
+      }
+      rmSync(METRIC_DIR, { recursive: true, force: true });
+    });
+
+    it("writes success timestamp and exit code to stable hashed textfiles", () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      writeCronHealthMetric("Daily Pi / Main!", 0, true);
+
+      const files = readdirSync(METRIC_DIR).filter((name) => name.endsWith(".prom")).sort();
+      assert.strictEqual(files.length, 2);
+      assert.ok(files.some((name) => /^minime_cron_Daily_Pi_Main_[a-f0-9]{12}\.success\.prom$/.test(name)), files.join(","));
+      assert.ok(files.some((name) => /^minime_cron_Daily_Pi_Main_[a-f0-9]{12}\.exit\.prom$/.test(name)), files.join(","));
+      const content = files.map((name) => readFileSync(join(METRIC_DIR, name), "utf8")).join("\n");
+      const after = Math.floor(Date.now() / 1000);
+      const timestampMatch = content.match(
+        /minime_cron_last_success_timestamp\{cron="Daily Pi \/ Main!"\} (\d+)/,
+      );
+
+      assert.ok(timestampMatch, content);
+      const timestamp = Number(timestampMatch[1]);
+      assert.ok(timestamp >= before && timestamp <= after, `timestamp ${timestamp} outside test window`);
+      assert.match(content, /minime_cron_last_exit_code\{cron="Daily Pi \/ Main!"\} 0/);
+      assert.deepStrictEqual(
+        readdirSync(METRIC_DIR).filter((name) => name.endsWith(".tmp")),
+        [],
+      );
+    });
+
+    it("preserves the previous success timestamp when writing a failure exit code", () => {
+      writeCronHealthMetric("failing-cron", 0, true);
+      const successFile = readdirSync(METRIC_DIR).find((name) => name.endsWith(".success.prom"));
+      assert.ok(successFile);
+      const successContent = readFileSync(join(METRIC_DIR, successFile), "utf8");
+
+      writeCronHealthMetric("failing-cron", 2, false);
+
+      assert.strictEqual(readFileSync(join(METRIC_DIR, successFile), "utf8"), successContent);
+      const exitFile = readdirSync(METRIC_DIR).find((name) => name.endsWith(".exit.prom"));
+      assert.ok(exitFile);
+      const exitContent = readFileSync(join(METRIC_DIR, exitFile), "utf8");
+      assert.match(exitContent, /minime_cron_last_exit_code\{cron="failing-cron"\} 2/);
+    });
+
+    it("keeps distinct files and labels for cron names that sanitize to the same stem", () => {
+      writeCronHealthMetric("a/b", 0, false);
+      writeCronHealthMetric("a_b", 1, false);
+
+      const files = readdirSync(METRIC_DIR).filter((name) => name.endsWith(".exit.prom")).sort();
+      assert.strictEqual(files.length, 2);
+      assert.notStrictEqual(files[0], files[1]);
+      const content = files.map((name) => readFileSync(join(METRIC_DIR, name), "utf8")).join("\n");
+      assert.match(content, /minime_cron_last_exit_code\{cron="a\/b"\} 0/);
+      assert.match(content, /minime_cron_last_exit_code\{cron="a_b"\} 1/);
+    });
+
+    it("escapes quotes, backslashes, and newlines in Prometheus labels", () => {
+      writeCronHealthMetric('quoted"slash\\newline\nname', 7, false);
+
+      const file = readdirSync(METRIC_DIR).find((name) => name.endsWith(".exit.prom"));
+      assert.ok(file);
+      assert.strictEqual(
+        readFileSync(join(METRIC_DIR, file), "utf8"),
+        'minime_cron_last_exit_code{cron="quoted\\"slash\\\\newline\\nname"} 7\n',
+      );
+    });
+
+    it("warns but does not throw when the textfile path cannot be written", () => {
+      const blocker = join(METRIC_DIR, "not-a-directory");
+      writeFileSync(blocker, "blocking file", "utf8");
+      process.env.CRON_HEALTH_TEXTFILE_DIR = join(blocker, "child");
+      const oldWrite = process.stderr.write;
+      const stderrWrites: string[] = [];
+
+      try {
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+          stderrWrites.push(String(chunk));
+          return true;
+        }) as typeof process.stderr.write;
+
+        assert.doesNotThrow(() => writeCronHealthMetric("blocked metric", 1, false));
+      } finally {
+        process.stderr.write = oldWrite;
+      }
+      const stderr = stderrWrites.join("");
+      assert.match(stderr, /blocked metric/);
+      assert.match(stderr, /failed to prepare cron health metric dir/);
+    });
+  });
+
+  describe("main behavior preservation", () => {
+    class MainExitError extends Error {
+      code: number;
+
+      constructor(code: number) {
+        super(`process.exit(${code})`);
+        this.code = code;
+      }
+    }
+
+    interface MainCalls {
+      consoleErrors: string[];
+      logs: Array<{ taskName: string; message: string }>;
+      defaultLoads: number;
+      cronLoads: Array<{ taskName: string; defaults?: DeliveryDefaults }>;
+      adminLoads: number;
+      workspaces: string[];
+      scripts: string[];
+      oneShots: Array<{ cronName: string; workspaceCwd: string; engine: "claude" | "pi"; agentData?: CronAgentData }>;
+      deliveries: Array<{ chatId: number; message: string; threadId?: number }>;
+      deliveryFailures: Array<{
+        cronName: string;
+        targetChatId: number;
+        errorMsg: string;
+        adminChatId: number | undefined;
+      }>;
+      metrics: Array<{ cronName: string; exitCode: number; success: boolean }>;
+      exits: number[];
+    }
+
+    function makeMainCron(overrides: Partial<CronJob> = {}): CronJob {
+      return {
+        name: "main-behavior-task",
+        schedule: "0 * * * *",
+        type: "llm",
+        prompt: "test prompt",
+        agentId: "main",
+        deliveryChatId: 111111111,
+        deliveryThreadId: 42,
+        ...overrides,
+      };
+    }
+
+    function makeMainHarness(cron: CronJob): { calls: MainCalls; deps: Partial<CronRunnerMainDeps> } {
+      const calls: MainCalls = {
+        consoleErrors: [],
+        logs: [],
+        defaultLoads: 0,
+        cronLoads: [],
+        adminLoads: 0,
+        workspaces: [],
+        scripts: [],
+        oneShots: [],
+        deliveries: [],
+        deliveryFailures: [],
+        metrics: [],
+        exits: [],
+      };
+
+      const deps: Partial<CronRunnerMainDeps> = {
+        argv: ["node", "cron-runner.ts", "--task", cron.name],
+        consoleError: (message?: unknown) => {
+          calls.consoleErrors.push(String(message));
+        },
+        exit: (code: number): never => {
+          calls.exits.push(code);
+          throw new MainExitError(code);
+        },
+        log: (taskName: string, message: string) => {
+          calls.logs.push({ taskName, message });
+        },
+        loadDefaultDelivery: () => {
+          calls.defaultLoads += 1;
+          return {};
+        },
+        loadCronTask: (taskName: string, _cronsPath?: string, defaults?: DeliveryDefaults) => {
+          calls.cronLoads.push({ taskName, defaults });
+          return cron;
+        },
+        loadAdminChatId: () => {
+          calls.adminLoads += 1;
+          return 999999999;
+        },
+        resolveCronAgentData: (agentId: string) => {
+          calls.workspaces.push(agentId);
+          return { id: agentId, workspaceCwd: "/tmp/main-workspace", systemPrompt: "persona", effort: "high" };
+        },
+        runScript: (scriptCron: CronJob) => {
+          calls.scripts.push(scriptCron.name);
+          return "script output";
+        },
+        runClaude: (llmCron: CronJob, workspaceCwd: string) => {
+          calls.oneShots.push({ cronName: llmCron.name, workspaceCwd, engine: "claude" });
+          return "llm output";
+        },
+        runPi: (llmCron: CronJob, workspaceCwd: string, agentData?: CronAgentData) => {
+          calls.oneShots.push({ cronName: llmCron.name, workspaceCwd, engine: "pi", agentData });
+          return "llm output";
+        },
+        deliver: (chatId: number, message: string, threadId?: number) => {
+          calls.deliveries.push({ chatId, message, threadId });
+        },
+        handleDeliveryFailure: (
+          cronName: string,
+          targetChatId: number,
+          errorMsg: string,
+          adminChatId: number | undefined,
+        ) => {
+          calls.deliveryFailures.push({ cronName, targetChatId, errorMsg, adminChatId });
+        },
+        writeCronHealthMetric: (cronName: string, exitCode: number, success: boolean) => {
+          calls.metrics.push({ cronName, exitCode, success });
+        },
+      };
+
+      return { calls, deps };
+    }
+
+    async function assertMainExits(
+      deps: Partial<CronRunnerMainDeps>,
+      expectedCode: number,
+    ): Promise<void> {
+      await assert.rejects(
+        () => main(deps),
+        (err: unknown) => err instanceof MainExitError && err.code === expectedCode,
+      );
+    }
+
+    it("writes an unknown failure metric and exits when --task is missing", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.argv = ["node", "cron-runner.ts"];
+
+      await assertMainExits(deps, 1);
+
+      assert.deepStrictEqual(calls.consoleErrors, ["Usage: cron-runner.ts --task <name>"]);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: "unknown", exitCode: 1, success: false },
+      ]);
+      assert.deepStrictEqual(calls.cronLoads, []);
+    });
+
+    it("keeps script crons on the script path and delivers their output", async () => {
+      const cron = makeMainCron({
+        type: "script",
+        prompt: undefined,
+        command: "echo script",
+        engine: "pi",
+      });
+      const { calls, deps } = makeMainHarness(cron);
+      deps.resolveCronAgentData = () => {
+        throw new Error("script crons must not resolve an agent workspace");
+      };
+      deps.runClaude = () => {
+        throw new Error("script crons must not use Claude dispatch");
+      };
+      deps.runPi = () => {
+        throw new Error("script crons must not use LLM dispatch");
+      };
+
+      await main(deps);
+
+      assert.deepStrictEqual(calls.scripts, [cron.name]);
+      assert.deepStrictEqual(calls.workspaces, []);
+      assert.deepStrictEqual(calls.oneShots, []);
+      assert.deepStrictEqual(calls.deliveries, [
+        { chatId: 111111111, message: "script output", threadId: 42 },
+      ]);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 0, success: true },
+      ]);
+      assert.strictEqual(calls.exits.length, 0);
+      assert.ok(calls.logs.some((entry) => entry.message === "Script returned 13 chars"));
+      assert.ok(calls.logs.some((entry) => entry.message === "DONE"));
+    });
+
+    it("resolves workspace and uses one-shot LLM dispatch for LLM crons", async () => {
+      const cron = makeMainCron({ engine: "pi" });
+      const { calls, deps } = makeMainHarness(cron);
+
+      await main(deps);
+
+      assert.deepStrictEqual(calls.workspaces, ["main"]);
+      assert.deepStrictEqual(calls.oneShots, [
+        {
+          cronName: cron.name,
+          workspaceCwd: "/tmp/main-workspace",
+          engine: "pi",
+          agentData: { id: "main", workspaceCwd: "/tmp/main-workspace", systemPrompt: "persona", effort: "high" },
+        },
+      ]);
+      assert.deepStrictEqual(calls.deliveries, [
+        { chatId: 111111111, message: "llm output", threadId: 42 },
+      ]);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 0, success: true },
+      ]);
+      assert.ok(calls.logs.some((entry) => entry.message === "LLM engine=pi returned 10 chars"));
+    });
+
+    it("uses real main dispatch kill-switch fallback for Pi crons", async () => {
+      const oldCronPiDisabled = process.env.CRON_PI_DISABLED;
+      const cron = makeMainCron({ engine: "pi" });
+      const { calls, deps } = makeMainHarness(cron);
+
+      try {
+        process.env.CRON_PI_DISABLED = "1";
+        await main(deps);
+      } finally {
+        if (oldCronPiDisabled === undefined) {
+          delete process.env.CRON_PI_DISABLED;
+        } else {
+          process.env.CRON_PI_DISABLED = oldCronPiDisabled;
+        }
+      }
+
+      assert.deepStrictEqual(calls.oneShots, [
+        { cronName: cron.name, workspaceCwd: "/tmp/main-workspace", engine: "claude" },
+      ]);
+      assert.ok(calls.logs.some((entry) => entry.message === "LLM engine=claude returned 10 chars"));
+    });
+
+    it("keeps empty output as a successful skip without delivery", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runClaude = (llmCron: CronJob, workspaceCwd: string) => {
+        calls.oneShots.push({ cronName: llmCron.name, workspaceCwd, engine: "claude" });
+        return "";
+      };
+
+      await main(deps);
+
+      assert.deepStrictEqual(calls.deliveries, []);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 0, success: true },
+      ]);
+      assert.ok(calls.logs.some((entry) => entry.message === "WARN: empty output — skipping delivery"));
+      assert.ok(calls.logs.some((entry) => entry.message === "DONE"));
+    });
+
+    it("keeps LLM NO_REPLY output as a successful skip without delivery", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runClaude = (llmCron: CronJob, workspaceCwd: string) => {
+        calls.oneShots.push({ cronName: llmCron.name, workspaceCwd, engine: "claude" });
+        return "All clean.\n\nNO_REPLY";
+      };
+
+      await main(deps);
+
+      assert.deepStrictEqual(calls.deliveries, []);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 0, success: true },
+      ]);
+      assert.ok(calls.logs.some((entry) => entry.message === "NO_REPLY — skipping delivery"));
+      assert.ok(calls.logs.some((entry) => entry.message === "DONE"));
+    });
+
+    it("does not apply NO_REPLY suppression to script output", async () => {
+      const cron = makeMainCron({
+        type: "script",
+        prompt: undefined,
+        command: "echo NO_REPLY",
+      });
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runScript = (scriptCron: CronJob) => {
+        calls.scripts.push(scriptCron.name);
+        return "NO_REPLY";
+      };
+
+      await main(deps);
+
+      assert.deepStrictEqual(calls.deliveries, [
+        { chatId: 111111111, message: "NO_REPLY", threadId: 42 },
+      ]);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 0, success: true },
+      ]);
+    });
+
+    it("sends cron FAIL notifications and exits when execution fails", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runClaude = () => {
+        throw new Error("runner exploded");
+      };
+
+      await assertMainExits(deps, 1);
+
+      assert.strictEqual(calls.deliveries.length, 1);
+      assert.strictEqual(calls.deliveries[0].chatId, 111111111);
+      assert.strictEqual(calls.deliveries[0].threadId, 42);
+      assert.match(calls.deliveries[0].message, /Cron FAIL: main-behavior-task/);
+      assert.match(calls.deliveries[0].message, /runner exploded/);
+      assert.deepStrictEqual(calls.deliveryFailures, []);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 1, success: false },
+      ]);
+    });
+
+    it("sends cron FAIL notifications and exits when LLM workspace resolution fails", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.resolveCronAgentData = () => {
+        throw new Error('Agent "missing" not found in config.yaml / config.local.yaml');
+      };
+      deps.runClaude = () => {
+        throw new Error("LLM dispatch must not run without a workspace");
+      };
+
+      await assertMainExits(deps, 1);
+
+      assert.deepStrictEqual(calls.oneShots, []);
+      assert.strictEqual(calls.deliveries.length, 1);
+      assert.strictEqual(calls.deliveries[0].chatId, 111111111);
+      assert.match(calls.deliveries[0].message, /Cron FAIL: main-behavior-task/);
+      assert.match(calls.deliveries[0].message, /Agent "missing" not found/);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 1, success: false },
+      ]);
+    });
+
+    it("keeps subprocess diagnostics out of cron FAIL notifications", async () => {
+      const cron = makeMainCron({ engine: "pi" });
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runPi = () => {
+        throw Object.assign(new Error("Pi cron produced stderr without stdout"), {
+          diagnostics: "stderr: secret-token-should-stay-in-local-log",
+        });
+      };
+
+      await assertMainExits(deps, 1);
+
+      assert.strictEqual(calls.deliveries.length, 1);
+      assert.match(calls.deliveries[0].message, /Pi cron produced stderr without stdout/);
+      assert.doesNotMatch(calls.deliveries[0].message, /secret-token/);
+      assert.ok(
+        calls.logs.some((entry) => entry.message.includes("secret-token-should-stay-in-local-log")),
+        "expected local diagnostics log",
+      );
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 1, success: false },
+      ]);
+    });
+
+    it("uses the admin fallback when cron FAIL notification delivery fails", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.runClaude = () => {
+        throw new Error("runner exploded");
+      };
+      deps.deliver = (chatId: number, message: string, threadId?: number) => {
+        calls.deliveries.push({ chatId, message, threadId });
+        throw new Error("bot blocked");
+      };
+
+      await assertMainExits(deps, 1);
+
+      assert.strictEqual(calls.deliveryFailures.length, 1);
+      assert.deepStrictEqual(calls.deliveryFailures[0], {
+        cronName: cron.name,
+        targetChatId: 111111111,
+        errorMsg: 'Cron task "main-behavior-task" failed: runner exploded\n(notification delivery failed: bot blocked)',
+        adminChatId: 999999999,
+      });
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 1, success: false },
+      ]);
+    });
+
+    it("uses the admin fallback and exits when final output delivery fails", async () => {
+      const cron = makeMainCron();
+      const { calls, deps } = makeMainHarness(cron);
+      deps.deliver = (chatId: number, message: string, threadId?: number) => {
+        calls.deliveries.push({ chatId, message, threadId });
+        throw new Error("delivery transport failed");
+      };
+
+      await assertMainExits(deps, 1);
+
+      assert.deepStrictEqual(calls.deliveries, [
+        { chatId: 111111111, message: "llm output", threadId: 42 },
+      ]);
+      assert.deepStrictEqual(calls.deliveryFailures, [
+        {
+          cronName: cron.name,
+          targetChatId: 111111111,
+          errorMsg: "delivery transport failed",
+          adminChatId: 999999999,
+        },
+      ]);
+      assert.deepStrictEqual(calls.metrics, [
+        { cronName: cron.name, exitCode: 1, success: false },
+      ]);
     });
   });
 

--- a/bot/src/__tests__/cron-runner.test.ts
+++ b/bot/src/__tests__/cron-runner.test.ts
@@ -1002,14 +1002,14 @@ bindings: []
       assert.match(content, /minime_cron_last_exit_code\{cron="a_b"\} 1/);
     });
 
-    it("escapes quotes, backslashes, and newlines in Prometheus labels", () => {
-      writeCronHealthMetric('quoted"slash\\newline\nname', 7, false);
+    it("escapes quotes, backslashes, newlines, and carriage returns in Prometheus labels", () => {
+      writeCronHealthMetric('quoted"slash\\newline\ncarriage\rname', 7, false);
 
       const file = readdirSync(METRIC_DIR).find((name) => name.endsWith(".exit.prom"));
       assert.ok(file);
       assert.strictEqual(
         readFileSync(join(METRIC_DIR, file), "utf8"),
-        'minime_cron_last_exit_code{cron="quoted\\"slash\\\\newline\\nname"} 7\n',
+        'minime_cron_last_exit_code{cron="quoted\\"slash\\\\newline\\ncarriage\\rname"} 7\n',
       );
     });
 

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -626,6 +626,24 @@ describe("buildPiSpawnEnv", () => {
     }
   });
 
+  it("builds PATH without empty elements when inherited PATH is blank or has separators", () => {
+    const oldPath = process.env.PATH;
+
+    try {
+      process.env.PATH = "";
+      assert.strictEqual(buildPiSpawnEnv(testAgent).PATH, "/opt/homebrew/bin");
+
+      process.env.PATH = ":/usr/bin::/bin:";
+      assert.strictEqual(buildPiSpawnEnv(testAgent).PATH, "/opt/homebrew/bin:/usr/bin:/bin");
+    } finally {
+      if (oldPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = oldPath;
+      }
+    }
+  });
+
   it("scrubs the CLAUDECODE session marker (parity with the Claude path)", () => {
     const oldMarker = process.env.CLAUDECODE;
 

--- a/bot/src/__tests__/pi-rpc-protocol.test.ts
+++ b/bot/src/__tests__/pi-rpc-protocol.test.ts
@@ -525,38 +525,80 @@ describe("Pi extension loading (--extension)", () => {
 });
 
 describe("buildPiSpawnEnv", () => {
-  it("removes Anthropic credentials while preserving unrelated env", () => {
-    const oldClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    const oldApiKey = process.env.ANTHROPIC_API_KEY;
-    const oldMarker = process.env.PI_RPC_TEST_MARKER;
+  it("allows only Pi runtime env and removes ambient credentials", () => {
+    const envKeys = [
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_OAUTH_TOKEN",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "DISCORD_BOT_TOKEN",
+      "GITHUB_TOKEN",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "LC_CTYPE",
+      "LC_SECRET",
+      "NPM_TOKEN",
+      "OPENAI_API_KEY",
+      "PI_CODING_AGENT_SESSION_DIR",
+      "PI_RPC_TEST_MARKER",
+      "SSH_AUTH_SOCK",
+      "TAVILY_API_KEY",
+      "TELEGRAM_BOT_TOKEN",
+      "MINIME_SESSION_SECRET",
+    ];
+    const oldValues = new Map(envKeys.map((key) => [key, process.env[key]]));
 
     try {
-      process.env.CLAUDE_CODE_OAUTH_TOKEN = "secret";
-      process.env.ANTHROPIC_API_KEY = "secret";
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "fixture";
+      process.env.ANTHROPIC_API_KEY = "fixture";
+      process.env.ANTHROPIC_OAUTH_TOKEN = "fixture";
+      process.env.AWS_ACCESS_KEY_ID = "fixture";
+      process.env.AWS_SECRET_ACCESS_KEY = "fixture";
+      process.env.AWS_SESSION_TOKEN = "fixture";
+      process.env.DISCORD_BOT_TOKEN = "fixture";
+      process.env.GITHUB_TOKEN = "fixture";
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/tmp/google-creds.json";
+      process.env.LC_CTYPE = "UTF-8";
+      process.env.LC_SECRET = "fixture";
+      process.env.NPM_TOKEN = "fixture";
+      process.env.OPENAI_API_KEY = "fixture";
+      process.env.PI_CODING_AGENT_SESSION_DIR = "/tmp/pi-sessions";
       process.env.PI_RPC_TEST_MARKER = "keep";
+      process.env.SSH_AUTH_SOCK = "/tmp/ssh-agent.sock";
+      process.env.TAVILY_API_KEY = "fixture";
+      process.env.TELEGRAM_BOT_TOKEN = "fixture";
+      process.env.MINIME_SESSION_SECRET = "fixture";
 
       const env = buildPiSpawnEnv(testAgent);
 
       assert.strictEqual(env.CLAUDE_CODE_OAUTH_TOKEN, undefined);
       assert.strictEqual(env.ANTHROPIC_API_KEY, undefined);
-      assert.strictEqual(env.PI_RPC_TEST_MARKER, "keep");
+      assert.strictEqual(env.DISCORD_BOT_TOKEN, undefined);
+      assert.strictEqual(env.PI_CODING_AGENT_SESSION_DIR, "/tmp/pi-sessions");
+      assert.strictEqual(env.PI_RPC_TEST_MARKER, undefined);
+      assert.strictEqual(env.SSH_AUTH_SOCK, undefined);
+      assert.strictEqual(env.TAVILY_API_KEY, undefined);
+      assert.strictEqual(env.TELEGRAM_BOT_TOKEN, undefined);
+      assert.strictEqual(env.MINIME_SESSION_SECRET, undefined);
+      assert.strictEqual(env.ANTHROPIC_OAUTH_TOKEN, undefined);
+      assert.strictEqual(env.AWS_ACCESS_KEY_ID, undefined);
+      assert.strictEqual(env.AWS_SECRET_ACCESS_KEY, undefined);
+      assert.strictEqual(env.AWS_SESSION_TOKEN, undefined);
+      assert.strictEqual(env.GITHUB_TOKEN, undefined);
+      assert.strictEqual(env.GOOGLE_APPLICATION_CREDENTIALS, undefined);
+      assert.strictEqual(env.LC_CTYPE, "UTF-8");
+      assert.strictEqual(env.LC_SECRET, undefined);
+      assert.strictEqual(env.NPM_TOKEN, undefined);
+      assert.strictEqual(env.OPENAI_API_KEY, undefined);
     } finally {
-      if (oldClaudeToken === undefined) {
-        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-      } else {
-        process.env.CLAUDE_CODE_OAUTH_TOKEN = oldClaudeToken;
-      }
-
-      if (oldApiKey === undefined) {
-        delete process.env.ANTHROPIC_API_KEY;
-      } else {
-        process.env.ANTHROPIC_API_KEY = oldApiKey;
-      }
-
-      if (oldMarker === undefined) {
-        delete process.env.PI_RPC_TEST_MARKER;
-      } else {
-        process.env.PI_RPC_TEST_MARKER = oldMarker;
+      for (const key of envKeys) {
+        const oldValue = oldValues.get(key);
+        if (oldValue === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = oldValue;
+        }
       }
     }
   });

--- a/bot/src/__tests__/run-cron-wrapper.test.ts
+++ b/bot/src/__tests__/run-cron-wrapper.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const runCronScript = resolve(__dirname, "../../scripts/run-cron.sh");
+
+describe("run-cron.sh", () => {
+  it("continues without CLAUDE_CODE_OAUTH_TOKEN when the Keychain lookup fails", () => {
+    const fixture = mkdtempSync(join(tmpdir(), "run-cron-wrapper-"));
+    const binDir = join(fixture, "bin");
+    const captureFile = join(fixture, "capture.txt");
+
+    try {
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(binDir, "security"), "#!/bin/bash\nexit 44\n", "utf8");
+      writeFileSync(
+        join(binDir, "npx"),
+        `#!/bin/bash
+{
+  printf 'args=%s\\n' "$*"
+  printf 'token=%s\\n' "\${CLAUDE_CODE_OAUTH_TOKEN-__unset__}"
+  printf 'anthropic=%s\\n' "\${ANTHROPIC_API_KEY-__unset__}"
+  printf 'claudecode=%s\\n' "\${CLAUDECODE-__unset__}"
+} > "$CAPTURE_FILE"
+`,
+        "utf8",
+      );
+      chmodSync(join(binDir, "security"), 0o755);
+      chmodSync(join(binDir, "npx"), 0o755);
+
+      const result = spawnSync("/bin/bash", [runCronScript, "pi-task"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: fixture,
+          PATH: "",
+          MINIME_PATH_PREFIX: `${binDir}:/usr/bin:/bin:/usr/sbin:/sbin`,
+          CAPTURE_FILE: captureFile,
+          CLAUDE_CODE_OAUTH_TOKEN: "stale-token",
+          ANTHROPIC_API_KEY: "stale-anthropic-key",
+          CLAUDECODE: "stale-claudecode",
+        },
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr || result.stdout || "run-cron.sh failed");
+      const capture = readFileSync(captureFile, "utf8");
+      assert.match(capture, /^args=tsx src\/cron-runner\.ts --task pi-task$/m);
+      assert.match(capture, /^token=__unset__$/m);
+      assert.match(capture, /^anthropic=__unset__$/m);
+      assert.match(capture, /^claudecode=__unset__$/m);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});

--- a/bot/src/__tests__/run-cron-wrapper.test.ts
+++ b/bot/src/__tests__/run-cron-wrapper.test.ts
@@ -26,6 +26,7 @@ describe("run-cron.sh", () => {
   printf 'token=%s\\n' "\${CLAUDE_CODE_OAUTH_TOKEN-__unset__}"
   printf 'anthropic=%s\\n' "\${ANTHROPIC_API_KEY-__unset__}"
   printf 'claudecode=%s\\n' "\${CLAUDECODE-__unset__}"
+  printf 'path=%s\\n' "$PATH"
 } > "$CAPTURE_FILE"
 `,
         "utf8",
@@ -53,6 +54,8 @@ describe("run-cron.sh", () => {
       assert.match(capture, /^token=__unset__$/m);
       assert.match(capture, /^anthropic=__unset__$/m);
       assert.match(capture, /^claudecode=__unset__$/m);
+      const pathLine = capture.split("\n").find((line) => line.startsWith("path="));
+      assert.strictEqual(pathLine, `path=${binDir}:/usr/bin:/bin:/usr/sbin:/sbin`);
     } finally {
       rmSync(fixture, { recursive: true, force: true });
     }

--- a/bot/src/cron-plist.ts
+++ b/bot/src/cron-plist.ts
@@ -1,0 +1,29 @@
+export interface CronPlistDef {
+  name: string;
+  schedule: string;
+  type?: "llm" | "script";
+  engine?: "claude" | "pi";
+  prompt?: string;
+  command?: string;
+  agentId: string;
+  deliveryChatId?: number;
+  timeout?: number;
+  enabled?: boolean;
+}
+
+export function validateCronForPlist(cron: CronPlistDef): string | undefined {
+  const cronType = cron.type ?? "llm";
+  if (cronType !== "llm" && cronType !== "script") {
+    return `${cron.name} has invalid type "${cron.type}" (must be "llm" or "script")`;
+  }
+  if (cronType === "llm" && cron.engine !== undefined && cron.engine !== "claude" && cron.engine !== "pi") {
+    return `${cron.name} has invalid engine "${cron.engine}" (must be "claude" or "pi")`;
+  }
+  if (cronType === "script" && (!cron.command || !cron.command.trim())) {
+    return `${cron.name} is type "script" but missing required "command" field`;
+  }
+  if (cronType === "llm" && (!cron.prompt || !cron.prompt.trim())) {
+    return `${cron.name} is type "llm" but missing required "prompt" field`;
+  }
+  return undefined;
+}

--- a/bot/src/cron-runner.ts
+++ b/bot/src/cron-runner.ts
@@ -2,15 +2,29 @@
 // Usage: npx tsx src/cron-runner.ts --task <name>
 // Loads cron definition from crons.yaml, runs claude -p one-shot, delivers output to Telegram
 
-import { readFileSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, appendFileSync, mkdirSync, existsSync, writeFileSync, renameSync } from "node:fs";
 import { loadRawMergedConfig } from "./config.js";
-import { execSync } from "node:child_process";
+import {
+  execSync,
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from "node:child_process";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 import { parse as parseYaml } from "yaml";
 import type { CronJob, AgentConfig } from "./types.js";
 import { shouldSuppressNoReply } from "./no-reply.js";
+import {
+  buildPiSpawnEnv,
+  resolvePiExtensionArgs,
+  PI_SUBAGENT_CHILD_WRAPPER_RELPATHS,
+  PI_EXTENSIONS_DISABLED_ENV,
+  shouldIncludePiChildEnvKey,
+} from "./pi-rpc-protocol.js";
+import { assemblePiContext } from "./pi-context-assembler.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BOT_DIR = resolve(__dirname, "..");
@@ -20,6 +34,45 @@ const LOG_DIR = process.env.LOG_DIR ?? join(homedir(), ".minime", "logs");
 const DELIVER_SCRIPT = resolve(BOT_DIR, "scripts", "deliver.sh");
 
 const DEFAULT_TIMEOUT_MS = 900000; // 15 minutes
+const DEFAULT_CRON_HEALTH_TEXTFILE_DIR = "/opt/homebrew/var/node_exporter/textfile";
+const PI_CRON_MODEL = "openai-codex/gpt-5.5";
+const PI_BIN = "pi";
+const PI_ERROR_EXCERPT_CHARS = 1000;
+type PiThinkingLevel = NonNullable<AgentConfig["effort"]>;
+const PI_THINKING_LEVELS = new Set<PiThinkingLevel>(["low", "medium", "high"]);
+export interface CronAgentData {
+  id: string;
+  workspaceCwd: string;
+  systemPrompt?: string;
+  effort?: AgentConfig["effort"];
+}
+
+export type PiRunResult =
+  | { status: "ok"; output: string }
+  | { status: "error"; message: string; diagnostics?: string };
+type PiErrorRunResult = Extract<PiRunResult, { status: "error" }>;
+
+class CronRunError extends Error {
+  diagnostics?: string;
+
+  constructor(message: string, diagnostics?: string) {
+    super(message);
+    this.name = "CronRunError";
+    this.diagnostics = diagnostics;
+  }
+}
+
+function errorFromUnknown(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+function cronErrorDiagnostics(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null || !("diagnostics" in err)) {
+    return undefined;
+  }
+  const diagnostics = (err as { diagnostics?: unknown }).diagnostics;
+  return typeof diagnostics === "string" && diagnostics.trim() ? diagnostics : undefined;
+}
 
 function log(taskName: string, msg: string): void {
   mkdirSync(LOG_DIR, { recursive: true });
@@ -27,6 +80,76 @@ function log(taskName: string, msg: string): void {
   const line = `[${new Date().toISOString()}] ${msg}\n`;
   appendFileSync(logFile, line);
   process.stderr.write(line);
+}
+
+function shortStableHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function sanitizeCronMetricStem(cronName: string): string {
+  const safeName = cronName.trim()
+    .replace(/[^A-Za-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return `${safeName || "unnamed"}_${shortStableHash(cronName)}`;
+}
+
+function escapePrometheusLabelValue(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/"/g, "\\\"");
+}
+
+function writeAtomicTextFile(dir: string, fileName: string, content: string): void {
+  const filePath = join(dir, fileName);
+  const tmpPath = join(
+    dir,
+    `.${fileName}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, filePath);
+}
+
+function writeCronHealthMetric(cronName: string, exitCode: number, success: boolean): void {
+  const fileStem = sanitizeCronMetricStem(cronName);
+  const label = escapePrometheusLabelValue(cronName);
+  const dir = process.env.CRON_HEALTH_TEXTFILE_DIR ?? DEFAULT_CRON_HEALTH_TEXTFILE_DIR;
+  const normalizedExitCode = Number.isFinite(exitCode) ? Math.trunc(exitCode) : 1;
+
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    process.stderr.write(
+      `[cron-runner] WARN: failed to prepare cron health metric dir for "${cronName}": ${(err as Error).message}\n`,
+    );
+    return;
+  }
+
+  if (success) {
+    try {
+      writeAtomicTextFile(
+        dir,
+        `minime_cron_${fileStem}.success.prom`,
+        `minime_cron_last_success_timestamp{cron="${label}"} ${Math.floor(Date.now() / 1000)}\n`,
+      );
+    } catch (err) {
+      process.stderr.write(
+        `[cron-runner] WARN: failed to write cron health success metric for "${cronName}": ${(err as Error).message}\n`,
+      );
+    }
+  }
+
+  try {
+    writeAtomicTextFile(
+      dir,
+      `minime_cron_${fileStem}.exit.prom`,
+      `minime_cron_last_exit_code{cron="${label}"} ${normalizedExitCode}\n`,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `[cron-runner] WARN: failed to write cron health exit metric for "${cronName}": ${(err as Error).message}\n`,
+    );
+  }
 }
 
 interface CronsYaml {
@@ -135,6 +258,15 @@ function loadCronTask(taskName: string, cronsPath?: string, defaults?: DeliveryD
   if (typeof c.timeout === "number" && (!Number.isFinite(c.timeout) || c.timeout <= 0)) {
     throw new Error(`Task "${taskName}" has invalid 'timeout' (${c.timeout}): must be a positive number`);
   }
+
+  let engine: CronJob["engine"];
+  if (cronType === "llm" && c.engine !== undefined) {
+    if (c.engine !== "claude" && c.engine !== "pi") {
+      throw new Error(`Task "${taskName}" has invalid 'engine' "${c.engine}" (must be "claude" or "pi")`);
+    }
+    engine = c.engine;
+  }
+
   return {
     name: String(c.name),
     schedule: String(c.schedule ?? ""),
@@ -146,18 +278,70 @@ function loadCronTask(taskName: string, cronsPath?: string, defaults?: DeliveryD
     deliveryThreadId,
     timeout: typeof c.timeout === "number" ? c.timeout : undefined,
     enabled: c.enabled === false ? false : undefined,
+    engine,
   };
 }
 
-function getAgentWorkspace(agentId: string): string {
-  const raw = loadRawMergedConfig() as {
+function isCronPiEffort(value: unknown): value is PiThinkingLevel {
+  return typeof value === "string" && PI_THINKING_LEVELS.has(value as PiThinkingLevel);
+}
+
+function resolveCronAgentData(agentId: string, configPath?: string): CronAgentData {
+  const raw = loadRawMergedConfig(configPath) as {
     agents?: Record<string, unknown>;
   };
-  if (!raw?.agents?.[agentId]) {
+  if (
+    typeof raw?.agents !== "object" ||
+    raw.agents === null ||
+    !Object.prototype.hasOwnProperty.call(raw.agents, agentId)
+  ) {
     throw new Error(`Agent "${agentId}" not found in config.yaml / config.local.yaml`);
   }
-  const agent = raw.agents[agentId] as AgentConfig;
-  return agent.workspaceCwd;
+  const rawAgent = raw.agents[agentId];
+  if (typeof rawAgent !== "object" || rawAgent === null) {
+    throw new Error(`Agent "${agentId}" missing workspaceCwd`);
+  }
+
+  const agent = rawAgent as Record<string, unknown>;
+  if (typeof agent.workspaceCwd !== "string" || !agent.workspaceCwd.trim()) {
+    throw new Error(`Agent "${agentId}" missing workspaceCwd`);
+  }
+
+  const result: CronAgentData = {
+    id: agentId,
+    workspaceCwd: agent.workspaceCwd,
+  };
+  if (typeof agent.systemPrompt === "string") {
+    result.systemPrompt = agent.systemPrompt;
+  }
+  if (isCronPiEffort(agent.effort)) {
+    result.effort = agent.effort;
+  }
+  return result;
+}
+
+function buildPiCronAgentConfig(agentId: string, configPath?: string): AgentConfig {
+  return buildPiCronAgentConfigFromData(resolveCronAgentData(agentId, configPath));
+}
+
+function buildPiCronAgentConfigFromData(agent: CronAgentData): AgentConfig {
+  const result: AgentConfig = {
+    id: agent.id,
+    workspaceCwd: agent.workspaceCwd,
+    provider: "pi",
+    model: PI_CRON_MODEL,
+  };
+  if (agent.systemPrompt !== undefined) {
+    result.systemPrompt = agent.systemPrompt;
+  }
+  if (agent.effort !== undefined) {
+    result.effort = agent.effort;
+  }
+  return result;
+}
+
+function getAgentWorkspace(agentId: string, configPath?: string): string {
+  return resolveCronAgentData(agentId, configPath).workspaceCwd;
 }
 
 export function loadAdminChatId(configPath?: string): number | undefined {
@@ -267,8 +451,8 @@ function runScript(cron: CronJob): string {
 }
 
 function runClaude(cron: CronJob, workspaceCwd: string): string {
-  const today = new Date().toISOString().split("T")[0];
   const timeoutMs = cron.timeout ?? DEFAULT_TIMEOUT_MS;
+  const systemInstruction = buildCronSystemInstruction();
 
   const args: string[] = [
     "claude",
@@ -287,7 +471,7 @@ function runClaude(cron: CronJob, workspaceCwd: string): string {
     "--add-dir",
     workspaceCwd,
     "--append-system-prompt",
-    `Today is ${today}. Respond concisely.`,
+    systemInstruction,
   ];
 
   // Build env without CLAUDECODE and without ANTHROPIC_API_KEY
@@ -311,102 +495,377 @@ function runClaude(cron: CronJob, workspaceCwd: string): string {
   return output.trim();
 }
 
+function normalizeSpawnOutput(value: string | Buffer | null | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  return value;
+}
+
+function buildCronSystemInstruction(): string {
+  const today = new Date().toISOString().split("T")[0];
+  return `Today is ${today}. Respond concisely.`;
+}
+
+function sanitizeCapturedOutput(value: string): string {
+  return value
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "?")
+    .trim();
+}
+
+function formatCapturedOutputExcerpt(label: "stdout" | "stderr", value: string): string | undefined {
+  const trimmed = sanitizeCapturedOutput(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= PI_ERROR_EXCERPT_CHARS) {
+    return `${label}: ${trimmed}`;
+  }
+
+  const excerpt = trimmed.slice(0, PI_ERROR_EXCERPT_CHARS);
+  return `${label} (first ${PI_ERROR_EXCERPT_CHARS} chars): ${excerpt}... [truncated ${trimmed.length - PI_ERROR_EXCERPT_CHARS} chars]`;
+}
+
+function piErrorResult(summary: string, stdout: string, stderr: string): PiErrorRunResult {
+  const details = [
+    formatCapturedOutputExcerpt("stderr", stderr),
+    formatCapturedOutputExcerpt("stdout", stdout),
+  ].filter((line): line is string => line !== undefined);
+  return {
+    status: "error",
+    message: summary,
+    diagnostics: details.length > 0 ? details.join("; ") : undefined,
+  };
+}
+
+function classifyPiResult(
+  exitCode: number | null | undefined,
+  signal: NodeJS.Signals | string | null | undefined,
+  stdoutValue: string | Buffer | null | undefined,
+  stderrValue: string | Buffer | null | undefined,
+): PiRunResult {
+  const stdout = normalizeSpawnOutput(stdoutValue);
+  const stderr = normalizeSpawnOutput(stderrValue);
+  const trimmedStdout = stdout.trim();
+  const trimmedStderr = stderr.trim();
+
+  if (signal) {
+    return piErrorResult(`Pi cron exited with signal ${signal}`, stdout, stderr);
+  }
+  if (exitCode !== 0) {
+    const summary = typeof exitCode === "number"
+      ? `Pi cron exited with code ${exitCode}`
+      : "Pi cron exited without an exit code";
+    return piErrorResult(summary, stdout, stderr);
+  }
+  if (trimmedStdout) {
+    return { status: "ok", output: trimmedStdout };
+  }
+  if (trimmedStderr) {
+    return piErrorResult("Pi cron produced stderr without stdout", stdout, stderr);
+  }
+  return { status: "ok", output: "" };
+}
+
+type PiSpawnSync = (
+  command: string,
+  args: string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+) => SpawnSyncReturns<string>;
+
+export interface PiRunDeps {
+  spawnSync: PiSpawnSync;
+  buildAgentConfig: (cron: CronJob, workspaceCwd: string, agentData?: CronAgentData) => AgentConfig;
+  buildEnv: (agent: AgentConfig) => Record<string, string>;
+  assembleContext: typeof assemblePiContext;
+  resolveExtensionArgs: typeof resolvePiExtensionArgs;
+}
+
+function buildPiCronAgentConfigForRun(cron: CronJob, workspaceCwd: string, agentData?: CronAgentData): AgentConfig {
+  const agent = agentData ?? resolveCronAgentData(cron.agentId);
+  return buildPiCronAgentConfigFromData({ ...agent, workspaceCwd });
+}
+
+const defaultPiDeps: PiRunDeps = {
+  spawnSync,
+  buildAgentConfig: buildPiCronAgentConfigForRun,
+  buildEnv: buildPiSpawnEnv,
+  assembleContext: assemblePiContext,
+  resolveExtensionArgs: resolvePiExtensionArgs,
+};
+
+function resolvePiCronExtensionArgs(resolveExtensionArgs: typeof resolvePiExtensionArgs): string[] {
+  if (process.env[PI_EXTENSIONS_DISABLED_ENV] === "1") {
+    throw new Error(`${PI_EXTENSIONS_DISABLED_ENV}=1 cannot disable the required Pi cron guard extension; set CRON_PI_DISABLED=1 to run Pi crons on Claude`);
+  }
+
+  const extensionArgs = resolveExtensionArgs({ relpaths: PI_SUBAGENT_CHILD_WRAPPER_RELPATHS });
+  if (extensionArgs.length === 0) {
+    throw new Error("Pi cron extension resolver returned no guard extension; refusing to spawn an unguarded Pi cron");
+  }
+  return extensionArgs;
+}
+
+function hardenPiCronEnv(rawEnv: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawEnv)) {
+    if (shouldIncludePiChildEnvKey(key)) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function buildPiCronPromptArg(prompt: string): string {
+  // Pi parses leading "-" as options and leading "@" as file references.
+  return prompt.startsWith("-") || prompt.startsWith("@") ? ` ${prompt}` : prompt;
+}
+
+function runPi(
+  cron: CronJob,
+  workspaceCwd: string,
+  deps: PiRunDeps = defaultPiDeps,
+  agentData?: CronAgentData,
+): string {
+  if (!cron.prompt) {
+    throw new Error(`Pi cron "${cron.name}" has no prompt`);
+  }
+
+  const agent = deps.buildAgentConfig(cron, workspaceCwd, agentData);
+  const thinking = isCronPiEffort(agent.effort) ? agent.effort : "medium";
+  const systemInstruction = buildCronSystemInstruction();
+  const args: string[] = [
+    "-p",
+    buildPiCronPromptArg(cron.prompt),
+    "--no-session",
+    "--no-extensions",
+    "--model",
+    PI_CRON_MODEL,
+    "--thinking",
+    thinking,
+  ];
+
+  const context = deps.assembleContext(agent);
+  if (context) {
+    if (context.systemPromptPath) {
+      args.push("--system-prompt", context.systemPromptPath);
+    }
+    args.push("--append-system-prompt", context.appendSystemPromptPath);
+    args.push("--no-context-files");
+  }
+
+  args.push("--append-system-prompt", systemInstruction);
+  args.push(...resolvePiCronExtensionArgs(deps.resolveExtensionArgs));
+
+  const env = hardenPiCronEnv(deps.buildEnv(agent));
+  // Pi authenticates via ~/.pi/agent/auth.json, not Claude OAuth credentials.
+  env.HOME ||= homedir();
+
+  const result = deps.spawnSync(PI_BIN, args, {
+    cwd: workspaceCwd,
+    timeout: cron.timeout ?? DEFAULT_TIMEOUT_MS,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    env,
+  });
+
+  if (result.error) {
+    const spawnError = piErrorResult(`Pi cron spawn failed: ${result.error.message}`, result.stdout, result.stderr);
+    throw new CronRunError(spawnError.message, spawnError.diagnostics);
+  }
+
+  const classified = classifyPiResult(result.status, result.signal, result.stdout, result.stderr);
+  if (classified.status === "error") {
+    throw new CronRunError(classified.message, classified.diagnostics);
+  }
+  return classified.output;
+}
+
+function resolveCronEngine(cron: CronJob): "claude" | "pi" {
+  const engine = cron.engine ?? "claude";
+  if (engine === "pi" && process.env.CRON_PI_DISABLED === "1") {
+    return "claude";
+  }
+  return engine;
+}
+
+interface OneShotDeps {
+  runClaude: (cron: CronJob, workspaceCwd: string) => string;
+  runPi: (cron: CronJob, workspaceCwd: string, agentData?: CronAgentData) => string;
+}
+
+const defaultOneShotDeps: OneShotDeps = {
+  runClaude,
+  runPi: (cron, workspaceCwd, agentData) => runPi(cron, workspaceCwd, defaultPiDeps, agentData),
+};
+
+function runOneShot(
+  cron: CronJob,
+  workspaceCwd: string,
+  deps: OneShotDeps = defaultOneShotDeps,
+  agentData?: CronAgentData,
+): string {
+  const engine = resolveCronEngine(cron);
+  if (engine === "pi") {
+    return deps.runPi(cron, workspaceCwd, agentData);
+  }
+  return deps.runClaude(cron, workspaceCwd);
+}
+
 function shellEscape(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
-async function main(): Promise<void> {
-  const taskIdx = process.argv.indexOf("--task");
-  if (taskIdx === -1 || !process.argv[taskIdx + 1]) {
-    console.error("Usage: cron-runner.ts --task <name>");
-    process.exit(1);
-  }
-  const taskName = process.argv[taskIdx + 1];
+export interface CronRunnerMainDeps {
+  argv: string[];
+  consoleError: (message?: unknown, ...optionalParams: unknown[]) => void;
+  exit: (code: number) => never;
+  log: (taskName: string, msg: string) => void;
+  loadDefaultDelivery: (configPath?: string) => DeliveryDefaults;
+  loadCronTask: (taskName: string, cronsPath?: string, defaults?: DeliveryDefaults) => CronJob;
+  loadAdminChatId: (configPath?: string) => number | undefined;
+  resolveCronAgentData: (agentId: string, configPath?: string) => CronAgentData;
+  runScript: (cron: CronJob) => string;
+  runClaude: (cron: CronJob, workspaceCwd: string) => string;
+  runPi: (cron: CronJob, workspaceCwd: string, agentData?: CronAgentData) => string;
+  deliver: (chatId: number, message: string, threadId?: number) => void;
+  handleDeliveryFailure: (
+    cronName: string,
+    targetChatId: number,
+    errorMsg: string,
+    adminChatId: number | undefined,
+  ) => void;
+  writeCronHealthMetric: (cronName: string, exitCode: number, success: boolean) => void;
+}
 
-  log(taskName, `Starting cron task: ${taskName}`);
+const defaultMainDeps: Omit<CronRunnerMainDeps, "argv"> = {
+  consoleError: console.error,
+  exit: (code: number): never => process.exit(code),
+  log,
+  loadDefaultDelivery,
+  loadCronTask,
+  loadAdminChatId,
+  resolveCronAgentData,
+  runScript,
+  runClaude,
+  runPi: (cron, workspaceCwd, agentData) => runPi(cron, workspaceCwd, defaultPiDeps, agentData),
+  deliver,
+  handleDeliveryFailure,
+  writeCronHealthMetric,
+};
+
+async function main(overrides: Partial<CronRunnerMainDeps> = {}): Promise<void> {
+  const deps: CronRunnerMainDeps = {
+    ...defaultMainDeps,
+    argv: process.argv,
+    ...overrides,
+  };
+
+  const taskIdx = deps.argv.indexOf("--task");
+  if (taskIdx === -1 || !deps.argv[taskIdx + 1]) {
+    deps.consoleError("Usage: cron-runner.ts --task <name>");
+    deps.writeCronHealthMetric("unknown", 1, false);
+    deps.exit(1);
+  }
+  const taskName = deps.argv[taskIdx + 1];
+
+  deps.log(taskName, `Starting cron task: ${taskName}`);
 
   let defaults: DeliveryDefaults = {};
   try {
-    defaults = loadDefaultDelivery();
+    defaults = deps.loadDefaultDelivery();
   } catch (err) {
-    log(taskName, `WARN: could not load delivery defaults from config: ${(err as Error).message}`);
+    deps.log(taskName, `WARN: could not load delivery defaults from config: ${(err as Error).message}`);
   }
 
   let cron: CronJob;
   try {
-    cron = loadCronTask(taskName, undefined, defaults);
+    cron = deps.loadCronTask(taskName, undefined, defaults);
   } catch (err) {
-    log(taskName, `FAIL: ${(err as Error).message}`);
-    process.exit(1);
+    deps.log(taskName, `FAIL: ${(err as Error).message}`);
+    deps.writeCronHealthMetric(taskName, 1, false);
+    deps.exit(1);
   }
 
   let adminChatId: number | undefined;
   try {
-    adminChatId = loadAdminChatId();
+    adminChatId = deps.loadAdminChatId();
   } catch (err) {
-    log(taskName, `WARN: could not load adminChatId from config: ${(err as Error).message}`);
+    deps.log(taskName, `WARN: could not load adminChatId from config: ${(err as Error).message}`);
   }
 
-  log(taskName, `Loaded: type=${cron.type}, agent=${cron.agentId}, deliver=${cron.deliveryChatId}${cron.deliveryThreadId ? `, thread=${cron.deliveryThreadId}` : ""}`);
-
-  let workspaceCwd: string | undefined;
-  if (cron.type !== "script") {
-    try {
-      workspaceCwd = getAgentWorkspace(cron.agentId);
-    } catch (err) {
-      log(taskName, `FAIL: ${(err as Error).message}`);
-      process.exit(1);
-    }
-  }
+  deps.log(taskName, `Loaded: type=${cron.type}, agent=${cron.agentId}, deliver=${cron.deliveryChatId}${cron.deliveryThreadId ? `, thread=${cron.deliveryThreadId}` : ""}`);
 
   let output: string;
   try {
     if (cron.type === "script") {
-      output = runScript(cron);
-      log(taskName, `Script returned ${output.length} chars`);
+      output = deps.runScript(cron);
+      deps.log(taskName, `Script returned ${output.length} chars`);
     } else {
-      output = runClaude(cron, workspaceCwd!);
-      log(taskName, `Claude returned ${output.length} chars`);
+      const cronAgentData = deps.resolveCronAgentData(cron.agentId);
+      const workspaceCwd = cronAgentData.workspaceCwd;
+      const engine = resolveCronEngine(cron);
+      output = runOneShot(
+        cron,
+        workspaceCwd,
+        { runClaude: deps.runClaude, runPi: deps.runPi },
+        cronAgentData,
+      );
+      deps.log(taskName, `LLM engine=${engine} returned ${output.length} chars`);
     }
   } catch (err) {
-    const errMsg = `Cron task "${taskName}" failed: ${(err as Error).message}`;
-    log(taskName, `FAIL: ${errMsg}`);
+    const error = errorFromUnknown(err);
+    const errMsg = `Cron task "${taskName}" failed: ${error.message}`;
+    deps.log(taskName, `FAIL: ${errMsg}`);
+    const diagnostics = cronErrorDiagnostics(err);
+    if (diagnostics) {
+      deps.log(taskName, `FAIL diagnostics: ${diagnostics}`);
+    }
 
     // Send failure notification to delivery chat; use admin fallback if delivery fails
     try {
-      deliver(cron.deliveryChatId, `⚠️ Cron FAIL: ${taskName}\n${errMsg.slice(0, 500)}`, cron.deliveryThreadId);
+      deps.deliver(cron.deliveryChatId, `⚠️ Cron FAIL: ${taskName}\n${errMsg.slice(0, 500)}`, cron.deliveryThreadId);
     } catch (deliveryErr) {
-      handleDeliveryFailure(
+      deps.handleDeliveryFailure(
         taskName,
         cron.deliveryChatId,
         `${errMsg.slice(0, 400)}\n(notification delivery failed: ${(deliveryErr as Error).message})`,
         adminChatId,
       );
     }
-    process.exit(1);
+    deps.writeCronHealthMetric(taskName, 1, false);
+    deps.exit(1);
   }
 
   if (!output) {
-    log(taskName, "WARN: empty output — skipping delivery");
-    log(taskName, "DONE");
+    deps.log(taskName, "WARN: empty output — skipping delivery");
+    deps.writeCronHealthMetric(taskName, 0, true);
+    deps.log(taskName, "DONE");
     return;
   }
   if (cron.type === "llm" && shouldSuppressNoReply(output)) {
-    log(taskName, "NO_REPLY — skipping delivery");
-    log(taskName, "DONE");
+    deps.log(taskName, "NO_REPLY — skipping delivery");
+    deps.writeCronHealthMetric(taskName, 0, true);
+    deps.log(taskName, "DONE");
     return;
   }
 
   // Deliver output to target chat
   try {
-    deliver(cron.deliveryChatId, output, cron.deliveryThreadId);
-    log(taskName, `Delivered to chat ${cron.deliveryChatId}${cron.deliveryThreadId ? ` thread ${cron.deliveryThreadId}` : ""}`);
+    deps.deliver(cron.deliveryChatId, output, cron.deliveryThreadId);
+    deps.log(taskName, `Delivered to chat ${cron.deliveryChatId}${cron.deliveryThreadId ? ` thread ${cron.deliveryThreadId}` : ""}`);
   } catch (err) {
-    handleDeliveryFailure(taskName, cron.deliveryChatId, (err as Error).message, adminChatId);
-    process.exit(1);
+    deps.handleDeliveryFailure(taskName, cron.deliveryChatId, (err as Error).message, adminChatId);
+    deps.writeCronHealthMetric(taskName, 1, false);
+    deps.exit(1);
   }
 
-  log(taskName, "DONE");
+  deps.writeCronHealthMetric(taskName, 0, true);
+  deps.log(taskName, "DONE");
 }
 
 // Only run main() when executed directly (not when imported in tests)
@@ -417,4 +876,4 @@ if (isMain) {
   main();
 }
 
-export { loadCronTask, getAgentWorkspace, deliver, buildDeliverCommand, runClaude, runScript, shellEscape };
+export { loadCronTask, resolveCronAgentData, buildPiCronAgentConfig, getAgentWorkspace, deliver, buildDeliverCommand, runClaude, runPi, runOneShot, resolveCronEngine, classifyPiResult, writeCronHealthMetric, runScript, shellEscape, main };

--- a/bot/src/cron-runner.ts
+++ b/bot/src/cron-runner.ts
@@ -96,6 +96,7 @@ function sanitizeCronMetricStem(cronName: string): string {
 function escapePrometheusLabelValue(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
+    .replace(/\r/g, "\\r")
     .replace(/\n/g, "\\n")
     .replace(/"/g, "\\\"");
 }

--- a/bot/src/pi-context-assembler.ts
+++ b/bot/src/pi-context-assembler.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { createHash } from "node:crypto";
 import type { AgentConfig } from "./types.js";
 import { log } from "./logger.js";
 
@@ -52,6 +53,18 @@ export interface ContextSection {
 }
 
 export type PiArtifactKind = "bundle" | "persona";
+
+function safeArtifactAgentId(agentId: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(agentId)) {
+    return agentId;
+  }
+  const stem = agentId
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const hash = createHash("sha256").update(agentId).digest("hex").slice(0, 12);
+  return `${stem || "agent"}-${hash}`;
+}
 
 /**
  * A standalone `@<path>` import line: optional leading whitespace, `@`, a single
@@ -345,7 +358,7 @@ function readOutputStyleContent(workspaceCwd: string): string | null {
 
 /**
  * Atomically write a bundle/persona artifact to a STABLE per-agent path under
- * `<workspaceCwd>/.tmp/`: `pi-context-<agentId>.<kind>.md`. Write a staging file
+ * `<workspaceCwd>/.tmp/`: `pi-context-<safe-agent-id>.<kind>.md`. Write a staging file
  * (`<path>.tmp.<pid>`) then `renameSync` over the final path, so a concurrent
  * reader never sees a half-written file. Stable path ⇒ no accumulation, no cleanup
  * job. Returns the final path. May throw (e.g. unwritable `.tmp/`) — the caller
@@ -359,7 +372,7 @@ export function writeTempArtifact(
 ): string {
   const tmpDir = join(workspaceCwd, ".tmp");
   mkdirSync(tmpDir, { recursive: true });
-  const finalPath = join(tmpDir, `pi-context-${agentId}.${kind}.md`);
+  const finalPath = join(tmpDir, `pi-context-${safeArtifactAgentId(agentId)}.${kind}.md`);
   const stagingPath = `${finalPath}.tmp.${process.pid}`;
   writeFileSync(stagingPath, content, "utf8");
   renameSync(stagingPath, finalPath);

--- a/bot/src/pi-extensions/README.md
+++ b/bot/src/pi-extensions/README.md
@@ -57,14 +57,17 @@ If a wrapper ever grows logic worth testing, move that logic into a
 
 ## Context assembler (Claude→Pi parity at spawn)
 
-`bot/src/pi-context-assembler.ts` gives a `provider: "pi"` spawn the SAME context a
-Claude Code session loads. Pi reads context files as FLAT text — no `@`-import
-expansion, no `.claude/rules/` auto-load, no memory recall — so an agent's
-CLAUDE.md `@`-imports and rule files silently vanish under Pi. The assembler reads
-the agent's LIVE workspace files (zero drift, always fresh) and hands the result to
-Pi via CLI args. It is wired into `buildPiSpawnArgs` in
-`bot/src/pi-rpc-protocol.ts`, and runs ONLY for `provider: "pi"` — the
-`claude -p` path is untouched.
+`bot/src/pi-context-assembler.ts` gives Pi spawns the SAME context a Claude Code
+session loads. Pi reads context files as FLAT text — no `@`-import expansion, no
+`.claude/rules/` auto-load, no memory recall — so an agent's CLAUDE.md
+`@`-imports and rule files silently vanish under Pi. The assembler reads the
+agent's LIVE workspace files (zero drift, always fresh) and hands the result to Pi
+via CLI args. It is wired into `buildPiSpawnArgs` in
+`bot/src/pi-rpc-protocol.ts` for `provider: "pi"` RPC sessions, and `cron-runner.ts`
+also calls it directly for `engine: pi` print-mode crons. For crons, the runner
+builds a minimal Pi agent from `agentId`, `workspaceCwd`, optional
+`systemPrompt`, and `effort`, then injects CLAUDE/MEMORY/rules context via files.
+The `claude -p` path is untouched.
 
 ### Layer mapping
 

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -88,6 +88,50 @@ export interface PiExtensionResolveOptions {
   relpaths?: readonly string[];
 }
 
+const PI_CHILD_ENV_KEY_ALLOWLIST = new Set([
+  "CI",
+  "COLORTERM",
+  "FORCE_COLOR",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "NO_COLOR",
+  "PATH",
+  "PI_CODING_AGENT_DIR",
+  "PI_CODING_AGENT_SESSION_DIR",
+  "PI_OFFLINE",
+  "PI_PACKAGE_DIR",
+  "PI_SHARE_VIEWER_URL",
+  "PI_SKIP_VERSION_CHECK",
+  "PI_TELEMETRY",
+  "SHELL",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+]);
+
+const PI_CHILD_LC_ENV_KEYS = new Set([
+  "LC_ALL",
+  "LC_COLLATE",
+  "LC_CTYPE",
+  "LC_MESSAGES",
+  "LC_MONETARY",
+  "LC_NUMERIC",
+  "LC_TIME",
+]);
+
+export function shouldIncludePiChildEnvKey(key: string): boolean {
+  return PI_CHILD_ENV_KEY_ALLOWLIST.has(key) || PI_CHILD_LC_ENV_KEYS.has(key);
+}
+
 /**
  * Resolve the repeatable `--extension <abs-path>` args for a Pi spawn.
  *
@@ -296,14 +340,14 @@ export function buildPiSpawnEnv(agent: AgentConfig): Record<string, string> {
 
   const env: Record<string, string> = {};
   for (const [key, val] of Object.entries(process.env)) {
-    if (val !== undefined) {
+    if (val !== undefined && shouldIncludePiChildEnvKey(key)) {
       env[key] = val;
     }
   }
 
-  // A Pi/Codex subprocess authenticates via ~/.pi/agent/auth.json and has no
-  // use for Anthropic credentials — scrub both so they never reach it (matches
-  // cron-runner.ts's sanitization of script subprocesses).
+  // A Pi/Codex subprocess authenticates via ~/.pi/agent/auth.json. Keep the
+  // child environment allowlisted so prompt-influenced agents do not inherit
+  // ambient credentials such as provider tokens or SSH agent sockets.
   delete env.CLAUDE_CODE_OAUTH_TOKEN;
   delete env.ANTHROPIC_API_KEY;
   // Parity with the Claude path (cli-protocol.ts): never leak the Claude Code

--- a/bot/src/pi-rpc-protocol.ts
+++ b/bot/src/pi-rpc-protocol.ts
@@ -358,9 +358,11 @@ export function buildPiSpawnEnv(agent: AgentConfig): Record<string, string> {
   // parent guard — only the subagent child spawn sets it (see the constant doc).
   delete env[PI_GUARD_WORKSPACE_ROOT_ENV];
 
-  if (!env.PATH?.includes("/opt/homebrew/bin")) {
-    env.PATH = `/opt/homebrew/bin:${env.PATH ?? ""}`;
+  const pathParts = (env.PATH ?? "").split(":").filter(Boolean);
+  if (!pathParts.includes("/opt/homebrew/bin")) {
+    pathParts.unshift("/opt/homebrew/bin");
   }
+  env.PATH = pathParts.join(":");
 
   return env;
 }

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -75,6 +75,7 @@ export interface CronJob {
   deliveryThreadId?: number;
   timeout?: number;
   enabled?: boolean;
+  engine?: "claude" | "pi";
 }
 
 export interface SessionState {

--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -23,7 +23,9 @@ agents:
     # model: opus[1m]
     # model: claude-haiku-4-5-20251001
     # provider: claude   # coding backend: "claude" (default, omit) or "pi" (Pi RPC + OpenAI Codex)
-    # thinking: xhigh    # optional for provider: pi; allowed: off, minimal, low, medium, high, xhigh
+    # thinking: xhigh    # optional for provider: pi sessions; allowed: off, minimal, low, medium, high, xhigh
+    # effort: high       # Pi crons map low/medium/high to --thinking; absent/unsupported defaults to medium
+                         # Cron engine is configured in crons*.yaml. Pi crons ignore provider/model/fallbackModel/maxTurns/allowedTools.
 
 bindings:
   - chatId: 123456789           # your Telegram user ID (get it from @userinfobot)

--- a/config.yaml
+++ b/config.yaml
@@ -29,12 +29,15 @@ agents:
     workspaceCwd: /tmp/minime-workspace   # override in config.local.yaml with your actual workspace path
     # model / fallbackModel omitted — inherited from defaultModel / defaultFallbackModel
     maxTurns: 250     # safety limit for agentic loops per message (omit for unlimited)
-    effort: high      # Claude reasoning effort: low, medium, high (omit for default)
+    effort: high      # Claude reasoning effort; Pi crons map this to --thinking (low, medium, high; omit for default medium)
     # provider: claude  # coding backend: "claude" (default, omit) or "pi" (Pi RPC + OpenAI Codex).
                         # "pi" routes the agent through the Pi coding agent; "claude" uses `claude -p`.
                         # A "pi" agent MUST set an explicit model (e.g. model: gpt-5.5) — it does
                         # not inherit defaultModel (which is Claude-oriented).
-                        # Optional for "pi": thinking: off|minimal|low|medium|high|xhigh.
+                        # Optional for "pi" sessions: thinking: off|minimal|low|medium|high|xhigh.
+                        # Cron backend selection is separate: set crons*.yaml `engine: pi` per LLM cron.
+                        # Pi crons ignore provider/model/fallbackModel/maxTurns/allowedTools and use workspaceCwd,
+                        # optional systemPrompt, and effort only.
 
   # Add more agents as needed:
   # coder:

--- a/crons.local.yaml.example
+++ b/crons.local.yaml.example
@@ -20,8 +20,11 @@ crons:
   # Your own crons:
   # - name: daily-briefing
   #   schedule: "0 9 * * *"           # 9:00 AM daily
+  #   engine: pi                       # optional for LLM crons; omit/defaults to claude
+  #                                    # separate from agent provider; uses fixed Pi model, workspaceCwd,
+  #                                    # optional systemPrompt, and effort->--thinking only
   #   prompt: >
   #     Give me a brief summary of what I should focus on today.
   #   agentId: main
   #   deliveryChatId: 123456789        # Replace with your Telegram chat ID
-  #   timeout: 300000
+  #   timeout: 900000

--- a/crons.yaml
+++ b/crons.yaml
@@ -8,17 +8,19 @@
 # Field reference:
 #   name              (string, required)  Unique identifier for the cron job
 #   schedule          (string, required)  Cron expression (5-field), local timezone
-#   type              ("llm"|"script")    "llm" (default) runs claude -p with prompt; "script" runs a shell command
-#   prompt            (string)            Prompt text sent to Claude (required for type: llm)
+#   type              ("llm"|"script")    "llm" (default) runs one-shot LLM prompt; "script" runs a shell command
+#   engine            ("claude"|"pi")     LLM backend for type: llm; default is "claude", set "pi" for fixed-model Pi print mode
+#   prompt            (string)            Prompt text sent to the selected LLM engine (required for type: llm)
 #   command           (string)            Shell command to execute (required for type: script)
 #   agentId           (string, required)  Must match an agent in config.yaml (determines workspace)
 #   deliveryChatId    (number)            Telegram chat ID for result delivery (falls back to config default)
 #   deliveryThreadId  (number)            Telegram forum topic ID for delivery (falls back to config default)
-#   timeout           (number)            Per-cron timeout in milliseconds (default: 300000 = 5 min)
+#   timeout           (number)            Per-cron timeout in milliseconds (default: 900000 = 15 min)
 #   enabled           (boolean)           Set false to skip plist generation for this cron (default: true)
 #
 # Script-mode crons execute via /bin/bash, capture stdout, and deliver like LLM crons.
 # They skip all Claude-specific setup (model, workspace, env vars). Empty output skips delivery.
+# Pi LLM crons always use pi -p --no-session --no-extensions with model openai-codex/gpt-5.5 and only the explicit A1 guard extension.
 
 crons:
   # Weekly workspace health check (uses /workspace-health skill)
@@ -45,4 +47,4 @@ crons:
   #   type: script
   #   command: "/usr/bin/backup.sh --full"
   #   agentId: main
-  #   timeout: 300000
+  #   timeout: 900000

--- a/docs/plans/completed/2026-06-05-plan-c-cron-runner-pi-port.md
+++ b/docs/plans/completed/2026-06-05-plan-c-cron-runner-pi-port.md
@@ -1,0 +1,273 @@
+# Plan C — Port `cron-runner.ts` from `claude -p` to vanilla Pi print mode
+
+## Revision Notes (round 2)
+
+- Fixed the round-1 critical blocker: Pi crons must use a literal `openai-codex/gpt-5.5`, never `agent.model` and never `normalizePiModel()`.
+- Removed the `normalizePiModel` import requirement; it is module-private in `pi-rpc-protocol.ts`.
+- Cut the `run-cron.sh`/`cron-engine.ts` OAuth provider-guard scope. `buildPiSpawnEnv()` already deletes Claude/Anthropic credentials before spawning Pi.
+- Simplified agent resolution: build a minimal Pi `AgentConfig` for context assembly instead of adding a heavyweight config re-validation path.
+- Simplified cron-health metrics: write last success only on success, write last exit code on every run, no read-modify-write.
+- Split public-repo implementation tasks from private workspace operator rollout steps.
+
+## Goal
+
+Add a per-cron `engine: claude | pi` field, defaulting to `claude`, plus a global `CRON_PI_DISABLED=1` kill-switch. Generalize the LLM cron execution path from `runClaude()` into `runOneShot(cron, workspaceCwd)` and add `runPi()` that spawns vanilla Pi (`earendil-works/pi-coding-agent`) in blocking one-shot print mode.
+
+The ralphex deliverable is the **public-repo mechanism**: engine dispatch, Pi spawn, context parity, safety nets, tests, and docs. It must **not** flip production crons. Production flips are private workspace operator steps after merge/soak.
+
+## Status
+
+Public implementation is complete. Private post-merge rollout remains pending and is not part of this PR.
+
+## Cron Engine Contract
+
+- LLM crons default to `engine: claude`; `engine: pi` is opt-in and valid only for LLM crons. Script crons ignore `engine`.
+- `CRON_PI_DISABLED=1` forces all LLM crons to the Claude engine. `PI_EXTENSIONS_DISABLED=1` is not a cron rollback path because Pi crons require A1 and fail closed if A1 would be disabled.
+- Pi crons spawn `pi -p` with `--no-session --no-extensions`, literal model `openai-codex/gpt-5.5`, validated `--thinking` from agent `effort` or `medium`, context files from `assemblePiContext()`, and only the explicit A1 guard extension.
+- Pi crons build env with `buildPiSpawnEnv()`, set `HOME` when absent, and rely on Pi auth in `~/.pi/agent/auth.json`, not Claude OAuth.
+- Result classification preserves existing delivery behavior: non-empty stdout is deliverable output, empty stdout/stderr is successful no-delivery, `NO_REPLY` is successful no-delivery for LLM crons, and stderr-only success/non-zero/signal/spawn failures enter the existing `⚠️ Cron FAIL` path.
+- Cron health textfiles are best-effort node_exporter files: last success timestamp is updated only on success, last exit code is updated on every run, and metric failures must not mask the cron result.
+
+`main()` must remain behavior-preserving. The only sanctioned diffs are:
+1. `runClaude()` call site becomes `runOneShot()` engine dispatch.
+2. A cron-health metric hook records success/failure state.
+
+Everything else stays the same: delivery behavior, `NO_REPLY` suppression, intentional empty-output skip, `⚠️ Cron FAIL` delivery/admin fallback, exit codes, script cron behavior, and 15-minute timeout default.
+
+## Context
+
+Implementation target: public repo `fitz123/claude-code-bot`, under `bot/`.
+
+Source evidence checked in the public repo:
+
+- `bot/src/cron-runner.ts:269-312` — current `runClaude()` uses `execSync`, text output, timeout, `cwd: workspaceCwd`, and returns `output.trim()`.
+- `bot/src/cron-runner.ts:318-410` — current `main()` contract: load cron, resolve workspace for LLM crons, run script/LLM, deliver fail/success, skip empty/NO_REPLY.
+- `bot/src/types.ts:64-75` — `CronJob` currently has no `engine` field.
+- `bot/src/config.ts:173-175` — validated agent `effort` allows only `low | medium | high`; no `xhigh`/`minimal` from config today.
+- `bot/src/pi-context-assembler.ts:40-46` — `PiContextArtifacts` has optional `systemPromptPath` and always-present `appendSystemPromptPath` on success.
+- `bot/src/pi-context-assembler.ts:466-507` — `assemblePiContext()` returns `PiContextArtifacts | null`; on non-null it writes bundle and optional persona artifact paths.
+- `bot/src/pi-rpc-protocol.ts:103-126` — `resolvePiExtensionArgs()` returns repeatable `--extension <abs>` args and fails closed if wrappers are missing.
+- `bot/src/pi-rpc-protocol.ts:223-229` — `normalizePiModel()` is not exported; do not import it.
+- `bot/src/pi-rpc-protocol.ts:290-318` — `buildPiSpawnEnv()` clones env, deletes `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `CLAUDECODE`, and stale guard root, then ensures `/opt/homebrew/bin` in PATH.
+- `bot/src/pi-extensions/subagent-args.ts:77-109` — pure spawn-arg builder pattern and DI-testable shape for Pi child commands.
+
+## Validation Commands
+
+Run from the bot package directory in the public repo checkout.
+
+```bash
+cd ~/src/claude-code-bot/bot
+npm test
+npm run lint
+npm run build
+
+# Required Pi print-mode shape is present.
+grep -nE 'PI_CRON_MODEL|openai-codex/gpt-5\.5|"-p"|"--no-session"|"--no-context-files"|"--thinking"' src/cron-runner.ts
+
+# Required reuse points are imported/used.
+grep -nE 'buildPiSpawnEnv|resolvePiExtensionArgs|PI_SUBAGENT_CHILD_WRAPPER_RELPATHS|assemblePiContext' src/cron-runner.ts
+
+# Model is literal and not derived from config.
+grep -n 'const PI_CRON_MODEL = "openai-codex/gpt-5.5"' src/cron-runner.ts
+grep -n 'normalizePiModel' src/cron-runner.ts && exit 1 || true
+grep -n 'agent.model' src/cron-runner.ts && exit 1 || true
+
+# Forbidden Pi one-shot flags must not appear in runPi(). Review manually if grep finds matches from runClaude().
+grep -nE 'runPi|--mode|--output-format|--fallback-model|--max-turns|--session ' src/cron-runner.ts
+
+# Engine dispatch, kill-switch, and metrics are present.
+grep -nE 'engine|CRON_PI_DISABLED|runOneShot|runPi' src/cron-runner.ts
+grep -nE 'minime_cron_last_success_timestamp|minime_cron_last_exit_code|node_exporter/textfile' src/cron-runner.ts
+
+# New tests exist and run directly with the same TS loader/Node flags as package tests.
+ls src/__tests__/cron-runner-pi.test.ts
+node --experimental-test-module-mocks --import tsx --test src/__tests__/cron-runner-pi.test.ts
+```
+
+## Decisions
+
+| ID | Decision | Resolution |
+|---|---|---|
+| Q1 | Scope/deadline | Ship mechanism + safety nets + tests + documented safe-subset rollout. Do not flip production crons in this PR. Dangerous/browser crons stay on Claude until later soak. |
+| Q2 | Browser/MCP crons | Browser/MCP crons stay on Claude. Vanilla Pi has no MCP/`--allowedTools` parity in this plan. |
+| Q3 | Dispatch/rollback | Add per-cron `engine: claude | pi`; default absent value to `claude`. `CRON_PI_DISABLED=1` forces Claude for all LLM crons. |
+| Q4 | Silent-failure safety net | Pi real errors must enter the existing `⚠️ Cron FAIL` path, never the empty-output skip. Emit cron-health textfile metrics. |
+| Q5 | Model | Hardcode `const PI_CRON_MODEL = "openai-codex/gpt-5.5"`; do not derive from `agent.model`; do not import `normalizePiModel`. |
+| D-CTX | Context parity | Reuse `assemblePiContext()` for persona + context bundle; when non-null, pass bundle + `--no-context-files`. |
+| D-EXT | Extensions | Use only A1 guard wrapper via `resolvePiExtensionArgs({ relpaths: PI_SUBAGENT_CHILD_WRAPPER_RELPATHS })`; no A2/A3 in cron one-shot. |
+| D-ENV | Auth/env | Reuse `buildPiSpawnEnv()`; set `env.HOME ||= homedir()` inside `runPi()`; Pi auth comes from `~/.pi/agent/auth.json`, not Claude OAuth token. |
+| D-SPAWN | Process API | Use `spawnSync` with an argv array for the Pi path; no shell string and no `execFileSync`, because result classification needs status/signal/stdout/stderr. |
+
+## Assumptions
+
+- [UNVERIFIED] Pi print mode accepts `pi -p <prompt> --no-session --model openai-codex/gpt-5.5 --thinking <level>` and emits final assistant text to stdout in default text mode. Risk if wrong: `runPi()` exits non-zero and the loud FAIL path fires.
+- [UNVERIFIED] Pi supports `--system-prompt <path>` / `--append-system-prompt <path>` as currently used by the RPC path (`bot/src/pi-rpc-protocol.ts:260-264`) and subagent path (`bot/src/pi-extensions/subagent-args.ts:97-99`). Risk if wrong: FAIL path fires or context is missing; tests must pin the argv path behavior we expect.
+- [UNVERIFIED] Headless OAuth refresh from `~/.pi/agent/auth.json` works under launchd. Risk if wrong: visible cron FAIL + stale success metric; recovery is manual `pi /login`.
+- Production cron flips are private workspace state and must happen after merge + restart + observation, not inside ralphex.
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---:|---:|---|
+| Wrong Pi CLI flag | Medium | High | argv tests + real errors classified as FAIL, not empty skip |
+| Empty stdout with stderr gets swallowed | Medium | High | `classifyPiResult()` treats empty stdout + stderr as error |
+| Missing A1 extension silently spawns unguarded Pi | Low | High | `resolvePiExtensionArgs()` fail-closed; `CRON_PI_DISABLED=1` rollback |
+| Claude credentials leak to Pi | Low | Medium | `buildPiSpawnEnv()` deletes Claude/Anthropic vars |
+| Context parity drift | Medium | Medium | reuse `assemblePiContext()`; no reimplementation |
+| Metrics file breaks cron run | Low | Medium | metric writer must be best-effort after preserving exit status semantics |
+| Scope creep into workspace rollout | Medium | High | operator rollout section is explicitly NOT ralphex |
+
+## Tasks
+
+### Task 1: Add cron engine typing and parsing [HIGH]
+
+- [x] In `bot/src/types.ts`, add `engine?: "claude" | "pi"` to `CronJob`.
+- [x] In `bot/src/cron-runner.ts` `loadCronTask()`, validate raw `engine`: absent means `undefined`/default Claude; present must be exactly `"claude"` or `"pi"`.
+- [x] Return the parsed `engine` field in the `CronJob` object.
+- [x] Keep script crons unaffected; `engine` only matters for LLM crons.
+- [x] Write unit tests for absent/default, `claude`, `pi`, and invalid engine rejection.
+- [x] Run the relevant cron-runner tests separately after writing them.
+
+### Task 2: Add minimal Pi cron agent construction [HIGH]
+
+- [x] Keep `getAgentWorkspace(agentId)` or replace it with a small helper that reads `loadRawMergedConfig()` once and returns enough data for Pi context assembly: `id`, `workspaceCwd`, optional `systemPrompt`, optional `effort`.
+- [x] Do not add a heavyweight full `validateAgent()`/`loadConfig()` path just to run a cron.
+- [x] For `runPi()`, construct a minimal `AgentConfig` compatible with `assemblePiContext()`:
+  - `id: cron.agentId`
+  - `workspaceCwd`
+  - `provider: "pi"`
+  - `model: PI_CRON_MODEL`
+  - `systemPrompt` copied from raw config only if string
+  - `effort` copied only if it is one of `low | medium | high`
+- [x] If the helper sees a missing agent or missing `workspaceCwd`, preserve the current error semantics: fail before spawn and enter the existing `⚠️ Cron FAIL` path.
+- [x] Write tests for agent data resolution including default `main` agent and invalid/missing workspace.
+- [x] Run the relevant tests separately.
+
+### Task 3: Introduce `runOneShot()` engine dispatch and kill-switch [HIGH]
+
+- [x] Add `function resolveCronEngine(cron: CronJob): "claude" | "pi"`:
+  - `cron.engine ?? "claude"`
+  - if resolved `pi` and `process.env.CRON_PI_DISABLED === "1"`, return `"claude"`
+- [x] Add `function runOneShot(cron: CronJob, workspaceCwd: string): string` that dispatches to `runClaude()` or `runPi()`.
+- [x] Change `main()` only at the LLM call site from `runClaude(cron, workspaceCwd!)` to `runOneShot(cron, workspaceCwd!)` and update the log label to include resolved engine/output length without changing behavior.
+- [x] Do not change script cron dispatch.
+- [x] Write tests for default Claude, explicit Claude, explicit Pi, and kill-switch fallback.
+- [x] Run the relevant tests separately.
+
+### Task 4: Add Pi result classification [HIGH]
+
+- [x] Define a small result type for Pi spawn output, e.g. `{ status: "ok"; output: string } | { status: "error"; message: string }`.
+- [x] Implement `classifyPiResult(exitCode, signal, stdout, stderr)`:
+  - exit code `0` + non-empty stdout => ok with `stdout.trim()`
+  - exit code `0` + empty stdout + empty stderr => ok with empty string (intentional empty-output skip remains possible)
+  - exit code `0` + empty stdout + non-empty stderr => error
+  - non-zero exit or signal => error including bounded stderr/stdout excerpts
+- [x] Ensure errors are thrown from `runPi()` so `main()` uses the existing `⚠️ Cron FAIL` branch.
+- [x] Ensure intentional `NO_REPLY` and intentional empty success still flow through the existing post-run suppression/skip logic.
+- [x] Write table-driven tests for all classifier branches.
+- [x] Run the relevant tests separately.
+
+### Task 5: Implement `runPi()` print-mode spawn [HIGH]
+
+- [x] Add imports in `bot/src/cron-runner.ts`:
+  - `spawnSync` from `node:child_process` (required; do not use `execFileSync` for Pi because the classifier needs status/signal/stdout/stderr)
+  - `buildPiSpawnEnv`, `resolvePiExtensionArgs`, `PI_SUBAGENT_CHILD_WRAPPER_RELPATHS` from `./pi-rpc-protocol.js`
+  - `assemblePiContext` from `./pi-context-assembler.js`
+- [x] Do **not** import `normalizePiModel`.
+- [x] Define `const PI_CRON_MODEL = "openai-codex/gpt-5.5";` in `cron-runner.ts`.
+- [x] Define `const PI_BIN = "pi";` and spawn with `spawnSync(PI_BIN, args, ...)`.
+- [x] Define `const PI_THINKING_LEVELS = new Set(["low", "medium", "high"]);` for current config-allowed effort values; default to `"medium"`.
+- [x] Build argv as text-mode print one-shot:
+  - `-p`, `cron.prompt!`
+  - `--no-session`
+  - `--model`, `PI_CRON_MODEL`
+  - `--thinking`, validated effort or `medium`
+  - context flags, if `assemblePiContext(agent)` returns non-null:
+    - if `ctx.systemPromptPath`, pass `--system-prompt`, `ctx.systemPromptPath`
+    - always pass `--append-system-prompt`, `ctx.appendSystemPromptPath`
+    - always pass `--no-context-files`
+  - extensions: `...resolvePiExtensionArgs({ relpaths: PI_SUBAGENT_CHILD_WRAPPER_RELPATHS })`
+- [x] Forbidden in `runPi()` argv: `--mode`, `--output-format`, `--fallback-model`, `--max-turns`, `--dangerously-skip-permissions`, `--add-dir`, `--session`.
+- [x] Add an explicit DI seam for tests: `runPi(cron, workspaceCwd, deps = defaultPiDeps)` or equivalent, where `deps.spawnSync` defaults to Node `spawnSync` and tests inject a fake. Keep production call sites simple.
+- [x] Spawn with `deps.spawnSync(PI_BIN, args, { cwd: workspaceCwd, timeout: cron.timeout ?? DEFAULT_TIMEOUT_MS, encoding: "utf8", maxBuffer: 10 * 1024 * 1024, env })`.
+- [x] Build env via `buildPiSpawnEnv(agent)` and set `env.HOME ||= homedir()`; add an inline comment that Pi auth is `~/.pi/agent/auth.json`, not Claude OAuth.
+- [x] Call `classifyPiResult()` and return the ok output or throw on error.
+- [x] Write DI fake-spawn tests for argv shape, env scrubbing/HOME, cwd, timeout, context args, extension args, and forbidden flags.
+- [x] Run the relevant tests separately.
+
+### Task 6: Add cron-health textfile metrics [HIGH]
+
+- [x] Add a small best-effort `writeCronHealthMetric(cronName, exitCode, success)` helper.
+- [x] Textfile directory default: `/opt/homebrew/var/node_exporter/textfile`; make it overrideable in tests via env var, e.g. `CRON_HEALTH_TEXTFILE_DIR`.
+- [x] Metric file name should be stable per cron, e.g. `minime_cron_<safe-name>.prom`; sanitize cron names for filenames and labels.
+- [x] On success only, include/update `minime_cron_last_success_timestamp{cron="<name>"} <epoch>`.
+- [x] On every run, include/update `minime_cron_last_exit_code{cron="<name>"} <code>`.
+- [x] Do not read/parse old metric files and do not preserve old timestamp by read-modify-write.
+- [x] Use atomic temp-file + rename.
+- [x] Metric write failures must be logged but must not mask the original cron success/failure.
+- [x] Wire the helper into `main()` so success writes exit code `0`, and every failure path writes a non-zero exit code before `process.exit(1)`.
+- [x] Write tests using a temp directory.
+- [x] Run the relevant tests separately.
+
+### Task 7: Preserve `main()` behavior [HIGH]
+
+- [x] Audit the diff around `main()` manually.
+- [x] Confirm the only sanctioned behavior changes are engine dispatch and metric hook.
+- [x] Confirm these remain unchanged:
+  - script cron path
+  - delivery command and admin fallback
+  - empty-output skip
+  - `NO_REPLY` suppression
+  - `process.exit(1)` on failure
+  - timeout default
+- [x] Add/adjust tests to pin the behavior-preserving cases.
+- [x] Run the relevant tests separately.
+
+### Task 8: Document safe-subset rollout criteria [MED]
+
+- [x] In bot docs (public repo only), document `engine: claude | pi`, default `claude`, and `CRON_PI_DISABLED=1`.
+- [x] Document that browser/MCP crons and dangerous state-mutating crons should remain on Claude until Pi has the needed browser/MCP/soak coverage.
+- [x] Document the recommended safe first subset as criteria, not private cron names: read-only, non-browser, non-secret, non-mutating, low blast-radius, visible output or metric-covered.
+- [x] Do not edit private `crons.local.yaml`, monitoring rules, migration-state, or ADR files in this task.
+
+### Task 9: Verify acceptance criteria [HIGH]
+
+- [x] From `bot/`, run `npm test`.
+- [x] From `bot/`, run `npm run lint`.
+- [x] From `bot/`, run `npm run build`.
+- [x] From `bot/`, run `node --experimental-test-module-mocks --import tsx --test src/__tests__/cron-runner-pi.test.ts`.
+- [x] Verify `cron-runner.ts` contains literal `const PI_CRON_MODEL = "openai-codex/gpt-5.5"`.
+- [x] Verify `cron-runner.ts` does not import or call `normalizePiModel`.
+- [x] Verify `runPi()` does not contain forbidden flags (`--mode`, `--output-format`, `--fallback-model`, `--max-turns`, `--dangerously-skip-permissions`, `--add-dir`, `--session`).
+- [x] Verify tests cover engine dispatch, kill-switch, Pi argv, env/HOME, context args, extension args, FAIL-vs-empty-success classification, and cron-health metrics.
+- [x] Record command output in the ralphex final report.
+
+### Task 10: Update documentation [HIGH]
+
+- [x] Update public bot docs only. Prefer an existing cron/config doc over adding a new doc unless the repo already has a clear plans/docs convention.
+- [x] Include a minimal YAML example:
+  ```yaml
+  crons:
+    - name: read-only-example
+      type: llm
+      engine: pi
+      agentId: main
+      prompt: "..."
+  ```
+- [x] Document rollback:
+  - per cron: remove `engine: pi` or set `engine: claude`
+  - global: set `CRON_PI_DISABLED=1`
+- [x] Document operational warning: production flips are post-merge operator work, not part of the PR.
+
+## Operator steps (post-merge — NOT ralphex)
+
+These steps are private workspace operations after the public PR is merged, upstream-synced, and the bot is restarted with explicit confirmation.
+
+- [ ] Ask Ninja whether to record the cron Pi mechanism/rollout policy as an ADR.
+- [ ] Sync public repo into the private workspace via upstream merge.
+- [ ] Restart the bot with the canonical restart script only after explicit confirmation.
+- [ ] Select a tiny SAFE/read-only subset of production LLM crons and set `engine: pi` in private cron overrides.
+- [ ] Do not migrate browser/MCP crons or dangerous state-mutating crons in the first flip.
+- [ ] Add/enable Prometheus alert for stale `minime_cron_last_success_timestamp` after the metric exists.
+- [ ] Watch logs + metrics for at least one full firing cycle before expanding the subset.
+- [ ] If any Pi cron fails, set `CRON_PI_DISABLED=1` or flip that cron back to `engine: claude` and investigate from logs.


### PR DESCRIPTION
## Summary
- add `engine: claude | pi` for LLM crons, with `CRON_PI_DISABLED=1` rollback
- implement Pi print-mode cron execution with context assembly, A1 guard extension, safe result classification, and cron-health textfile metrics
- document safe rollout criteria and keep production cron flips out of this PR

## Validation
- Ralphex completed successfully after review/fix loops
- post-rebase validation passed on `plan-c-cron-runner-pi-port`:
  - `node --experimental-test-module-mocks --import tsx --test src/__tests__/cron-runner-pi.test.ts`
  - `npm test` (1503 pass)
  - `npm run lint`
  - `npm run build`
- local gitleaks scan on the squashed PR branch: no leaks found

Note: PR branch is squashed to avoid gitleaks history false positives from the plan file mentioning a package scope. The squashed tree matches the validated rebased branch except for that documentation spelling.
