### PR TITLE
Harden web_fetch host egress checks

### DIFF
--- a/bot/src/__tests__/tavily.test.ts
+++ b/bot/src/__tests__/tavily.test.ts
@@ -81,6 +81,7 @@ function makeDeps(overrides: Partial<RunToolDeps> = {}): { deps: RunToolDeps; wa
   const deps: RunToolDeps = {
     apiKey: KEY,
     fetchImpl: mockFetch(async () => jsonResponse({ results: [] })).fn,
+    resolveHost: async () => ["93.184.216.34"],
     warn: (e) => warns.push(e),
     ...overrides,
   };
@@ -440,6 +441,8 @@ describe("tavily: executeWebFetch", () => {
       "http://169.254.1.1/",
       "http://172.16.0.1/",
       "http://192.168.1.1/",
+      "http://192.0.0.9/",
+      "http://192.0.0.10/",
       "http://192.0.2.1/",
       "http://198.18.0.1/",
       "http://198.51.100.1/",
@@ -461,6 +464,49 @@ describe("tavily: executeWebFetch", () => {
       reason: "blocked-egress" as const,
       detail: "url targets a local/private host",
     })));
+  });
+
+  it("blocks hostnames that resolve to local/private addresses before external egress", async () => {
+    const mock = mockFetch(async () => jsonResponse({ results: [] }));
+    const resolveCalls: string[] = [];
+    const { deps, warns } = makeDeps({
+      fetchImpl: mock.fn,
+      resolveHost: async (hostname) => {
+        resolveCalls.push(hostname);
+        return ["10.0.0.1"];
+      },
+    });
+
+    const res = await executeWebFetch({ url: "https://10.0.0.1.nip.io/docs" }, deps);
+
+    assert.equal(res.ok, false);
+    assert.match(res.text, /blocked/);
+    assert.equal(mock.calls.length, 0);
+    assert.deepEqual(resolveCalls, ["10.0.0.1.nip.io"]);
+    assert.deepEqual(warns, [{
+      tool: "web_fetch",
+      reason: "blocked-egress",
+      detail: "url host resolves to a local/private address",
+    }]);
+  });
+
+  it("fails closed when hostname resolution is unavailable", async () => {
+    const mock = mockFetch(async () => jsonResponse({ results: [] }));
+    const { deps, warns } = makeDeps({
+      fetchImpl: mock.fn,
+      resolveHost: async () => { throw new Error("ENOTFOUND"); },
+    });
+
+    const res = await executeWebFetch({ url: "https://example.test/docs" }, deps);
+
+    assert.equal(res.ok, false);
+    assert.match(res.text, /blocked/);
+    assert.equal(mock.calls.length, 0);
+    assert.deepEqual(warns, [{
+      tool: "web_fetch",
+      reason: "blocked-egress",
+      detail: "url host could not be resolved safely",
+    }]);
   });
 
   it("blocks local, private, and reserved IPv6 literal URLs before external egress", async () => {

--- a/bot/src/pi-extensions/tavily.ts
+++ b/bot/src/pi-extensions/tavily.ts
@@ -18,11 +18,13 @@
  *    with a {@link TavilyWarn} so the Pi session logs it (the wrapper passes
  *    `console.warn` of {@link formatTavilyWarn}).
  *
- * Everything here is pure + dependency-injected (`fetchImpl`, `apiKey`, `warn`)
- * so `tavily.test.ts` can exercise request shape, response parse, HTTP-error,
- * and missing-key paths with a mock fetch and never touch the network.
+ * Everything here is pure + dependency-injected (`fetchImpl`, `apiKey`,
+ * `resolveHost`, `warn`) so `tavily.test.ts` can exercise request shape,
+ * response parse, HTTP-error, DNS-based egress guard, and missing-key paths
+ * with mocks and never touch the network.
  */
 
+import { lookup as lookupDns } from "node:dns/promises";
 import { isIP } from "node:net";
 import { TAVILY_SOPS_FILE_RELPATH, TAVILY_SOPS_KEY } from "./tavily-constants.js";
 
@@ -37,6 +39,7 @@ export const MAX_SEARCH_MAX_RESULTS = 20;
 export const MAX_SEARCH_QUERY_CHARS = 300;
 /** Hard cap for fetch URLs before they are sent to Tavily. */
 export const MAX_FETCH_URL_CHARS = 2048;
+const DNS_RESOLVE_TIMEOUT_MS = 1500;
 
 /** A fully-described HTTP request (so tests can assert shape without a network). */
 export interface TavilyHttpRequest {
@@ -95,11 +98,15 @@ export interface TavilyWarn {
   detail?: string;
 }
 
+export type ResolveHost = (hostname: string) => Promise<readonly string[]>;
+
 export interface RunToolDeps {
   /** Tavily API key, or undefined when the SOPS lookup failed at load. */
   apiKey: string | undefined;
   /** Injected fetch (defaults to global `fetch` in the wrapper). */
   fetchImpl: typeof fetch;
+  /** Optional DNS resolver for hostname egress checks (mocked in tests). */
+  resolveHost?: ResolveHost;
   /** Structured warn sink. */
   warn?: (event: TavilyWarn) => void;
 }
@@ -213,7 +220,7 @@ function isPublicIpv4(octets: readonly number[]): boolean {
   const isLoopback = a === 127;
   const isSharedAddressSpace = a === 100 && b >= 64 && b <= 127;
   const isLinkLocal = a === 169 && b === 254;
-  const isIetfProtocolAssignment = a === 192 && b === 0 && c === 0 && d !== 9 && d !== 10;
+  const isIetfProtocolAssignment = a === 192 && b === 0 && c === 0;
   const isDocumentation = (
     (a === 192 && b === 0 && c === 2) ||
     (a === 198 && b === 51 && c === 100) ||
@@ -329,6 +336,50 @@ function isPrivateOrLocalHost(hostname: string): boolean {
   return !isPublicIpv6(v6);
 }
 
+async function defaultResolveHost(hostname: string): Promise<readonly string[]> {
+  const records = await lookupDns(hostname, { all: true, verbatim: true });
+  return records.map((record) => record.address);
+}
+
+async function resolveHostWithTimeout(resolveHost: ResolveHost, hostname: string): Promise<readonly string[]> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error("dns-timeout")), DNS_RESOLVE_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([resolveHost(hostname), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function validateResolvedHostname(hostname: string, resolveHost: ResolveHost): Promise<string | undefined> {
+  const host = canonicalHostname(hostname);
+  if (isIP(host)) {
+    return undefined;
+  }
+
+  let addresses: readonly string[];
+  try {
+    addresses = await resolveHostWithTimeout(resolveHost, host);
+  } catch {
+    return "url host could not be resolved safely";
+  }
+
+  if (addresses.length === 0) {
+    return "url host could not be resolved safely";
+  }
+
+  if (addresses.some((address) => isPrivateOrLocalHost(address))) {
+    return "url host resolves to a local/private address";
+  }
+
+  return undefined;
+}
+
 function validateWebSearchEgress(query: string): string | undefined {
   return validateOutboundText("query", query, MAX_SEARCH_QUERY_CHARS, {
     checkLocalPaths: true,
@@ -361,7 +412,10 @@ function validateDecodedUrlText(kind: "url path" | "url fragment", rawText: stri
   });
 }
 
-function validateWebFetchEgress(url: string): WebFetchEgressValidation {
+async function validateWebFetchEgress(
+  url: string,
+  resolveHost: ResolveHost = defaultResolveHost,
+): Promise<WebFetchEgressValidation> {
   const textProblem = validateOutboundText("url", url, MAX_FETCH_URL_CHARS, {
     checkSensitiveAssignments: false,
   });
@@ -384,6 +438,11 @@ function validateWebFetchEgress(url: string): WebFetchEgressValidation {
   }
   if (isPrivateOrLocalHost(parsed.hostname)) {
     return { problem: "url targets a local/private host" };
+  }
+
+  const resolvedHostProblem = await validateResolvedHostname(parsed.hostname, resolveHost);
+  if (resolvedHostProblem) {
+    return { problem: resolvedHostProblem };
   }
 
   const rawPathProblem = validateOutboundText("url path", parsed.pathname, MAX_FETCH_URL_CHARS, {
@@ -613,7 +672,7 @@ export async function executeWebFetch(args: WebFetchArgs, deps: RunToolDeps): Pr
     return errResult("web_fetch requires a non-empty 'url' string.");
   }
 
-  const egress = validateWebFetchEgress(url);
+  const egress = await validateWebFetchEgress(url, deps.resolveHost ?? defaultResolveHost);
   if (egress.problem) {
     deps.warn?.({ tool: "web_fetch", reason: "blocked-egress", detail: egress.problem });
     return errResult(`web_fetch blocked: ${egress.problem}. Do not send local or private data to external web services.`);


### PR DESCRIPTION
## Summary
- fail closed when `web_fetch` cannot safely resolve a hostname before handing it to Tavily
- block hostnames that resolve to private/reserved IP addresses, not just IP literals / localhost suffixes
- treat the full `192.0.0.0/24` IETF protocol assignment block as non-public

## Context
Follow-up to #147 for Copilot findings that arrived after #147 was already merged.

## Validation
- `cd bot && npm test -- --test-name-pattern='tavily'` (runs the suite in this repo; pass)
- `cd bot && npm run typecheck`
- `cd bot && npm run validate-config`
- `git diff --check`
